### PR TITLE
SCons: Allow to configure Goost build options via file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,11 +38,12 @@
 # Cache
 __pycache__/
 
-# For projects that use SCons for building: http://http://www.scons.org/
+# SCons
 .sconf_temp
 .sconsign*.dblite
 *.pyc
 .scons_cache
+custom.py
 
 # Test-related output files
 /tests/project/out/*

--- a/SConstruct
+++ b/SConstruct
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 # Upstream: https://github.com/goostengine/goost
-# Version: 1.3.1 (Godot Engine 3.2.2+)
+# Version: 1.4 (Godot Engine 3.2.2+)
 # License: MIT
 #
 # `SConstruct` which allows to build any C++ module just like Godot Engine.
@@ -54,7 +54,7 @@ for path in godot_search_dirs:
 godot_url = os.getenv("GODOT_REPO_URL", "https://github.com/godotengine/godot")
 
 # Setup SCons command-line options.
-opts = Variables()
+opts = Variables("custom.py", ARGUMENTS)
 opts.Add("godot_version", "Godot Engine version (branch, tags, commit hashes)", godot_version)
 opts.Add(BoolVariable("godot_sync", "Synchronize Godot Engine version from remote URL before building", False))
 opts.Add(BoolVariable("godot_modules_enabled", "Build all Godot builtin modules", True))


### PR DESCRIPTION
Similar to Godot's `custom.py`. The following file can be created at root:

```python
# custom.py

# Automatically update Godot version from upstream.
godot_sync = "yes"
# Speed up compilation by disabling non-essential modules:
godot_modules_enabled = "no"
```

This removes the need to specify those options via the command-line interface each time, mainly useful for development purposes.