### PR TITLE
Add stamp_rect method to ImageBlender

### DIFF
--- a/core/image/image_blender.cpp
+++ b/core/image/image_blender.cpp
@@ -128,8 +128,42 @@ void ImageBlender::blend_rect(const Ref<Image> p_src, const Rect2 &p_src_rect, R
 	p_dst->unlock();
 }
 
+void ImageBlender::stamp_rect(const Ref<Image> p_src, const Rect2 &p_src_rect, Ref<Image> p_dst, const Point2 &p_dst_init_pos, const Point2 &p_dst_end_pos, float p_spacing) const {
+	float semi_width = p_src_rect.get_size().width / 2;
+	float semi_height = p_src_rect.get_size().height / 2;
+
+	Point2 start_point(p_dst_init_pos.x - semi_width, p_dst_init_pos.y - semi_height);
+	Point2 end_point(p_dst_end_pos.x - semi_width, p_dst_end_pos.y - semi_height);
+
+	float delta_x = end_point.x - start_point.x;
+	float delta_y = end_point.y - start_point.y;
+
+	float distance = sqrt(delta_x * delta_x + delta_y * delta_y);
+
+	float step_x = 0.0;
+	float step_y = 0.0;
+	if (distance > 0.0) {
+		float invert_distance = 1.0 / distance;
+		step_x = delta_x * invert_distance;
+		step_y = delta_y * invert_distance;
+	}
+
+	float offset_x = 0.0;
+	float offset_y = 0.0;
+
+	do {
+		blend_rect(p_src, p_src_rect, p_dst, Point2(start_point.x + offset_x, start_point.y + offset_y));
+
+		offset_x += step_x * p_spacing;
+		offset_y += step_y * p_spacing;
+
+		distance -= p_spacing;
+	} while (distance >= p_spacing);
+}
+
 void ImageBlender::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("blend_rect", "src", "src_rect", "dst", "dst_pos"), &ImageBlender::blend_rect);
+	ClassDB::bind_method(D_METHOD("stamp_rect", "src", "src_rect", "dst", "dst_init_pos", "dst_end_pos", "spacing"), &ImageBlender::stamp_rect);
 
 	ClassDB::bind_method(D_METHOD("set_rgb_equation", "equation"), &ImageBlender::set_rgb_equation);
 	ClassDB::bind_method(D_METHOD("get_rgb_equation"), &ImageBlender::get_rgb_equation);

--- a/core/image/image_blender.h
+++ b/core/image/image_blender.h
@@ -2,6 +2,7 @@
 #define GOOST_IMAGE_BLENDER_H
 
 #include "core/image.h"
+#include "core/method_bind_ext.gen.inc"
 
 class ImageBlender : public Reference {
 	GDCLASS(ImageBlender, Reference);
@@ -52,6 +53,7 @@ private:
 
 public:
 	void blend_rect(const Ref<Image> p_src, const Rect2 &p_src_rect, Ref<Image> p_dst, const Point2 &p_dst_pos) const;
+	void stamp_rect(const Ref<Image> p_src, const Rect2 &p_src_rect, Ref<Image> p_dst, const Point2 &p_dst_init_pos, const Point2 &p_dst_end_pos, float p_spacing) const;
 
 	void set_rgb_equation(BlendEquation p_equation) { rgb_equation = p_equation; };
 	void set_alpha_equation(BlendEquation p_equation) { alpha_equation = p_equation; };

--- a/doc/ImageBlender.xml
+++ b/doc/ImageBlender.xml
@@ -24,6 +24,25 @@
 				Blends [code]src_rect[/code] from [code]src[/code] image to [code]dst[/code] image at coordinates [code]dst_pos[/code].
 			</description>
 		</method>
+		<method name="stamp_rect" qualifiers="const">
+			<return type="void">
+			</return>
+			<argument index="0" name="src" type="Image">
+			</argument>
+			<argument index="1" name="src_rect" type="Rect2">
+			</argument>
+			<argument index="2" name="dst" type="Image">
+			</argument>
+			<argument index="3" name="dst_init_pos" type="Vector2">
+			</argument>
+			<argument index="4" name="dst_end_pos" type="Vector2">
+			</argument>
+			<argument index="5" name="spacing" type="float">
+			</argument>
+			<description>
+				Stamps [code]src_rect[/code] from [code]src[/code] image to [code]dst[/code] image in a straight line from [code]dst_init_pos[/code] to [code]dst_end_pos[/code], with a certain [code]spacing[/code] between stamps.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="rgb_equation" type="int" setter="set_rgb_equation" getter="get_rgb_equation" enum="ImageBlender.BlendEquation" default="0">


### PR DESCRIPTION
Stamping is a technic that emulates a brush, and the method stamp_rect aims to recreate this technic. [This](https://losingfight.com/blog/2007/08/18/how-to-implement-a-basic-bitmap-brush/) tutorial explains the steps that I have followed to implement this new method.

At first, I considered implementing it in GoostImage. However, I thought it would be useful if it supports custom blending. So I decided to implement it in ImageBlender instead.


