### PR TITLE
Add `shuffle` method to `Random`

### DIFF
--- a/core/math/random.cpp
+++ b/core/math/random.cpp
@@ -91,6 +91,18 @@ Variant Random::choice(const Variant &p_sequence) {
 	return Variant();
 }
 
+void Random::shuffle(Array p_array) {
+	if (p_array.size() < 2) {
+		return;
+	}
+	for (int i = p_array.size() - 1; i > 0; --i) {
+		const uint32_t j = randi() % (i + 1);
+		const Variant tmp = p_array[i];
+		p_array[i] = p_array[j];
+		p_array[j] = tmp;
+	}
+}
+
 void Random::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("new_instance"), &Random::new_instance);
 
@@ -106,6 +118,7 @@ void Random::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("range", "from", "to"), &Random::range);
 	ClassDB::bind_method(D_METHOD("choice", "from_sequence"), &Random::choice);
+	ClassDB::bind_method(D_METHOD("shuffle", "array"), &Random::shuffle);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "number"), "", "get_number");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "value"), "", "get_value");

--- a/core/math/random.h
+++ b/core/math/random.h
@@ -26,6 +26,7 @@ public:
 
 	Variant range(const Variant &p_from, const Variant &p_to);
 	Variant choice(const Variant &p_sequence);
+	void shuffle(Array p_array);
 
 	Random() {
 		if (!singleton) {

--- a/doc/Random.xml
+++ b/doc/Random.xml
@@ -93,6 +93,15 @@
 				For any other type, the value is linearly interpolated with a random weight of [code]0.0..1.0[/code].
 			</description>
 		</method>
+		<method name="shuffle">
+			<return type="void">
+			</return>
+			<argument index="0" name="array" type="Array">
+			</argument>
+			<description>
+				Shuffles the array such that the items will have a random order. By default, this method uses the global random number generator in [Random] singletons, but unlike in [method Array.shuffle], local instances of [Random] can be created with [method new_instance] to achieve reproducible results given the same seed.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="color" type="Color" setter="" getter="get_color" default="Color( 0.461085, 0.853845, 0.756011, 1 )">

--- a/tests/project/goost/core/math/test_random.gd
+++ b/tests/project/goost/core/math/test_random.gd
@@ -135,3 +135,29 @@ func test_choice():
 	# https://github.com/godotengine/godot-proposals/issues/1763
 	# assert_null(rng.choice(""))
 	# assert_null(rng.choice([]))
+
+
+func test_shuffle_array():
+	var rng = Random.new_instance()
+
+	rng.seed = 100
+	var array = [
+		"Godot",
+		37,
+		"Goost",
+		Color.red,
+		Vector2.UP
+	]
+	rng.shuffle(array)
+	assert_eq(array[0], Color.red)
+	assert_eq(array[1], "Godot")
+	assert_eq(array[2], "Goost")
+	assert_eq(array[3], 37)
+	assert_eq(array[4], Vector2.UP)
+
+	rng.shuffle(array)
+	assert_eq(array[0], "Goost")
+	assert_eq(array[1], Vector2.UP)
+	assert_eq(array[2], Color.red)
+	assert_eq(array[3], 37)
+	assert_eq(array[4], "Godot")


### PR DESCRIPTION
Unlike in `Array.shuffle()`, *local* instances of `Random` can be created to achieve reproducible results given the same seed.