### PR TITLE
Automatically call `randomize()` in `Random` singletons

### DIFF
--- a/core/math/2d/random_2d.cpp
+++ b/core/math/2d/random_2d.cpp
@@ -129,4 +129,15 @@ void Random2D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "direction"), "", "get_direction");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "rotation"), "", "get_rotation");
+
+	// Default values are non-deterministic, override those for documentation purposes.	
+	ADD_PROPERTY_DEFAULT("direction", Vector2(1, 0));
+	ADD_PROPERTY_DEFAULT("rotation", Math_TAU);
+
+	// Have to override in base class as well.
+	ADD_PROPERTY_DEFAULT("number", 37);
+	ADD_PROPERTY_DEFAULT("value", 0.5);
+	ADD_PROPERTY_DEFAULT("color", Color(0, 0, 1));
+	ADD_PROPERTY_DEFAULT("condition", true);
+	ADD_PROPERTY_DEFAULT("seed", 0);
 }

--- a/core/math/2d/random_2d.h
+++ b/core/math/2d/random_2d.h
@@ -26,6 +26,7 @@ public:
 
 	Random2D() {
 		if (!singleton) {
+			randomize(); // Only the global one is randomized automatically.
 			singleton = this;
 		}
 	}

--- a/core/math/random.cpp
+++ b/core/math/random.cpp
@@ -124,4 +124,12 @@ void Random::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "value"), "", "get_value");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "color"), "", "get_color");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "condition"), "", "get_condition");
+
+	// Default values are non-deterministic, override those for documentation purposes.
+	ADD_PROPERTY_DEFAULT("number", 37);
+	ADD_PROPERTY_DEFAULT("value", 0.5);
+	ADD_PROPERTY_DEFAULT("color", Color(0, 0, 1));
+	ADD_PROPERTY_DEFAULT("condition", true);
+	// Have to override in base class as well.
+	ADD_PROPERTY_DEFAULT("seed", 0);
 }

--- a/core/math/random.h
+++ b/core/math/random.h
@@ -30,6 +30,7 @@ public:
 
 	Random() {
 		if (!singleton) {
+			randomize(); // Only the global one is randomized automatically.
 			singleton = this;
 		}
 	}

--- a/doc/Random.xml
+++ b/doc/Random.xml
@@ -13,6 +13,7 @@
 		[/codeblock]
 		The class provides other useful and intuitive methods other than what [RandomNumberGenerator] already provides out of the box.
 		It's not possible to instantiate a new [Random] instance with [code]Random.new()[/code] in GDScript. If you'd like to instantiate a local instance of [Random], use [method new_instance] instead, or [code]ClassDB.instance("Random")[/code], see [method ClassDB.instance].
+		You have to call [method randomize] for local instances manually if you want to have non-reproducible results, else done automatically for the global instance by default.
 		For 2D, use [Random2D] class, which inherits all the functionality behind [Random] as well.
 	</description>
 	<tutorials>
@@ -104,14 +105,14 @@
 		</method>
 	</methods>
 	<members>
-		<member name="color" type="Color" setter="" getter="get_color" default="Color( 0.461085, 0.853845, 0.756011, 1 )">
+		<member name="color" type="Color" setter="" getter="get_color" default="Color( 0.894257, 0.564905, 0.226137, 1 )">
 			Generates a random color in RGB color space. Equivalent to the following code:
 			[codeblock]
 			var color = Color(randf(), randf(), randf())
 			[/codeblock]
 			For more options, use [method color_hsv].
 		</member>
-		<member name="condition" type="bool" setter="" getter="get_condition" default="false">
+		<member name="condition" type="bool" setter="" getter="get_condition" default="true">
 			Generates a random boolean value. Useful for randomizing [code]true[/code] and [code]false[/code] states, conditions, decisions etc. The outcome is equal for both values.
 			[codeblock]
 			if Random.condition:
@@ -123,10 +124,11 @@
 			    pass
 			[/codeblock]
 		</member>
-		<member name="number" type="int" setter="" getter="get_number" default="3161026589">
+		<member name="number" type="int" setter="" getter="get_number" default="505729919">
 			Generates a random unsigned 32-bit integer. Equivalent to [method RandomNumberGenerator.randi].
 		</member>
-		<member name="value" type="float" setter="" getter="get_value" default="0.962688">
+		<member name="seed" type="int" setter="set_seed" getter="get_seed" override="true" default="1330373036540619517" />
+		<member name="value" type="float" setter="" getter="get_value" default="0.370127">
 			Generates a random real number in the range of [code]0.0..1.0[/code]. Equivalent to [method RandomNumberGenerator.randf].
 		</member>
 	</members>

--- a/doc/Random.xml
+++ b/doc/Random.xml
@@ -105,7 +105,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="color" type="Color" setter="" getter="get_color" default="Color( 0.894257, 0.564905, 0.226137, 1 )">
+		<member name="color" type="Color" setter="" getter="get_color" default="Color( 0, 0, 1, 1 )">
 			Generates a random color in RGB color space. Equivalent to the following code:
 			[codeblock]
 			var color = Color(randf(), randf(), randf())
