### PR TITLE
SCons: Add build options to replace some env vars

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   GOOST_BASE_BRANCH: gd3
-  GODOT_BUILTIN_MODULES: disabled
+  SCONSFLAGS: godot_modules_enabled=no --jobs=4
   SCONS_CACHE_LIMIT: 4096
 
 jobs:
@@ -70,4 +70,4 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons -j2 verbose=yes warnings=all werror=yes platform=android target=release tools=no
+          scons verbose=yes warnings=all werror=yes platform=android target=release tools=no

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   GOOST_BASE_BRANCH: gd3
-  GODOT_BUILTIN_MODULES: disabled
+  SCONSFLAGS: godot_modules_enabled=no --jobs=4
   SCONS_CACHE_LIMIT: 4096
 
 jobs:
@@ -48,4 +48,4 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons -j2 verbose=yes warnings=all werror=no platform=iphone target=release tools=no
+          scons verbose=yes warnings=all werror=no platform=iphone target=release tools=no

--- a/.github/workflows/javascript_builds.yml
+++ b/.github/workflows/javascript_builds.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   GOOST_BASE_BRANCH: gd3
-  GODOT_BUILTIN_MODULES: disabled
+  SCONSFLAGS: godot_modules_enabled=no --jobs=4
   SCONS_CACHE_LIMIT: 4096
   EM_VERSION: 1.39.20
   EM_CACHE_FOLDER: 'emsdk-cache'
@@ -74,4 +74,4 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons -j2 verbose=yes warnings=all werror=yes platform=javascript target=release tools=no use_closure_compiler=yes
+          scons verbose=yes warnings=all werror=yes platform=javascript target=release tools=no use_closure_compiler=yes

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   GOOST_BASE_BRANCH: gd3
-  GODOT_BUILTIN_MODULES: disabled
+  SCONSFLAGS: godot_modules_enabled=no --jobs=4
   SCONS_CACHE_LIMIT: 4096
 
 jobs:
@@ -61,7 +61,7 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons -j2 verbose=yes warnings=all werror=yes platform=linuxbsd tools=yes target=release_debug module_mono_enabled=yes mono_glue=no
+          scons verbose=yes warnings=all werror=yes platform=linuxbsd tools=yes target=release_debug module_mono_enabled=yes mono_glue=no
 
       - uses: actions/upload-artifact@v2
         with:
@@ -116,7 +116,7 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons -j2 verbose=yes warnings=all werror=yes platform=server tools=yes target=debug
+          scons verbose=yes warnings=all werror=yes platform=server tools=yes target=debug
 
       - name: Run GUT Tests
         run: |
@@ -170,7 +170,7 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons -j2 verbose=yes warnings=all werror=yes platform=linuxbsd target=release tools=no module_mono_enabled=yes mono_glue=no
+          scons verbose=yes warnings=all werror=yes platform=linuxbsd target=release tools=no module_mono_enabled=yes mono_glue=no
 
   # Goost-specific
 
@@ -222,7 +222,7 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons -j2 verbose=yes warnings=all werror=yes platform=linuxbsd tools=yes target=release_debug goost_core_enabled=no
+          scons verbose=yes warnings=all werror=yes platform=linuxbsd tools=yes target=release_debug goost_core_enabled=no
 
   linux-goost-server:
     runs-on: "ubuntu-20.04"
@@ -272,7 +272,7 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons -j2 verbose=yes warnings=all werror=yes platform=server tools=yes target=debug goost_editor_enabled=no
+          scons verbose=yes warnings=all werror=yes platform=server tools=yes target=debug goost_editor_enabled=no
 
   linux-goost-template:
     runs-on: "ubuntu-20.04"
@@ -322,4 +322,4 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons -j2 verbose=yes warnings=all werror=yes platform=linuxbsd target=release tools=no goost_scene_enabled=no
+          scons verbose=yes warnings=all werror=yes platform=linuxbsd target=release tools=no goost_scene_enabled=no

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   GOOST_BASE_BRANCH: gd3
-  GODOT_BUILTIN_MODULES: disabled
+  SCONSFLAGS: godot_modules_enabled=no --jobs=4
   SCONS_CACHE_LIMIT: 4096
 
 jobs:
@@ -49,7 +49,7 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons -j2 verbose=yes warnings=all werror=yes platform=osx tools=yes target=release_debug
+          scons verbose=yes warnings=all werror=yes platform=osx tools=yes target=release_debug
 
       - uses: actions/upload-artifact@v2
         with:
@@ -91,4 +91,4 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons -j2 verbose=yes warnings=all werror=yes platform=osx target=release tools=no
+          scons verbose=yes warnings=all werror=yes platform=osx target=release tools=no

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   GOOST_BASE_BRANCH: gd3
-  GODOT_BUILTIN_MODULES: disabled
+  SCONSFLAGS: godot_modules_enabled=no --jobs=4
   SCONS_CACHE_MSVC_CONFIG: true
   SCONS_CACHE_LIMIT: 4096
 
@@ -50,7 +50,7 @@ jobs:
       env:
         SCONS_CACHE: /.scons_cache/
       run: |
-        scons -j2 verbose=yes warnings=all werror=yes platform=windows tools=yes target=release_debug
+        scons verbose=yes warnings=all werror=yes platform=windows tools=yes target=release_debug
 
     - uses: actions/upload-artifact@v2
       with:
@@ -94,4 +94,4 @@ jobs:
       env:
         SCONS_CACHE: /.scons_cache/
       run: |
-        scons -j2 verbose=yes warnings=all werror=yes platform=windows target=release tools=no
+        scons verbose=yes warnings=all werror=yes platform=windows target=release tools=no


### PR DESCRIPTION
## Added

SCons build options which are only relevant for when you build Goost with `scons` command:

`godot_version=3.2` "Godot Engine version (branch, tags, commit hashes)"
`godot_sync=no`, "Synchronize Godot Engine version from remote URL before building"
`godot_modules_enabled=yes`, "Build all Godot builtin modules"
`parent_modules_enabled=no`, "Build all modules which may reside in the same parent directory"

These options can be looked up with `scons --help` command.

### Usage examples

#### Compile the stable version of the engine with Goost module:
```
scons godot_version=3.2-stable
```
#### Compile the beta versions of the engine, synchronizing any changes from remote URL automatically:
```
scons godot_version=3.2 godot_sync=yes
```
#### Disable non-essential Godot modules for testing purposes (speeds up compilation, optimizes for size):
```
scons godot_modules_enabled=no
```
#### Compile additional modules which may reside alongside Goost:
```
scons parent_modules_enabled=yes
```

## Removed

`GOOST_PARENT_MODULES`, `GODOT_BUILTIN_MODULES` environment variables.

