### PR TITLE
Add `VisualShape2D` node

### DIFF
--- a/config.py
+++ b/config.py
@@ -51,6 +51,7 @@ def get_doc_classes():
         "ImageIndexed",
         "ImageIndexed",
         "ShapeCast2D",
+        "VisualShape2D",
     ]
 
 

--- a/doc/VisualShape2D.xml
+++ b/doc/VisualShape2D.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="VisualShape2D" inherits="Node2D" version="3.2">
+	<brief_description>
+		Draws any [Shape2D] resource. Useful for quick prototyping.
+	</brief_description>
+	<description>
+		This is a node with the entire purpose of rendering [Shape2D] resources just like drawing collision shapes in the editor, yet it's also possible to override the color per each node rather than globally with this class. While the class supports all existing shapes, it's currently not convenient to edit polygon-based shapes, so use [Polygon2D] node which is much more superior for editing and drawing of polygons (with textures).
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+	</methods>
+	<members>
+		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color( 1, 1, 1, 1 )">
+			The fill color used to draw the [member shape].
+		</member>
+		<member name="debug_sync_visible_collision_shapes" type="bool" setter="set_debug_sync_visible_collision_shapes" getter="is_debug_sync_visible_collision_shapes" default="false">
+			If [code]true[/code], respects the "Visible Collision Shapes" option so that the shape is only drawn when the option is enabled while the game is running.
+		</member>
+		<member name="debug_use_default_color" type="bool" setter="set_debug_use_default_color" getter="is_using_debug_default_color" default="false">
+			If [code]true[/code], this overrides the [member color] with the color used to draw the collision shapes.
+		</member>
+		<member name="shape" type="Shape2D" setter="set_shape" getter="get_shape">
+			The shape resource used as a reference to draw. The drawing method is specific for each shape and the properties must be configured per shape.
+		</member>
+	</members>
+	<constants>
+	</constants>
+</class>

--- a/doc/VisualShape2D.xml
+++ b/doc/VisualShape2D.xml
@@ -33,7 +33,7 @@
 			The shape resource used as a reference to draw. The drawing method is specific for each shape and the properties must be configured per shape.
 		</member>
 		<member name="use_parent_shape" type="bool" setter="set_use_parent_shape" getter="is_using_parent_shape" default="false">
-			If [code]true[/code], the shape is fetched from the parent node to draw instead of its own [member shape]. The parent node must have either [code]shape[/code] [Shape2D] property or [code]polygon[/code] [PoolVector2Array] property defined, else nothing is drawn.
+			If [code]true[/code], the shape is fetched from the parent node to draw instead of its own [member shape]. The parent node must have either [code]shape[/code] as [Shape2D] property or [code]points[/code], [code]polygon[/code] as [PoolVector2Array] property defined, else nothing is drawn.
 		</member>
 	</members>
 	<signals>

--- a/doc/VisualShape2D.xml
+++ b/doc/VisualShape2D.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShape2D" inherits="Node2D" version="3.2">
 	<brief_description>
-		Draws any [Shape2D] resource. Useful for quick prototyping.
+		Draws any [Shape2D] resource. Useful for quick prototyping and debugging.
 	</brief_description>
 	<description>
-		This is a node with the entire purpose of rendering [Shape2D] resources just like drawing collision shapes in the editor, yet it's also possible to override the color per each node rather than globally with this class. While the class supports all existing shapes, it's currently not convenient to edit polygon-based shapes, so use [Polygon2D] node which is much more superior for editing and drawing of polygons (with textures).
+		This is a node with the entire purpose of rendering [Shape2D] resources just like collision shapes are drawn in the editor, yet it's also possible to override the color per each node rather than globally with this class. You may use Godot's [Polygon2D] node which is much more suitable for polygon editing and drawing with textures, as any shape can be represented with it.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -23,7 +23,17 @@
 		<member name="shape" type="Shape2D" setter="set_shape" getter="get_shape">
 			The shape resource used as a reference to draw. The drawing method is specific for each shape and the properties must be configured per shape.
 		</member>
+		<member name="use_parent_shape" type="bool" setter="set_use_parent_shape" getter="is_using_parent_shape" default="false">
+			If [code]true[/code], the shape is fetched from the parent node to draw instead of its own [member shape]. The parent node must have either [code]shape[/code] [Shape2D] property or [code]polygon[/code] [PoolVector2Array] property defined, else nothing is drawn.
+		</member>
 	</members>
