### PR TITLE
CI: Upload SCons build result as artifact

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -63,6 +63,11 @@ jobs:
         run: |
           scons -j2 verbose=yes warnings=all werror=yes platform=linuxbsd tools=yes target=release_debug module_mono_enabled=yes mono_glue=no
 
+      - uses: actions/upload-artifact@v2
+        with:
+          name: godot.x11.opt.tools.64.goost.mono
+          path: godot/bin/godot.x11.opt.tools.64.goost.mono
+
   linux-server:
     runs-on: "ubuntu-20.04"
     name: Server (target=debug, tools=yes, tests=yes)

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -51,6 +51,11 @@ jobs:
         run: |
           scons -j2 verbose=yes warnings=all werror=yes platform=osx tools=yes target=release_debug
 
+      - uses: actions/upload-artifact@v2
+        with:
+          name: godot.osx.opt.tools.64.goost
+          path: godot/bin/godot.osx.opt.tools.64.goost
+
   macos-template:
     runs-on: "macos-latest"
     name: Template (target=release, tools=no)

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -52,6 +52,11 @@ jobs:
       run: |
         scons -j2 verbose=yes warnings=all werror=yes platform=windows tools=yes target=release_debug
 
+    - uses: actions/upload-artifact@v2
+      with:
+        name: godot.windows.opt.tools.64.goost
+        path: godot/bin/godot.windows.opt.tools.64.goost.exe
+
   windows-template:
     runs-on: "windows-latest"
     name: Template (target=release, tools=no)


### PR DESCRIPTION
For Linux, macOS, and Windows builds.

Tested downloading Windows artifacts, works!