@@ -124,11 +124,11 @@
 			    pass
 			[/codeblock]
 		</member>
-		<member name="number" type="int" setter="" getter="get_number" default="505729919">
+		<member name="number" type="int" setter="" getter="get_number" default="37">
 			Generates a random unsigned 32-bit integer. Equivalent to [method RandomNumberGenerator.randi].
 		</member>
-		<member name="seed" type="int" setter="set_seed" getter="get_seed" override="true" default="1330373036540619517" />
-		<member name="value" type="float" setter="" getter="get_value" default="0.370127">
+		<member name="seed" type="int" setter="set_seed" getter="get_seed" override="true" default="0" />
+		<member name="value" type="float" setter="" getter="get_value" default="0.5">
 			Generates a random real number in the range of [code]0.0..1.0[/code]. Equivalent to [method RandomNumberGenerator.randf].
 		</member>
 	</members>

--- a/doc/Random2D.xml
+++ b/doc/Random2D.xml
@@ -71,21 +71,16 @@
 		</method>
 	</methods>
 	<members>
-		<member name="color" type="Color" setter="" getter="get_color" override="true" default="Color( 0.153056, 0.472216, 0.293778, 1 )" />
-		<member name="condition" type="bool" setter="" getter="get_condition" override="true" default="false" />
-		<member name="direction" type="Vector2" setter="" getter="get_direction" default="Vector2( 0.290031, 0.957017 )">
+		<member name="direction" type="Vector2" setter="" getter="get_direction" default="Vector2( 1, 0 )">
 			A random normalized direction. Equivalent to [method point_in_circle] with minimum and maximum radiuses set to unit length of [code]1.0[/code] and is slightly more efficient. The unit vector can be multiplied by a scalar value.
 			[codeblock]
 			var radius = 64.0
 			var impulse = Random2D.direction * radius
 			[/codeblock]
 		</member>
-		<member name="number" type="int" setter="" getter="get_number" override="true" default="51361403" />
-		<member name="rotation" type="float" setter="" getter="get_rotation" default="4.21857">
+		<member name="rotation" type="float" setter="" getter="get_rotation" default="6.28319">
 			A random rotation in radians. Ranges from [code]0.0[/code] to [constant @GDScript.TAU].
 		</member>
-		<member name="seed" type="int" setter="set_seed" getter="get_seed" override="true" default="-2833408348807289048" />
-		<member name="value" type="float" setter="" getter="get_value" override="true" default="0.812761" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/Random2D.xml
+++ b/doc/Random2D.xml
@@ -71,16 +71,21 @@
 		</method>
 	</methods>
 	<members>
-		<member name="direction" type="Vector2" setter="" getter="get_direction" default="Vector2( -0.726713, -0.686941 )">
+		<member name="color" type="Color" setter="" getter="get_color" override="true" default="Color( 0.153056, 0.472216, 0.293778, 1 )" />
+		<member name="condition" type="bool" setter="" getter="get_condition" override="true" default="false" />
+		<member name="direction" type="Vector2" setter="" getter="get_direction" default="Vector2( 0.290031, 0.957017 )">
 			A random normalized direction. Equivalent to [method point_in_circle] with minimum and maximum radiuses set to unit length of [code]1.0[/code] and is slightly more efficient. The unit vector can be multiplied by a scalar value.
 			[codeblock]
 			var radius = 64.0
 			var impulse = Random2D.direction * radius
 			[/codeblock]
 		</member>
-		<member name="rotation" type="float" setter="" getter="get_rotation" default="4.76497">
+		<member name="number" type="int" setter="" getter="get_number" override="true" default="51361403" />
+		<member name="rotation" type="float" setter="" getter="get_rotation" default="4.21857">
 			A random rotation in radians. Ranges from [code]0.0[/code] to [constant @GDScript.TAU].
 		</member>
+		<member name="seed" type="int" setter="set_seed" getter="get_seed" override="true" default="-2833408348807289048" />
+		<member name="value" type="float" setter="" getter="get_value" override="true" default="0.812761" />
 	</members>
 	<constants>
 	</constants>

--- a/tests/project/goost/core/math/test_random.gd
+++ b/tests/project/goost/core/math/test_random.gd
@@ -99,7 +99,7 @@ func test_color_hsv():
 func test_condition():
 	var false_count = 0
 	var true_count = 0
-	for x in 10000:
+	for x in 100000:
 		if Random.condition:
 			true_count += 1
 		else:


### PR DESCRIPTION
Global instances (`Random`, `Random2D`) will automatically call `randomize()`, unlike GDScript in Godot 3.2 (but see similar PR at Godot in godotengine/godot#43330). Local instances must still call `randomize()` manually. 

The only issue is that the `--doctool` produces random values, so this creates annoying problem of diffs in VCS, and I'm not sure whether it's possible to fix this in a module, so postponing merging for now.

See also godotengine/godot-proposals#1774.