+	<signals>
+		<signal name="shape_changed">
+			<description>
+				Emitted when the [member shape] is changed (or cleared).
+			</description>
+		</signal>
+	</signals>
 	<constants>
 	</constants>
 </class>

--- a/doc/VisualShape2D.xml
+++ b/doc/VisualShape2D.xml
@@ -9,6 +9,13 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="update_parent_shape">
+			<return type="bool">
+			</return>
+			<description>
+				Forces to update the shape from parent node. This is called automatically each [b]idle frame[/b] if [member use_parent_shape] is enabled. Updating the shape each frame may be costly, so you can disable this behavior with [code]set_process(false)[/code] on this node, and update the shape manually with this method when needed.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color( 1, 1, 1, 1 )">
@@ -16,9 +23,11 @@
 		</member>
 		<member name="debug_sync_visible_collision_shapes" type="bool" setter="set_debug_sync_visible_collision_shapes" getter="is_debug_sync_visible_collision_shapes" default="false">
 			If [code]true[/code], respects the "Visible Collision Shapes" option so that the shape is only drawn when the option is enabled while the game is running.
+			[b]Note:[/b] available in debug builds only.
 		</member>
 		<member name="debug_use_default_color" type="bool" setter="set_debug_use_default_color" getter="is_using_debug_default_color" default="false">
 			If [code]true[/code], this overrides the [member color] with the color used to draw the collision shapes.
+			[b]Note:[/b] available in debug builds only.
 		</member>
 		<member name="shape" type="Shape2D" setter="set_shape" getter="get_shape">
 			The shape resource used as a reference to draw. The drawing method is specific for each shape and the properties must be configured per shape.

--- a/editor/2d/SCsub
+++ b/editor/2d/SCsub
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+Import("env_goost")
+
+env_goost.add_source_files(env_goost.modules_sources, "*.cpp")

--- a/editor/2d/visual_shape_2d_editor_plugin.cpp
+++ b/editor/2d/visual_shape_2d_editor_plugin.cpp
@@ -1,0 +1,82 @@
+#include "visual_shape_2d_editor_plugin.h"
+
+#include "scene/resources/concave_polygon_shape_2d.h"
+#include "scene/resources/convex_polygon_shape_2d.h"
+
+Node2D *VisualShape2DEditor::_get_node() const {
+	return node;
+}
+
+void VisualShape2DEditor::_set_node(Node *p_node) {
+	node = Object::cast_to<VisualShape2D>(p_node);
+}
+
+void VisualShape2DEditor::_set_polygon(int p_idx, const Variant &p_polygon) const {
+	VisualShape2D *n = Object::cast_to<VisualShape2D>(_get_node());
+
+	const Ref<Shape2D> &shape = n->get_shape();
+	Ref<ConvexPolygonShape2D> convex = shape;
+	Ref<ConcavePolygonShape2D> concave = shape;
+
+	if (convex.is_valid()) {
+		convex->set("points", p_polygon);
+	} else if (concave.is_valid()) {
+		concave->set("segments", p_polygon);
+	}
+}
+
+Variant VisualShape2DEditor::_get_polygon(int p_idx) const {
+	VisualShape2D *n = Object::cast_to<VisualShape2D>(_get_node());
+
+	const Ref<Shape2D> &shape = n->get_shape();
+	Ref<ConvexPolygonShape2D> convex = shape;
+	Ref<ConcavePolygonShape2D> concave = shape;
+
+	if (convex.is_valid()) {
+		return convex->get("points");
+	} else if (concave.is_valid()) {
+		return concave->get("segments");
+	}
+	return Variant();
+}
+
+void VisualShape2DEditor::_action_set_polygon(int p_idx, const Variant &p_previous, const Variant &p_polygon) {
+	undo_redo->add_do_method(this, "_set_polygon", 0, p_polygon);
+	undo_redo->add_undo_method(this, "_set_polygon", 0, p_previous);
+}
+
+bool VisualShape2DEditor::_has_resource() const {
+	if (!node) {
+		return false;
+	}
+	const Ref<Shape2D> &shape = node->get_shape();
+	Ref<ConvexPolygonShape2D> convex = shape;
+	Ref<ConcavePolygonShape2D> concave = shape;
+
+	return convex.is_valid() || concave.is_valid();
+}
+
+void VisualShape2DEditor::_create_resource() {
+	if (!node) {
+		return;
+	}
+	undo_redo->create_action(TTR("Create Convex Polygon Shape"));
+	undo_redo->add_do_method(node, "set_shape", Ref<ConvexPolygonShape2D>(memnew(ConvexPolygonShape2D)));
+	undo_redo->add_undo_method(node, "set_shape", Variant(REF()));
+	undo_redo->commit_action();
+
+	_menu_option(MODE_CREATE);
+}
+
+void VisualShape2DEditor::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("_set_polygon"), &VisualShape2DEditor::_set_polygon);
+}
+
+VisualShape2DEditor::VisualShape2DEditor(EditorNode *p_editor) :
+		AbstractPolygon2DEditor(p_editor) {
+	node = nullptr;
+}
+
+VisualShape2DEditorPlugin::VisualShape2DEditorPlugin(EditorNode *p_node) :
+		AbstractPolygon2DEditorPlugin(p_node, memnew(VisualShape2DEditor(p_node)), "VisualShape2D") {
+}

