### PR TITLE
Fix `Random.color_rgb`, use HSV for generating random colors by default

### DIFF
--- a/core/math/random.cpp
+++ b/core/math/random.cpp
@@ -14,9 +14,8 @@ real_t Random::get_value() {
 
 Color Random::get_color() {
 	Color color;
-	// "Not too dark" version:
-	// color.set_hsv(randf(), 1.0, randf_range(0.5, 1.0));
-	color = Color(randf(), randf(), randf());
+	// Pick not too pale and not too dark color.
+	color.set_hsv(randf(), randf_range(0.5, 1.0), randf_range(0.5, 1.0));
 	return color;
 }
 
@@ -47,7 +46,7 @@ Variant Random::range(const Variant &p_from, const Variant &p_to) {
 	return Variant();
 }
 
-Color Random::color_hsv(real_t h_min, real_t h_max, real_t s_min, real_t s_max, real_t v_min, real_t v_max, real_t a_min, real_t a_max) {
+Color Random::color_hsv(float h_min, float h_max, float s_min, float s_max, float v_min, float v_max, float a_min, float a_max) {
 	Color color;
 	color.set_hsv(
 			randf_range(h_min, h_max),
@@ -57,7 +56,7 @@ Color Random::color_hsv(real_t h_min, real_t h_max, real_t s_min, real_t s_max, 
 	return color;
 }
 
-Color Random::color_rgb(real_t r_min, real_t r_max, real_t g_min, real_t g_max, real_t b_min, real_t b_max, real_t a_min, real_t a_max) {
+Color Random::color_rgb(float r_min, float r_max, float g_min, float g_max, float b_min, float b_max, float a_min, float a_max) {
 	return Color(
 			randf_range(r_min, r_max),
 			randf_range(g_min, g_max),
@@ -114,7 +113,7 @@ void Random::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("color_hsv", "hue_min", "hue_max", "saturation_min", "saturation_max", "value_min", "value_max", "alpha_min", "alpha_max"),
 			&Random::color_hsv, DEFVAL(0.0), DEFVAL(1.0), DEFVAL(0.0), DEFVAL(1.0), DEFVAL(0.0), DEFVAL(1.0), DEFVAL(1.0), DEFVAL(1.0));
 	ClassDB::bind_method(D_METHOD("color_rgb", "red_min", "red_max", "green_min", "green_max", "blue_min", "blue_max", "alpha_min", "alpha_max"),
-			&Random::color_hsv, DEFVAL(0.0), DEFVAL(1.0), DEFVAL(0.0), DEFVAL(1.0), DEFVAL(0.0), DEFVAL(1.0), DEFVAL(1.0), DEFVAL(1.0));
+			&Random::color_rgb, DEFVAL(0.0), DEFVAL(1.0), DEFVAL(0.0), DEFVAL(1.0), DEFVAL(0.0), DEFVAL(1.0), DEFVAL(1.0), DEFVAL(1.0));
 
 	ClassDB::bind_method(D_METHOD("range", "from", "to"), &Random::range);
 	ClassDB::bind_method(D_METHOD("choice", "from_sequence"), &Random::choice);

--- a/core/math/random.h
+++ b/core/math/random.h
@@ -21,8 +21,8 @@ public:
 	Color get_color();
 	bool get_condition();
 
-	Color color_hsv(real_t h_min = 0.0, real_t h_max = 1.0, real_t s_min = 0.0, real_t s_max = 1.0, real_t v_min = 0.0, real_t v_max = 1.0, real_t a_min = 1.0, real_t a_max = 1.0);
-	Color color_rgb(real_t r_min = 0.0, real_t r_max = 1.0, real_t g_min = 0.0, real_t g_max = 1.0, real_t b_min = 0.0, real_t b_max = 1.0, real_t a_min = 1.0, real_t a_max = 1.0);
+	Color color_hsv(float h_min = 0.0, float h_max = 1.0, float s_min = 0.0, float s_max = 1.0, float v_min = 0.0, float v_max = 1.0, float a_min = 1.0, float a_max = 1.0);
+	Color color_rgb(float r_min = 0.0, float r_max = 1.0, float g_min = 0.0, float g_max = 1.0, float b_min = 0.0, float b_max = 1.0, float a_min = 1.0, float a_max = 1.0);
 
 	Variant range(const Variant &p_from, const Variant &p_to);
 	Variant choice(const Variant &p_sequence);

--- a/doc/Random.xml
+++ b/doc/Random.xml
@@ -48,7 +48,11 @@
 			<argument index="7" name="alpha_max" type="float" default="1.0">
 			</argument>
 			<description>
-				Generates a random [Color] specified in HSV color model. See also [method Color.from_hsv].
+				Generates a random [Color] specified in HSV color model. See also [method Color.from_hsv]. By default, equivalent to the following code:
+				[codeblock]
+				var color = Color.from_hsv(randf(), randf(), randf())
+				[/codeblock]
+				If you want to generate colors which are not too pale and not too dark, use [member color].
 			</description>
 		</method>
 		<method name="color_rgb">
@@ -71,7 +75,11 @@
 			<argument index="7" name="alpha_max" type="float" default="1.0">
 			</argument>
 			<description>
-				Generates a random [Color] specified in RGB color model.
+				Generates a random [Color] specified in RGB color model. By default, equivalent to the following code:
+				[codeblock]
+				var color = Color(randf(), randf(), randf())
+				[/codeblock]
+				If you want to generate colors which are not too pale and not too dark, use [member color].
 			</description>
 		</method>
 		<method name="new_instance" qualifiers="const">
@@ -106,11 +114,11 @@
 	</methods>
 	<members>
 		<member name="color" type="Color" setter="" getter="get_color" default="Color( 0, 0, 1, 1 )">
-			Generates a random color in RGB color space. Equivalent to the following code:
+			The next random color in HSV color space. Saturated, bright colors are preferred. Equivalent to the following code:
 			[codeblock]
-			var color = Color(randf(), randf(), randf())
+			var color = Color.from_hsv(randf(), rand_range(0.5, 1.0), rand_range(0.5, 1.0))
 			[/codeblock]
-			For more options, use [method color_hsv].
+			For more options, use [method color_hsv] or [method color_rgb].
 		</member>
 		<member name="condition" type="bool" setter="" getter="get_condition" default="true">
 			Generates a random boolean value. Useful for randomizing [code]true[/code] and [code]false[/code] states, conditions, decisions etc. The outcome is equal for both values.


### PR DESCRIPTION
Fixes wrong method bound to `color_rgb`... Copy-paste mistake, unfortunately, `ClassDB` never reports those kind of errors. 😕

---

This also changes `Random.color` to use HSV model to prefer saturated and bright colors. See for yourself:

![RGB_vs_HSV](https://user-images.githubusercontent.com/17108460/98421478-15eb7a80-2092-11eb-8be5-b5ec08778d7e.gif)

Might not be too much difference, but this ensures that no dark colors are ever generated by default. For naive way of generating colors with typical `Color(randf(), randf(), randf())`, you can always use `Random.color_rgb()` *method* instead, this is all documented. 🙂