### PR TITLE
SCons: Allow to build Goost out of the same directory

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+#
+# This is a convenience/compatibility SConstruct which allows to build Goost in 
+# the same way as building Godot Engine, so the usage should be the same:
+#
+#     scons target=release_debug tools=yes bits=64
+#
+# Requirements:
+# - Godot Engine source code can be found in the parent directory, OR
+# - GODOT_SOURCE_PATH env var is defined pointing to Godot repository.
+#
+# Caveats/Limitations:
+# - You have to switch to the relevant git branch in Godot repository yourself.
+# - The `custom_modules` option is overridden to build Goost and accompanying
+#   modules, so you cannot use this option to build other modules (currently).
+# - The `extra_suffix` option is also overridden.
+#
+import os
+import sys
+import pickle
+import subprocess
+
+import goost
+import version
+
+# Avoid issues when building with different versions of Python.
+SConsignFile(".sconsign{0}.dblite".format(pickle.HIGHEST_PROTOCOL))
+
+# Find a path to Godot source to build with this module.
+# Try relative path first.
+godot_path = Dir("../godot")
+if not godot_path.exists():
+    # Try environment variable.
+    godot_path = Dir(os.getenv("GODOT_SOURCE_PATH"))
+    if not godot_path.exists():
+        print("No path found to Godot Engine source.")
+        print("Make sure to specify GODOT_SOURCE_PATH environment variable.")
+        Exit()
+
+def run_command(args):
+    if sys.platform == "win32":
+        subprocess.run(args, check=True, shell=True, cwd=godot_path.abspath)
+    elif sys.platform == "linux":
+        # This may not actually work on Linux systems, but works on WSL.
+        subprocess.run(args, check=True, cwd=godot_path.abspath)
+
+# Setup base SCons arguments (just copy all from the command line).
+build_args = ["scons"]
+for arg in ARGLIST:
+    opt = "%s=%s" % (arg[0], arg[1])
+    build_args.append(opt)
+
+# Link this module as a custom module.
+modules = [
+    # We cannot link to a single module. As a byproduct, this may compile other 
+    # modules which reside in the same location as this module.
+    Dir("..").abspath,
+    # This module provides built-in and community modules, just like this one.
+    os.path.join(Dir(".").abspath, "modules")
+]
+build_args.append("custom_modules=%s" % ",".join(modules))
+
+# Append extra suffix to distinguish between other Godot builds.
+build_args.append("extra_suffix=%s" % version.short_name)
+
+# Extend build name to the module name, preserving any custom build names.
+build_name = os.environ["BUILD_NAME"]
+if build_name:
+    build_name = version.short_name.capitalize() + "." + build_name
+os.environ["BUILD_NAME"] = build_name
+
+print("Building Godot with Goost ...")
+run_command(build_args)

--- a/version.py
+++ b/version.py
@@ -1,7 +1,11 @@
 short_name = "goost"
 name = "Goost: Godot Engine Extension"
+url = "https://github.com/goostengine/goost"
 major = 0
 minor = 1
 patch = 0
 status = "dev"
 year = 2020
+
+godot_version = "3.2"
+godot_url = "https://github.com/godotengine/godot"


### PR DESCRIPTION
![Annotation 2020-09-03 172630](https://user-images.githubusercontent.com/17108460/92128840-7a2c5c80-ee0b-11ea-8743-549a71492f01.png)


Added root `SConstruct` which is a convenience/compatibility script allowing to build Goost in the same way as building Godot Engine so the usage should be the same.

Internally, this attempts to find Godot source and build the engine with the Goost module, also providing customization such as appending extra suffix to the resulting binaries and overriding engine build name, so this shouldn't interfere with your other builds.

If you have the Goost module checked out alongside Godot repository (in the same parent folder), then you don't have to do anything to compile the module that way. Otherwise, you first have to set/export environment variable `GODOT_SOURCE_PATH` to point to Godot repository source, and then compile the module with:

```
scons
```

This also allows to build Goost with the existing built-in and community `modules/`, which was pretty cumbersome to do (previously, you had to manually append to the `custom_modules` option). But both approaches are supported.