### PR TITLE
Add `Random` singleton

### DIFF
--- a/core/math/random.cpp
+++ b/core/math/random.cpp
@@ -1,0 +1,7 @@
+#include "random.h"
+
+Random *Random::singleton = nullptr;
+
+void Random::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("new_instance"), &Random::new_instance);
+}

--- a/core/math/random.h
+++ b/core/math/random.h
@@ -1,0 +1,27 @@
+#ifndef GOOST_RANDOM_H
+#define GOOST_RANDOM_H
+
+#include "core/math/random_number_generator.h"
+
+class Random : public RandomNumberGenerator {
+	GDCLASS(Random, RandomNumberGenerator);
+
+private:
+	static Random *singleton;
+
+protected:
+	static void _bind_methods();
+
+public:
+	static Random* get_singleton() { return singleton; }
+
+	Ref<Random> new_instance() const { return memnew(Random); }
+
+	Random() {
+		if (!singleton) {
+			singleton = this;
+		}
+	}
+};
+
+#endif // GOOST_RANDOM_H

--- a/core/math/register_math_types.cpp
+++ b/core/math/register_math_types.cpp
@@ -4,12 +4,19 @@
 
 #include "2d/geometry/goost_geometry_2d.h"
 #include "2d/geometry/goost_geometry_2d_bind.h"
+#include "random.h"
 
+static Ref<Random> _random;
 static _GoostGeometry2D *_goost_geometry_2d = nullptr;
 
 namespace goost {
 
 void register_math_types() {
+	_random.instance();
+	ClassDB::register_class<Random>();
+	Object *random = Object::cast_to<Object>(Random::get_singleton());
+	Engine::get_singleton()->add_singleton(Engine::Singleton("Random", random));
+
 	_goost_geometry_2d = memnew(_GoostGeometry2D);
 	GoostGeometry2D::initialize();
 
@@ -24,6 +31,7 @@ void register_math_types() {
 }
 
 void unregister_math_types() {
+	_random.unref();
 	memdelete(_goost_geometry_2d);
 	GoostGeometry2D::finalize();
 }

--- a/doc/Random.xml
+++ b/doc/Random.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="Random" inherits="RandomNumberGenerator" version="3.2">
+	<brief_description>
+		An instance of [RandomNumberGenerator] available at [@GlobalScope].
+	</brief_description>
+	<description>
+		This is a singleton which allows to use [RandomNumberGenerator] methods without instantiating a dedicated object. This means that [Random] can be used via script with methods such as [method @GDScript.randi]:
+		[codeblock]
+		Random.randomize() # Time-based.
+		Random.seed = hash("Goost") # Manual.
+		var i = Random.randi() % 100
+		var f = Random.randf_range(-1.0, 1.0)
+		[/codeblock]
+		The class may implement other methods other than what [RandomNumberGenerator] already provides out of the box.
+		It's not possible to instantiate a new [Random] instance with [code]Random.new()[/code] in GDScript. If you'd like to instantiate a local instance of [Random], use [method new_instance] instead, or [code]ClassDB.instance("Random")[/code], see [method ClassDB.instance].
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="new_instance" qualifiers="const">
+			<return type="Random">
+			</return>
+			<description>
+				Instantiates a new local [Random] instance based on [RandomNumberGenerator]. Does not override the [Random] instance accessible at [@GlobalScope].
+			</description>
+		</method>
+	</methods>
+	<constants>
+	</constants>
+</class>

--- a/goost.py
+++ b/goost.py
@@ -57,6 +57,7 @@ classes = [
     "PolyDecompParameters2D",
     "PolyOffsetParameters2D",
     "PolyNode2D",
+    "Random",
     "ShapeCast2D",
     "VisualShape2D",
 ]

--- a/tests/project/goost/core/math/test_random.gd
+++ b/tests/project/goost/core/math/test_random.gd
@@ -1,0 +1,23 @@
+extends "res://addons/gut/test.gd"
+
+
+func test_create_local_instance():
+	var rng = Random.new_instance()
+	Random.seed = hash("Goost")
+	rng.seed = 37
+	assert_ne(rng, Random, "The new local instance should not override the global one")
+	assert_ne(rng.seed, Random.seed)
+	assert_lt(rng.randf(), 1.0)
+
+
+func test_singleton():
+	Random.randomize()
+	Random.seed = 37
+	for x in 100:
+		var f = Random.randf()
+		assert_lt(f, 1.0)
+		assert_gt(f, 0.0)
+	for x in 100:
+		var i = Random.randi() % 100
+		assert_lt(i, 99)
+		assert_gt(i, 0)


### PR DESCRIPTION
Closes godotengine/godot-proposals#1741.

Provides a global instance of `RandomNumberGenerator` available via scripting at global scope, as a complementary for the lack of additional RNG methods in GDScript functions.

```gdscript
Random.randomize()
Random.seed = hash("Goost")
var i = Random.randi() % 100
var f = Random.randf_range(-1.0, 1.0)
```
is equivalent to:
```gdscript
randomize()
seed(hash("Goost"))
var i = randi() % 100
var f = rand_range(-1.0, 1.0)
```

Exposing this class as a global instance allows to use methods such as `randfn()`, `randi_range()` available in `RandomNumberGenerator`, which are *not* available in GDScript.

A new *local* instance has to be created with:
```gdscript
var rng = Random.new_instance()
```

You can still use `RandomNumberGenerator`, but a new set of randomization methods may/should be implemented in `Random` class as well, such as godotengine/godot#43103, but before this can happen, godotengine/godot#43113 has to be backported to Godot 3.2.4.