### PR TITLE
SCons: Add engine custom patching system

### DIFF
--- a/misc/patches/remove_warning_image_load.patch
+++ b/misc/patches/remove_warning_image_load.patch
@@ -1,0 +1,16 @@
+diff --git a/core/image.cpp b/core/image.cpp
+index 8cb95a8df..3f1cf94f2 100644
+--- a/core/image.cpp
++++ b/core/image.cpp
+@@ -1889,11 +1889,6 @@ Image::AlphaMode Image::detect_alpha() const {
+ }
+ 
+ Error Image::load(const String &p_path) {
+-#ifdef DEBUG_ENABLED
+-	if (p_path.begins_with("res://") && ResourceLoader::exists(p_path)) {
+-		WARN_PRINTS("Loaded resource as image file, this will not work on export: '" + p_path + "'. Instead, import the image file as an Image resource and load it normally as a resource.");
+-	}
+-#endif
+ 	return ImageLoader::load_image(p_path, this);
+ }
+ 


### PR DESCRIPTION
The Godot core cannot be modified without tinkering with the engine source, but in some cases, it's necessary to do so.

This change allows to circumvent the engine limitations and add small enhancements to Godot before build more easily by applying custom `git diff` patches.

This is disabled by default, and can be enabled with a new `use_godot_patches` and `godot_patches` SCons build options:

```sh
scons use_godot_patches=yes godot_patches=misc/patches
```

The `godot_patches` build option always defaults to `misc/patches` value. This way, only built-in patches will be applied, but any custom directory path can be passed as well. If you use a custom directory, the built-in patches will not be applied. It's recommended that you copy built-in patches to your own directory instead.

---

A new `remove_warning_image_load.patch` is added to remove the `Image.load()` warning, as proposed in godotengine/godot#42653.

Patches like this can be generated (Windows):

## Locally

`cd godot` and:

### For committed changes
```powershell
git format-patch HEAD~1 --stdout | Out-File -Encoding utf8 ../misc/patches/remove_warning_image_load.patch
```
### For non-committed changes (working tree)
```powershell
git diff | Out-File -Encoding utf8 ../misc/patches/remove_warning_image_load.patch
```

## Remotely

### From a pull request
```powershell
curl https://github.com/godotengine/godot/pull/42653.patch | Select-Object -Expand Content | Out-File -Encoding utf8 misc/patches/remove_warning_image_load.patch
```

The examples are written to work with `powershell` on Windows, but this can be adapted to work with plain Linux commands, documentation will be written in the [`godot-docs`](https://github.com/goostengine/goost-docs) repository in more detail. 🙂