--- a/editor/2d/visual_shape_2d_editor_plugin.cpp
+++ b/editor/2d/visual_shape_2d_editor_plugin.cpp
@@ -1,5 +1,7 @@
 #include "visual_shape_2d_editor_plugin.h"
 
+#include "editor/plugins/canvas_item_editor_plugin.h"
+
 #include "scene/resources/concave_polygon_shape_2d.h"
 #include "scene/resources/convex_polygon_shape_2d.h"
 
@@ -8,7 +10,14 @@ Node2D *VisualShape2DEditor::_get_node() const {
 }
 
 void VisualShape2DEditor::_set_node(Node *p_node) {
+	if (node) {
+		node->disconnect("shape_changed", this, "_update_editing");
+	}
 	node = Object::cast_to<VisualShape2D>(p_node);
+	if (node) {
+		node->connect("shape_changed", this, "_update_editing");
+	}
+	_update_editing();
 }
 
 void VisualShape2DEditor::_set_polygon(int p_idx, const Variant &p_polygon) const {
@@ -40,6 +49,25 @@ Variant VisualShape2DEditor::_get_polygon(int p_idx) const {
 	return Variant();
 }
 
+void VisualShape2DEditor::_update_editing() {
+	if (!node) {
+		return;
+	}
+	Ref<Shape2D> shape = node->get_shape();
+	Ref<ConvexPolygonShape2D> convex = shape;
+	Ref<ConcavePolygonShape2D> concave = shape;
+
+	const String reason = TTR("No polygon-based shape resource is set.");
+
+	if (shape.is_null()) {
+		disable_polygon_editing(true, reason);
+	} else if (convex.is_valid() || concave.is_valid()) {
+		disable_polygon_editing(false, "");
+	} else {
+		disable_polygon_editing(true, reason);
+	}
+}
+
 void VisualShape2DEditor::_action_set_polygon(int p_idx, const Variant &p_previous, const Variant &p_polygon) {
 	undo_redo->add_do_method(this, "_set_polygon", 0, p_polygon);
 	undo_redo->add_undo_method(this, "_set_polygon", 0, p_previous);
@@ -49,11 +77,7 @@ bool VisualShape2DEditor::_has_resource() const {
 	if (!node) {
 		return false;
 	}
-	const Ref<Shape2D> &shape = node->get_shape();
-	Ref<ConvexPolygonShape2D> convex = shape;
-	Ref<ConcavePolygonShape2D> concave = shape;
-
-	return convex.is_valid() || concave.is_valid();
+	return node->get_shape().is_valid();
 }
 
 void VisualShape2DEditor::_create_resource() {
@@ -66,10 +90,13 @@ void VisualShape2DEditor::_create_resource() {
 	undo_redo->commit_action();
 
 	_menu_option(MODE_CREATE);
+
+	EditorNode::get_singleton()->get_inspector()->refresh();
 }
 
 void VisualShape2DEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_set_polygon"), &VisualShape2DEditor::_set_polygon);
+	ClassDB::bind_method(D_METHOD("_update_editing"), &VisualShape2DEditor::_update_editing);
 }
 
 VisualShape2DEditor::VisualShape2DEditor(EditorNode *p_editor) :

--- a/editor/2d/visual_shape_2d_editor_plugin.cpp
+++ b/editor/2d/visual_shape_2d_editor_plugin.cpp
@@ -29,8 +29,19 @@ void VisualShape2DEditor::_set_polygon(int p_idx, const Variant &p_polygon) cons
 
 	if (convex.is_valid()) {
 		convex->set("points", p_polygon);
+
 	} else if (concave.is_valid()) {
-		concave->set("segments", p_polygon);
+		const Vector<Vector2> &polygon = p_polygon;
+
+		Vector<Vector2> segments;
+		segments.resize(polygon.size() * 2);
+		Vector2 *w = segments.ptrw();
+
+		for (int i = 0; i < polygon.size(); ++i) {
+			w[(i << 1) + 0] = polygon[i];
+			w[(i << 1) + 1] = polygon[(i + 1) % polygon.size()];
+		}
+		concave->set("segments", segments);
 	}
 }
 
@@ -43,8 +54,16 @@ Variant VisualShape2DEditor::_get_polygon(int p_idx) const {
 
 	if (convex.is_valid()) {
 		return convex->get("points");
+
 	} else if (concave.is_valid()) {
-		return concave->get("segments");
+		Vector<Vector2> polygon;
+		const Vector<Vector2> &segments = concave->get("segments");
+		const Vector2 *r = segments.ptr();
+
+		for (int i = 0; i < segments.size(); i += 2) {
+			polygon.push_back(r[i]);
+		}
+		return polygon;
 	}
 	return Variant();
 }

--- a/editor/2d/visual_shape_2d_editor_plugin.h
+++ b/editor/2d/visual_shape_2d_editor_plugin.h
@@ -1,0 +1,37 @@
+#ifndef GOOST_VISUAL_SHAPE_2D_EDITOR_PLUGIN_H
+#define GOOST_VISUAL_SHAPE_2D_EDITOR_PLUGIN_H
+
+#include "editor/plugins/abstract_polygon_2d_editor.h"
+#include "scene/2d/visual_shape_2d.h"
+
+class VisualShape2DEditor : public AbstractPolygon2DEditor {
+	GDCLASS(VisualShape2DEditor, AbstractPolygon2DEditor);
+
+	VisualShape2D *node;
+
+protected:
+	virtual Node2D *_get_node() const;
+	virtual void _set_node(Node *p_node);
+
+	virtual void _set_polygon(int p_idx, const Variant &p_polygon) const;
+	virtual Variant _get_polygon(int p_idx) const;
+
+	virtual void _action_set_polygon(int p_idx, const Variant &p_previous, const Variant &p_polygon);
+
+	virtual bool _has_resource() const;
+	virtual void _create_resource();
+
+	static void _bind_methods();
+
+public:
+	VisualShape2DEditor(EditorNode *p_editor);
+};
+
+class VisualShape2DEditorPlugin : public AbstractPolygon2DEditorPlugin {
+	GDCLASS(VisualShape2DEditorPlugin, AbstractPolygon2DEditorPlugin);
+
+public:
+	VisualShape2DEditorPlugin(EditorNode *p_node);
+};
+
+#endif // GOOST_VISUAL_SHAPE_2D_EDITOR_PLUGIN_H

--- a/editor/2d/visual_shape_2d_editor_plugin.h
+++ b/editor/2d/visual_shape_2d_editor_plugin.h
@@ -9,6 +9,8 @@ class VisualShape2DEditor : public AbstractPolygon2DEditor {
 
 	VisualShape2D *node;
 
+	void _update_editing();
+
 protected:
 	virtual Node2D *_get_node() const;
 	virtual void _set_node(Node *p_node);

--- a/editor/2d/visual_shape_2d_editor_plugin.h
+++ b/editor/2d/visual_shape_2d_editor_plugin.h
@@ -2,7 +2,7 @@
 #define GOOST_VISUAL_SHAPE_2D_EDITOR_PLUGIN_H
 
 #include "editor/plugins/abstract_polygon_2d_editor.h"
-#include "scene/2d/visual_shape_2d.h"
+#include "goost/scene/2d/visual_shape_2d.h"
 
 class VisualShape2DEditor : public AbstractPolygon2DEditor {
 	GDCLASS(VisualShape2DEditor, AbstractPolygon2DEditor);

--- a/editor/3d/SCsub
+++ b/editor/3d/SCsub
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+
+# Nothing here yet! 

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -1,3 +1,11 @@
 #!/usr/bin/env python
+Import("env")
+Import("env_goost")
 
-# Nothing here yet!
+if env_goost["goost_editor_enabled"]:
+    SConscript("2d/SCsub", exports="env_goost")
+
+    if not env["disable_3d"]:
+        SConscript("3d/SCsub", exports="env_goost")
+
+    env_goost.add_source_files(env_goost.modules_sources, "*.cpp")

--- a/editor/icons/README.md
+++ b/editor/icons/README.md
@@ -2,6 +2,6 @@
 
 This directory contains icons for classes provided by Goost.
 
-See official
+See official Godot Engine's
 [Editor icons](https://docs.godotengine.org/en/latest/development/editor/creating_icons.html)
 documentation page on how to create them.

--- a/editor/icons/icon_visual_shape_2d.svg
+++ b/editor/icons/icon_visual_shape_2d.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="16" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+<g transform="translate(0 -1036.4)">
+<path d="m14 1050.4h-12v-12h12z" fill="#a5b7f3" stroke="#a5b7f3" stroke-linejoin="round" stroke-width="2"/>
+</g>
+</svg>

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -1,0 +1,17 @@
+#include "register_editor_types.h"
+
+#include "editor/2d/visual_shape_2d_editor_plugin.h"
+
+namespace goost {
+
+void register_editor_types() {
+#ifdef TOOLS_ENABLED
+	EditorPlugins::add_by_type<VisualShape2DEditorPlugin>();
+#endif
+}
+
+void unregister_editor_types() {
+	// Nothing to do.
+}
+
+} // namespace goost

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -1,6 +1,6 @@
 #include "register_editor_types.h"
 
-#include "editor/2d/visual_shape_2d_editor_plugin.h"
+#include "2d/visual_shape_2d_editor_plugin.h"
 
 namespace goost {
 

--- a/editor/register_editor_types.h
+++ b/editor/register_editor_types.h
@@ -1,0 +1,6 @@
+namespace goost {
+
+void register_editor_types();
+void unregister_editor_types();
+
+} // namespace goost

--- a/goost.py
+++ b/goost.py
@@ -9,6 +9,7 @@ components = [
     "core/image",
     "core/math",
     "scene/physics",
+    "editor",
 ]
 
 def get_components():

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -2,6 +2,7 @@
 
 #include "core/register_core_types.h"
 #include "scene/register_scene_types.h"
+#include "editor/register_editor_types.h"
 
 void register_goost_types() {
 #ifdef GOOST_CORE_ENABLED
@@ -9,6 +10,9 @@ void register_goost_types() {
 #endif
 #ifdef GOOST_SCENE_ENABLED
 	goost::register_scene_types();
+#endif
+#ifdef GOOST_EDITOR_ENABLED
+	goost::register_editor_types();
 #endif
 }
 

--- a/scene/2d/SCsub
+++ b/scene/2d/SCsub
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+Import("env_goost")
+
+env_goost.add_source_files(env_goost.modules_sources, '*.cpp')

--- a/scene/2d/visual_shape_2d.cpp
+++ b/scene/2d/visual_shape_2d.cpp
@@ -10,6 +10,9 @@ void VisualShape2D::set_shape(const Ref<Shape2D> &p_shape) {
 	if (shape != p_shape) {
 		shape_changed = true;
 	}
+	if (shape.is_valid()) {
+		shape->disconnect(CoreStringNames::get_singleton()->changed, this, "update");
+	}
 	shape = p_shape;
 	if (p_shape.is_valid()) {
 		shape->connect(CoreStringNames::get_singleton()->changed, this, "update");

--- a/scene/2d/visual_shape_2d.cpp
+++ b/scene/2d/visual_shape_2d.cpp
@@ -1,0 +1,98 @@
+#include "visual_shape_2d.h"
+
+#include "core/core_string_names.h"
+#include "core/engine.h"
+
+void VisualShape2D::set_shape(const Ref<Shape2D> &p_shape) {
+	shape = p_shape;
+	if (p_shape.is_valid()) {
+		shape->connect(CoreStringNames::get_singleton()->changed, this, "update");
+	}
+	update();
+}
+
+Ref<Shape2D> VisualShape2D::get_shape() const {
+	return shape;
+}
+
+void VisualShape2D::set_color(const Color &p_color) {
+	color = p_color;
+	update();
+}
+
+Color VisualShape2D::get_color() const {
+	return color;
+}
+
+void VisualShape2D::set_debug_use_default_color(bool p_debug_use_default_color) {
+	debug_use_default_color = p_debug_use_default_color;
+	update();
+}
+
+bool VisualShape2D::is_using_debug_default_color() const {
+	return debug_use_default_color;
+}
+
+void VisualShape2D::set_debug_sync_visible_collision_shapes(bool p_debug_sync_visible_collision_shapes) {
+	debug_sync_visible_collision_shapes = p_debug_sync_visible_collision_shapes;
+	update();
+}
+
+bool VisualShape2D::is_debug_sync_visible_collision_shapes() const {
+	return debug_sync_visible_collision_shapes;
+}
+
+void VisualShape2D::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_DRAW: {
+			if (shape.is_null()) {
+				break;
+			}
+			Color draw_color = color;
+#ifdef TOOLS_ENABLED
+			if (debug_use_default_color) {
+				draw_color = get_tree()->get_debug_collisions_color();
+			}
+			if (debug_sync_visible_collision_shapes && !Engine::get_singleton()->is_editor_hint()) {
+				if (!get_tree()->is_debugging_collisions_hint()) {
+					break;
+				}
+			}
+#endif
+			shape->draw(get_canvas_item(), draw_color);
+		} break;
+	}
+}
+
+String VisualShape2D::get_configuration_warning() const {
+	String warning = Node2D::get_configuration_warning();
+
+	if (shape.is_null()) {
+		if (!warning.empty()) {
+			warning += "\n\n";
+		}
+		warning += TTR("Shape2D is required for this node to be drawn.");
+	}
+
+	return warning;
+}
+
+void VisualShape2D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_shape", "shape"), &VisualShape2D::set_shape);
+	ClassDB::bind_method(D_METHOD("get_shape"), &VisualShape2D::get_shape);
+
+	ClassDB::bind_method(D_METHOD("set_color", "color"), &VisualShape2D::set_color);
+	ClassDB::bind_method(D_METHOD("get_color"), &VisualShape2D::get_color);
+
+	ClassDB::bind_method(D_METHOD("set_debug_use_default_color", "enable"), &VisualShape2D::set_debug_use_default_color);
+	ClassDB::bind_method(D_METHOD("is_using_debug_default_color"), &VisualShape2D::is_using_debug_default_color);
+
+	ClassDB::bind_method(D_METHOD("set_debug_sync_visible_collision_shapes", "debug_sync_visible_collision_shapes"), &VisualShape2D::set_debug_sync_visible_collision_shapes);
+	ClassDB::bind_method(D_METHOD("is_debug_sync_visible_collision_shapes"), &VisualShape2D::is_debug_sync_visible_collision_shapes);
+
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shape", PROPERTY_HINT_RESOURCE_TYPE, "Shape2D"), "set_shape", "get_shape");
+	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "color"), "set_color", "get_color");
+	ADD_GROUP("Debug", "debug_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "debug_use_default_color"), "set_debug_use_default_color", "is_using_debug_default_color");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "debug_sync_visible_collision_shapes"), "set_debug_sync_visible_collision_shapes", "is_debug_sync_visible_collision_shapes");
+}

--- a/scene/2d/visual_shape_2d.cpp
+++ b/scene/2d/visual_shape_2d.cpp
@@ -22,6 +22,7 @@ void VisualShape2D::set_shape(const Ref<Shape2D> &p_shape) {
 	if (shape_changed) {
 		emit_signal("shape_changed");
 	}
+	update_configuration_warning();
 }
 
 Ref<Shape2D> VisualShape2D::get_shape() const {
@@ -31,6 +32,7 @@ Ref<Shape2D> VisualShape2D::get_shape() const {
 void VisualShape2D::set_use_parent_shape(bool p_use_parent_shape) {
 	use_parent_shape = p_use_parent_shape;
 	_update_parent_shape();
+	update_configuration_warning();
 	update();
 }
 
@@ -39,7 +41,7 @@ bool VisualShape2D::is_using_parent_shape() const {
 }
 
 void VisualShape2D::_update_parent_shape() {
-	bool valid = true;
+	bool valid = use_parent_shape;
 
 	if (!is_inside_tree()) {
 		valid = false;

--- a/scene/2d/visual_shape_2d.h
+++ b/scene/2d/visual_shape_2d.h
@@ -14,8 +14,8 @@ class VisualShape2D : public Node2D {
 
 	bool debug_use_default_color = false;
 	bool debug_sync_visible_collision_shapes = false;
-
-	void _update_parent_shape();
+	
+	bool _parent_shape_changed = false;
 
 protected:
 	void _notification(int p_what);
@@ -27,6 +27,8 @@ public:
 
 	void set_use_parent_shape(bool p_use_parent_shape);
 	bool is_using_parent_shape() const;
+	// Returns `true` if parent shape is changed.
+	bool update_parent_shape();
 
 	void set_color(const Color &p_color);
 	Color get_color() const;

--- a/scene/2d/visual_shape_2d.h
+++ b/scene/2d/visual_shape_2d.h
@@ -2,20 +2,25 @@
 #define GOOST_VISUAL_SHAPE_2D_H
 
 #include "scene/2d/node_2d.h"
+#include "scene/resources/concave_polygon_shape_2d.h"
+#include "scene/resources/convex_polygon_shape_2d.h"
 #include "scene/resources/shape_2d.h"
 
 class VisualShape2D : public Node2D {
 	GDCLASS(VisualShape2D, Node2D);
 
 	Ref<Shape2D> shape;
+
 	Ref<Shape2D> parent_shape;
 	bool use_parent_shape = false;
+
+	// Cache polygon-based parent geometry with this instance.
+	Ref<ConvexPolygonShape2D> polygon_shape;
+
 	Color color = Color(1, 1, 1, 1);
 
 	bool debug_use_default_color = false;
 	bool debug_sync_visible_collision_shapes = false;
-	
-	bool _parent_shape_changed = false;
 
 protected:
 	void _notification(int p_what);

--- a/scene/2d/visual_shape_2d.h
+++ b/scene/2d/visual_shape_2d.h
@@ -1,0 +1,38 @@
+#ifndef GOOST_VISUAL_SHAPE_2D_H
+#define GOOST_VISUAL_SHAPE_2D_H
+
+#include "scene/2d/node_2d.h"
+#include "scene/resources/shape_2d.h"
+
+class VisualShape2D : public Node2D {
+	GDCLASS(VisualShape2D, Node2D);
+	
+	Ref<Shape2D> shape;
+	Color color = Color(1, 1, 1, 1);
+	
+	bool debug_use_default_color = false;
+	bool debug_sync_visible_collision_shapes = false;
+
+protected:
+	void _notification(int p_what);
+	static void _bind_methods();
+	
+public:
+	void set_shape(const Ref<Shape2D> &p_shape);
+	Ref<Shape2D> get_shape() const;
+	
+	void set_color(const Color &p_color);
+	Color get_color() const;
+	
+	void set_debug_use_default_color(bool p_debug_use_default_color);
+	bool is_using_debug_default_color() const;
+	
+	void set_debug_sync_visible_collision_shapes(bool p_debug_sync_visible_collision_shapes);
+	bool is_debug_sync_visible_collision_shapes() const;
+	
+	String get_configuration_warning() const;
+	
+	VisualShape2D() {};
+};
+
+#endif // GOOST_VISUAL_SHAPE_2D_H

--- a/scene/2d/visual_shape_2d.h
+++ b/scene/2d/visual_shape_2d.h
@@ -6,33 +6,40 @@
 
 class VisualShape2D : public Node2D {
 	GDCLASS(VisualShape2D, Node2D);
-	
+
 	Ref<Shape2D> shape;
+	Ref<Shape2D> parent_shape;
+	bool use_parent_shape = false;
 	Color color = Color(1, 1, 1, 1);
-	
+
 	bool debug_use_default_color = false;
 	bool debug_sync_visible_collision_shapes = false;
+
+	void _update_parent_shape();
 
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
-	
+
 public:
 	void set_shape(const Ref<Shape2D> &p_shape);
 	Ref<Shape2D> get_shape() const;
-	
+
+	void set_use_parent_shape(bool p_use_parent_shape);
+	bool is_using_parent_shape() const;
+
 	void set_color(const Color &p_color);
 	Color get_color() const;
-	
+
 	void set_debug_use_default_color(bool p_debug_use_default_color);
 	bool is_using_debug_default_color() const;
-	
+
 	void set_debug_sync_visible_collision_shapes(bool p_debug_sync_visible_collision_shapes);
 	bool is_debug_sync_visible_collision_shapes() const;
-	
+
 	String get_configuration_warning() const;
-	
-	VisualShape2D() {};
+
+	VisualShape2D(){};
 };
 
 #endif // GOOST_VISUAL_SHAPE_2D_H

--- a/scene/3d/SCsub
+++ b/scene/3d/SCsub
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+
+# Nothing here yet! 

--- a/scene/SCsub
+++ b/scene/SCsub
@@ -1,5 +1,11 @@
 #!/usr/bin/env python
+Import("env")
 Import("env_goost")
+
+SConscript("2d/SCsub", exports="env_goost")
+
+if not env["disable_3d"]:
+    SConscript("3d/SCsub", exports="env_goost")
 
 if env_goost["goost_physics_enabled"]:
     SConscript("physics/SCsub", exports="env_goost")

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -3,9 +3,12 @@
 #include "physics/register_physics_types.h"
 #include "register_scene_types.h"
 
+#include "2d/visual_shape_2d.h"
+
 namespace goost {
 
 void register_scene_types() {
+	ClassDB::register_class<VisualShape2D>();
 #ifdef GOOST_PHYSICS_ENABLED
 	register_physics_types();
 #endif


### PR DESCRIPTION
Sort of closes godotengine/godot-proposals#1126.

![goost-visual-shapes](https://user-images.githubusercontent.com/17108460/85997909-cd042500-ba12-11ea-99dc-10d5a84b76e2.png)

This is pretty much another implementation of godotengine/godot#16483 (it's been suggested to implement this sort of class outside of Godot core), with a larger set of features:

- edit polygon-based shapes just like you edit `Polygon2D` (inheriting Godot's `AbstractPolygon2DEditor`)
- the shape can be automatically set from parent node (`CollisionShape2D`, `CollisionPolygon2D`, basically any node which have either `shape`, `polygon`, or `points` properties defined), so there's no need to set this via code to match those shapes:
  
    ![goost-visual-collision-shapes](https://user-images.githubusercontent.com/17108460/86017177-668c0080-ba2c-11ea-8981-4b23a6dbb0b2.png)

- optionally use Godot's default color for collision shapes debugging and respect the `Visible Collision Shapes` debug option, if you need to display the shapes of custom-made physics/collision nodes (for instance, not using `CollisionShape2D` but setting the collision shapes via code), which also helps godotengine/godot#36499.

### Limitations

1. ~~`ConcavePolygonShape2D` is not easy to edit because it uses segments over points. godotengine/godot#32979 is there to fix this inconsistency, but that's only 4.0 fix. So, please use `ConvexPolygonShape2D` for polygon editing (triangle, pentagons etc), though it's not limited to convex shapes, concave polygons can also be edited through this class. It may be possible to fix this locally in 3.2, but not high priority.~~ added.

2. There's no textures support, and probably won't be because this class heavily relies on per-shape drawing implemented in Godot. Use `Polygon2D` node for that. But you may be able to apply textures via shaders anyways.

## Example project

[visual_shapes.zip](https://github.com/GoostGD/goost/files/4845055/visual_shapes.zip) (will be merged to [Goost examples](https://github.com/GoostGD/goost-examples) once this is merged).

You'll have to checkout the [`visual-shape-2d` branch](https://github.com/GoostGD/goost/tree/visual-shape-2d) and compile the module to test this.

## Feedback

Suggestions welcome, including the name of the class.
