### PR TITLE
Rewrite polygon boolean, offset and decomposition API 

### DIFF
--- a/core/math/2d/geometry/goost_geometry_2d.cpp
+++ b/core/math/2d/geometry/goost_geometry_2d.cpp
@@ -77,13 +77,13 @@ Vector<Vector<Point2>> GoostGeometry2D::triangulate_polygon(const Vector<Point2>
 	Vector<Vector<Point2>> polygons;
 	polygons.push_back(p_polygon);
 	// Using DECOMP_TRIANGLES_MONO as it's mostly fail-proof in clipper10 backend (default).
-	return PolyDecomp2D::decompose_polygons(PolyDecomp2D::DECOMP_TRIANGLES_MONO, polygons);
+	return PolyDecomp2D::decompose_polygons(polygons, PolyDecomp2D::DECOMP_TRIANGLES_MONO);
 }
 
 Vector<Vector<Point2>> GoostGeometry2D::decompose_polygon(const Vector<Point2> &p_polygon) {
 	Vector<Vector<Point2>> polygons;
 	polygons.push_back(p_polygon);
-	return PolyDecomp2D::decompose_polygons(PolyDecomp2D::DECOMP_CONVEX_HM, polygons);
+	return PolyDecomp2D::decompose_polygons(polygons, PolyDecomp2D::DECOMP_CONVEX_HM);
 }
 
 Point2 GoostGeometry2D::polygon_centroid(const Vector<Point2> &p_polygon) {

--- a/core/math/2d/geometry/goost_geometry_2d.h
+++ b/core/math/2d/geometry/goost_geometry_2d.h
@@ -1,75 +1,26 @@
 #ifndef GOOST_GEOMETRY_2D_H
 #define GOOST_GEOMETRY_2D_H
 
-#include "core/object.h"
-#include "core/project_settings.h"
-
-#include "poly/boolean/poly_boolean.h"
-#include "poly/decomp/poly_decomp.h"
-#include "poly/offset/poly_offset.h"
+#include "core/variant.h"
 
 class GoostGeometry2D {
 public:
-	enum PolyBooleanOperation {
-		OPERATION_NONE, // May perform polygons fixup, build hierarchy etc.
-		OPERATION_UNION,
-		OPERATION_DIFFERENCE,
-		OPERATION_INTERSECTION,
-		OPERATION_XOR,
-	};
 	/* Polygon and polyline boolean operations */
-	static Vector<Vector<Point2>> merge_polygons(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b, Ref<PolyBooleanParameters2D> p_params = nullptr);
-	static Vector<Vector<Point2>> clip_polygons(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b, Ref<PolyBooleanParameters2D> p_params = nullptr);
-	static Vector<Vector<Point2>> intersect_polygons(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b, Ref<PolyBooleanParameters2D> p_params = nullptr);
-	static Vector<Vector<Point2>> exclude_polygons(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b, Ref<PolyBooleanParameters2D> p_params = nullptr);
-
-	static Vector<Vector<Point2>> merge_multiple_polygons(const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b, Ref<PolyBooleanParameters2D> p_params = nullptr);
-	static Vector<Vector<Point2>> clip_multiple_polygons(const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b, Ref<PolyBooleanParameters2D> p_params = nullptr);
-	static Vector<Vector<Point2>> intersect_multiple_polygons(const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b, Ref<PolyBooleanParameters2D> p_params = nullptr);
-	static Vector<Vector<Point2>> exclude_multiple_polygons(const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b, Ref<PolyBooleanParameters2D> p_params = nullptr);
-
-	// General-purpose polygon boolean operations.
-	static Vector<Vector<Point2>> polygons_boolean(PolyBooleanOperation p_op, const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b = Vector<Vector<Point2>>(), Ref<PolyBooleanParameters2D> p_params = nullptr);
-
-	// Returns a top-level root node which represents an hierarchy of polygons.
-	static Ref<PolyNode2D> polygons_boolean_tree(PolyBooleanOperation p_op, const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b = Vector<Vector<Point2>>(), Ref<PolyBooleanParameters2D> p_params = nullptr);
-
-	// Note: UNION and XOR do not apply here.
-	static Vector<Vector<Point2>> clip_polyline_with_polygon(const Vector<Point2> &p_polyline, const Vector<Point2> &p_polygon, Ref<PolyBooleanParameters2D> p_params = nullptr);
-	static Vector<Vector<Point2>> intersect_polyline_with_polygon(const Vector<Point2> &p_polyline, const Vector<Point2> &p_polygon, Ref<PolyBooleanParameters2D> p_params = nullptr);
-	static Vector<Vector<Point2>> clip_multiple_polylines_with_polygons(const Vector<Vector<Point2>> &p_polylines, const Vector<Vector<Point2>> &p_polygons, Ref<PolyBooleanParameters2D> p_params = nullptr);
-	static Vector<Vector<Point2>> intersect_multiple_polylines_with_polygons(const Vector<Vector<Point2>> &p_polylines, const Vector<Vector<Point2>> &p_polygons, Ref<PolyBooleanParameters2D> p_params = nullptr);
+	static Vector<Vector<Point2>> merge_polygons(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b);
+	static Vector<Vector<Point2>> clip_polygons(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b);
+	static Vector<Vector<Point2>> intersect_polygons(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b);
+	static Vector<Vector<Point2>> exclude_polygons(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b);
+	static Vector<Vector<Point2>> clip_polyline_with_polygon(const Vector<Point2> &p_polyline, const Vector<Point2> &p_polygon);
+	static Vector<Vector<Point2>> intersect_polyline_with_polygon(const Vector<Point2> &p_polyline, const Vector<Point2> &p_polygon);
 
 	/* Polygon inflating and deflating */
-	static Vector<Vector<Point2>> inflate_polygon(const Vector<Point2> &p_polygon, real_t p_delta, Ref<PolyOffsetParameters2D> p_params = nullptr);
-	static Vector<Vector<Point2>> deflate_polygon(const Vector<Point2> &p_polygon, real_t p_delta, Ref<PolyOffsetParameters2D> p_params = nullptr);
-	static Vector<Vector<Point2>> inflate_multiple_polygons(const Vector<Vector<Point2>> &p_polygons, real_t p_delta, Ref<PolyOffsetParameters2D> p_params = nullptr);
-	static Vector<Vector<Point2>> deflate_multiple_polygons(const Vector<Vector<Point2>> &p_polygons, real_t p_delta, Ref<PolyOffsetParameters2D> p_params = nullptr);
-
-	// Grows polyline into a polygon.
-	// Note: negative delta does not apply here.
-	static Vector<Vector<Point2>> deflate_polyline(const Vector<Point2> &p_polyline, real_t p_delta, Ref<PolyOffsetParameters2D> p_params = nullptr);
-	static Vector<Vector<Point2>> deflate_multiple_polylines(const Vector<Vector<Point2>> &p_polylines, real_t p_delta, Ref<PolyOffsetParameters2D> p_params = nullptr);
-
-	// General-purpose offsetting, accepts both negative and positive delta.
-	static Vector<Vector<Point2>> offset_polygon(const Vector<Point2> &p_polygon, real_t p_delta, Ref<PolyOffsetParameters2D> p_params = nullptr);
-	static Vector<Vector<Point2>> offset_multiple_polygons(const Vector<Vector<Point2>> &p_polygons, real_t p_delta, Ref<PolyOffsetParameters2D> p_params = nullptr);
+	static Vector<Vector<Point2>> inflate_polygon(const Vector<Point2> &p_polygon, real_t p_delta);
+	static Vector<Vector<Point2>> deflate_polygon(const Vector<Point2> &p_polygon, real_t p_delta);
+	static Vector<Vector<Point2>> deflate_polyline(const Vector<Point2> &p_polyline, real_t p_delta);
 
 	/* Polygon decomposition */
-	enum PolyDecompType {
-		DECOMP_TRIANGLES_EC, // Ear clipping algorithm.
-		DECOMP_TRIANGLES_OPT, // Minimal edge length.
-		DECOMP_TRIANGLES_MONO, // Monotone polygon partitioning, then triangulate.
-		DECOMP_CONVEX_HM, // Hertel-Mehlhorn algorithm.
-		DECOMP_CONVEX_OPT, // Minimal number of convex polygons.
-	};
-	static Vector<Vector<Point2>> triangulate_polygon(const Vector<Point2> &p_polygon, Ref<PolyDecompParameters2D> p_params = nullptr);
-	static Vector<Vector<Point2>> triangulate_multiple_polygons(const Vector<Vector<Point2>> &p_polygons, Ref<PolyDecompParameters2D> p_params = nullptr);
-	static Vector<Vector<Point2>> decompose_polygon_into_convex(const Vector<Point2> &p_polygon, Ref<PolyDecompParameters2D> p_params = nullptr);
-	static Vector<Vector<Point2>> decompose_multiple_polygons_into_convex(const Vector<Vector<Point2>> &p_polygons, Ref<PolyDecompParameters2D> p_params = nullptr);
-
-	// General-purpose polygon decomposition.
-	static Vector<Vector<Point2>> decompose_polygons(PolyDecompType p_type, const Vector<Vector<Point2>> &p_polygons, Ref<PolyDecompParameters2D> p_params = nullptr);
+	static Vector<Vector<Point2>> triangulate_polygon(const Vector<Point2> &p_polygon);
+	static Vector<Vector<Point2>> decompose_polygon(const Vector<Point2> &p_polygon);
 
 	/* Polygon/Polyline attributes */
 	static Point2 polygon_centroid(const Vector<Point2> &p_polygon);
@@ -83,146 +34,6 @@ public:
 	/* Polygon/shapes generation methods */
 	static Vector<Point2> regular_polygon(int p_edge_count, real_t p_size);
 	static Vector<Point2> circle(real_t p_radius, real_t p_max_error = 0.25);
-
-public:
-	static void initialize();
-	static void finalize();
-
-	static void set_poly_boolean_instance(PolyBoolean2D *p_instance) { poly_boolean = p_instance; }
-	static void set_poly_offset_instance(PolyOffset2D *p_instance) { poly_offset = p_instance; }
-	static void set_poly_decomp_instance(PolyDecomp2D *p_instance) { poly_decomp = p_instance; }
-
-protected:
-	static Ref<PolyBooleanParameters2D> configure_boolean(const Ref<PolyBooleanParameters2D> &p_params);
-	static Ref<PolyOffsetParameters2D> configure_offset(const Ref<PolyOffsetParameters2D> &p_params);
-	static Ref<PolyDecompParameters2D> configure_decomp(const Ref<PolyDecompParameters2D> &p_params);
-
-private:
-	static PolyBoolean2D *poly_boolean;
-	static PolyOffset2D *poly_offset;
-	static PolyDecomp2D *poly_decomp;
-
-	static Ref<PolyBooleanParameters2D> default_poly_boolean_params;
-	static Ref<PolyOffsetParameters2D> default_poly_offset_params;
-	static Ref<PolyDecompParameters2D> default_poly_decomp_params;
-};
-
-template <class T>
-class PolyBackend2DManager {
-	struct Backend {
-		String name = "";
-		T instance = nullptr;
-
-		Backend() :
-				name(""),
-				instance(nullptr) {}
-
-		Backend(String p_name, T p_instance) :
-				name(p_name),
-				instance(p_instance) {}
-	};
-
-	Vector<Backend> backends;
-	int default_backend_id = -1;
-	String default_backend_name;
-
-public:
-	String setting_name;
-
-public:
-	void register_backend(const String &p_name, T p_instance, bool p_default = false) {
-		backends.push_back(Backend(p_name, p_instance));
-		if (p_default) {
-			set_default_backend(p_name);
-		}
-	}
-	void set_default_backend(const String &p_name) {
-		default_backend_name = p_name;
-		default_backend_id = find_backend_id(p_name);
-	}
-
-	T get_default_backend_instance() const {
-		if (default_backend_id != -1) {
-			return backends[default_backend_id].instance;
-		}
-		return nullptr;
-	}
-
-	int find_backend_id(const String &p_name) const {
-		for (int i = 0; i < backends.size(); ++i) {
-			if (p_name == backends[i].name) {
-				return i;
-			}
-		}
-		return -1;
-	}
-
-	T get_backend_instance(const String &p_name) const {
-		int id = find_backend_id(p_name);
-		if (id != -1) {
-			return backends[id].instance;
-		}
-		return nullptr;
-	}
-
-	int get_backends_count() const { return backends.size(); }
-
-	String get_backend_name(int p_id) const {
-		CRASH_BAD_INDEX(p_id, backends.size());
-		return backends[p_id].name;
-	}
-
-	String update() {
-		String backends_list;
-
-		for (int i = 0; i < get_backends_count(); ++i) {
-			backends_list += get_backend_name(i);
-			if (i < get_backends_count() - 1) {
-				backends_list += ",";
-			}
-		}
-		T default_backend = get_default_backend_instance();
-		if (default_backend) {
-			// Suggest restart because the singleton can also be used in extension mode.
-			GLOBAL_DEF_RST(setting_name, default_backend_name);
-		}
-		if (!backends_list.empty()) {
-			ProjectSettings::get_singleton()->set_custom_property_info(
-					setting_name,
-					PropertyInfo(Variant::STRING, setting_name, PROPERTY_HINT_ENUM, backends_list));
-		}
-		return ProjectSettings::get_singleton()->has_setting(setting_name) ? GLOBAL_GET(setting_name) : "";
-	}
-
-	void finalize() {
-		for (int i = 0; i < backends.size(); ++i) {
-			if (backends[i].instance) {
-				memdelete(backends[i].instance);
-			}
-		}
-	}
-};
-
-class GoostGeometry2DManager {
-public:
-	static PolyBackend2DManager<PolyBoolean2D *> poly_boolean;
-	static PolyBackend2DManager<PolyOffset2D *> poly_offset;
-	static PolyBackend2DManager<PolyDecomp2D *> poly_decomp;
-
-	static void poly_backends_changed_update() {
-		String selected;
-		selected = poly_boolean.update();
-		GoostGeometry2D::set_poly_boolean_instance(poly_boolean.get_backend_instance(selected));
-		selected = poly_offset.update();
-		GoostGeometry2D::set_poly_offset_instance(poly_offset.get_backend_instance(selected));
-		selected = poly_decomp.update();
-		GoostGeometry2D::set_poly_decomp_instance(poly_decomp.get_backend_instance(selected));
-	}
-	static void finalize() {
-		poly_boolean.finalize();
-		poly_offset.finalize();
-		poly_decomp.finalize();
-	}
 };
 
 #endif // GOOST_GEOMETRY_2D_H

--- a/core/math/2d/geometry/goost_geometry_2d_bind.cpp
+++ b/core/math/2d/geometry/goost_geometry_2d_bind.cpp
@@ -1,9 +1,10 @@
 #include "goost_geometry_2d_bind.h"
+#include "goost_geometry_2d.h"
 
 _GoostGeometry2D *_GoostGeometry2D::singleton = nullptr;
 
-Array _GoostGeometry2D::merge_polygons(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b, Ref<PolyBooleanParameters2D> p_params) const {
-	Vector<Vector<Point2>> polys = GoostGeometry2D::merge_polygons(p_polygon_a, p_polygon_b, p_params);
+Array _GoostGeometry2D::merge_polygons(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b) const {
+	Vector<Vector<Point2>> polys = GoostGeometry2D::merge_polygons(p_polygon_a, p_polygon_b);
 	Array ret;
 	for (int i = 0; i < polys.size(); ++i) {
 		ret.push_back(polys[i]);
@@ -11,8 +12,8 @@ Array _GoostGeometry2D::merge_polygons(const Vector<Point2> &p_polygon_a, const 
 	return ret;
 }
 
-Array _GoostGeometry2D::clip_polygons(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b, Ref<PolyBooleanParameters2D> p_params) const {
-	Vector<Vector<Point2>> polys = GoostGeometry2D::clip_polygons(p_polygon_a, p_polygon_b, p_params);
+Array _GoostGeometry2D::clip_polygons(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b) const {
+	Vector<Vector<Point2>> polys = GoostGeometry2D::clip_polygons(p_polygon_a, p_polygon_b);
 	Array ret;
 	for (int i = 0; i < polys.size(); ++i) {
 		ret.push_back(polys[i]);
@@ -20,8 +21,8 @@ Array _GoostGeometry2D::clip_polygons(const Vector<Point2> &p_polygon_a, const V
 	return ret;
 }
 
-Array _GoostGeometry2D::intersect_polygons(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b, Ref<PolyBooleanParameters2D> p_params) const {
-	Vector<Vector<Point2>> polys = GoostGeometry2D::intersect_polygons(p_polygon_a, p_polygon_b, p_params);
+Array _GoostGeometry2D::intersect_polygons(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b) const {
+	Vector<Vector<Point2>> polys = GoostGeometry2D::intersect_polygons(p_polygon_a, p_polygon_b);
 	Array ret;
 	for (int i = 0; i < polys.size(); ++i) {
 		ret.push_back(polys[i]);
@@ -29,8 +30,8 @@ Array _GoostGeometry2D::intersect_polygons(const Vector<Point2> &p_polygon_a, co
 	return ret;
 }
 
-Array _GoostGeometry2D::exclude_polygons(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b, Ref<PolyBooleanParameters2D> p_params) const {
-	Vector<Vector<Point2>> polys = GoostGeometry2D::exclude_polygons(p_polygon_a, p_polygon_b, p_params);
+Array _GoostGeometry2D::exclude_polygons(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b) const {
+	Vector<Vector<Point2>> polys = GoostGeometry2D::exclude_polygons(p_polygon_a, p_polygon_b);
 	Array ret;
 	for (int i = 0; i < polys.size(); ++i) {
 		ret.push_back(polys[i]);
@@ -38,105 +39,8 @@ Array _GoostGeometry2D::exclude_polygons(const Vector<Point2> &p_polygon_a, cons
 	return ret;
 }
 
-Array _GoostGeometry2D::merge_multiple_polygons(Array p_polygons_a, Array p_polygons_b, Ref<PolyBooleanParameters2D> p_params) const {
-	Vector<Vector<Vector2>> polygons_a;
-	for (int i = 0; i < p_polygons_a.size(); ++i) {
-		polygons_a.push_back(p_polygons_a[i]);
-	}
-	Vector<Vector<Vector2>> polygons_b;
-	for (int i = 0; i < p_polygons_b.size(); ++i) {
-		polygons_b.push_back(p_polygons_b[i]);
-	}
-	Vector<Vector<Vector2>> solution = GoostGeometry2D::merge_multiple_polygons(polygons_a, polygons_b, p_params);
-	Array ret;
-	for (int i = 0; i < solution.size(); ++i) {
-		ret.push_back(solution[i]);
-	}
-	return ret;
-}
-
-Array _GoostGeometry2D::clip_multiple_polygons(Array p_polygons_a, Array p_polygons_b, Ref<PolyBooleanParameters2D> p_params) const {
-	Vector<Vector<Vector2>> polygons_a;
-	for (int i = 0; i < p_polygons_a.size(); ++i) {
-		polygons_a.push_back(p_polygons_a[i]);
-	}
-	Vector<Vector<Vector2>> polygons_b;
-	for (int i = 0; i < p_polygons_b.size(); ++i) {
-		polygons_b.push_back(p_polygons_b[i]);
-	}
-	Vector<Vector<Vector2>> solution = GoostGeometry2D::clip_multiple_polygons(polygons_a, polygons_b, p_params);
-	Array ret;
-	for (int i = 0; i < solution.size(); ++i) {
-		ret.push_back(solution[i]);
-	}
-	return ret;
-}
-
-Array _GoostGeometry2D::intersect_multiple_polygons(Array p_polygons_a, Array p_polygons_b, Ref<PolyBooleanParameters2D> p_params) const {
-	Vector<Vector<Vector2>> polygons_a;
-	for (int i = 0; i < p_polygons_a.size(); ++i) {
-		polygons_a.push_back(p_polygons_a[i]);
-	}
-	Vector<Vector<Vector2>> polygons_b;
-	for (int i = 0; i < p_polygons_b.size(); ++i) {
-		polygons_b.push_back(p_polygons_b[i]);
-	}
-	Vector<Vector<Vector2>> solution = GoostGeometry2D::intersect_multiple_polygons(polygons_a, polygons_b, p_params);
-	Array ret;
-	for (int i = 0; i < solution.size(); ++i) {
-		ret.push_back(solution[i]);
-	}
-	return ret;
-}
-
-Array _GoostGeometry2D::exclude_multiple_polygons(Array p_polygons_a, Array p_polygons_b, Ref<PolyBooleanParameters2D> p_params) const {
-	Vector<Vector<Vector2>> polygons_a;
-	for (int i = 0; i < p_polygons_a.size(); ++i) {
-		polygons_a.push_back(p_polygons_a[i]);
-	}
-	Vector<Vector<Vector2>> polygons_b;
-	for (int i = 0; i < p_polygons_b.size(); ++i) {
-		polygons_b.push_back(p_polygons_b[i]);
-	}
-	Vector<Vector<Vector2>> solution = GoostGeometry2D::exclude_multiple_polygons(polygons_a, polygons_b, p_params);
-	Array ret;
-	for (int i = 0; i < solution.size(); ++i) {
-		ret.push_back(solution[i]);
-	}
-	return ret;
-}
-
-Array _GoostGeometry2D::polygons_boolean(PolyBooleanOperation p_op, Array p_polygons_a, Array p_polygons_b, Ref<PolyBooleanParameters2D> p_params) const {
-	Vector<Vector<Vector2>> polygons_a;
-	for (int i = 0; i < p_polygons_a.size(); ++i) {
-		polygons_a.push_back(p_polygons_a[i]);
-	}
-	Vector<Vector<Vector2>> polygons_b;
-	for (int i = 0; i < p_polygons_b.size(); ++i) {
-		polygons_b.push_back(p_polygons_b[i]);
-	}
-	Vector<Vector<Vector2>> solution = GoostGeometry2D::polygons_boolean(GoostGeometry2D::PolyBooleanOperation(p_op), polygons_a, polygons_b, p_params);
-	Array ret;
-	for (int i = 0; i < solution.size(); ++i) {
-		ret.push_back(solution[i]);
-	}
-	return ret;
-}
-
-Ref<PolyNode2D> _GoostGeometry2D::polygons_boolean_tree(PolyBooleanOperation p_op, Array p_polygons_a, Array p_polygons_b, Ref<PolyBooleanParameters2D> p_params) const {
-	Vector<Vector<Point2>> polygons_a;
-	for (int i = 0; i < p_polygons_a.size(); i++) {
-		polygons_a.push_back(p_polygons_a[i]);
-	}
-	Vector<Vector<Point2>> polygons_b;
-	for (int i = 0; i < p_polygons_b.size(); i++) {
-		polygons_b.push_back(p_polygons_b[i]);
-	}
-	return GoostGeometry2D::polygons_boolean_tree(GoostGeometry2D::PolyBooleanOperation(p_op), polygons_a, polygons_b, p_params);
-}
-
-Array _GoostGeometry2D::clip_polyline_with_polygon(const Vector<Point2> &p_polyline, const Vector<Point2> &p_polygon, Ref<PolyBooleanParameters2D> p_params) const {
-	Vector<Vector<Point2>> polylines = GoostGeometry2D::clip_polyline_with_polygon(p_polyline, p_polygon, p_params);
+Array _GoostGeometry2D::clip_polyline_with_polygon(const Vector<Point2> &p_polyline, const Vector<Point2> &p_polygon) const {
+	Vector<Vector<Point2>> polylines = GoostGeometry2D::clip_polyline_with_polygon(p_polyline, p_polygon);
 	Array ret;
 	for (int i = 0; i < polylines.size(); ++i) {
 		ret.push_back(polylines[i]);
@@ -144,8 +48,8 @@ Array _GoostGeometry2D::clip_polyline_with_polygon(const Vector<Point2> &p_polyl
 	return ret;
 }
 
-Array _GoostGeometry2D::intersect_polyline_with_polygon(const Vector<Point2> &p_polyline, const Vector<Point2> &p_polygon, Ref<PolyBooleanParameters2D> p_params) const {
-	Vector<Vector<Point2>> polylines = GoostGeometry2D::intersect_polyline_with_polygon(p_polyline, p_polygon, p_params);
+Array _GoostGeometry2D::intersect_polyline_with_polygon(const Vector<Point2> &p_polyline, const Vector<Point2> &p_polygon) const {
+	Vector<Vector<Point2>> polylines = GoostGeometry2D::intersect_polyline_with_polygon(p_polyline, p_polygon);
 	Array ret;
 	for (int i = 0; i < polylines.size(); ++i) {
 		ret.push_back(polylines[i]);
@@ -153,16 +57,8 @@ Array _GoostGeometry2D::intersect_polyline_with_polygon(const Vector<Point2> &p_
 	return ret;
 }
 
-Array _GoostGeometry2D::clip_multiple_polylines_with_polygons(const Array &p_polylines, const Array &p_polygons, Ref<PolyBooleanParameters2D> p_params) const {
-	Vector<Vector<Point2>> polylines;
-	for (int i = 0; i < p_polylines.size(); i++) {
-		polylines.push_back(p_polylines[i]);
-	}
-	Vector<Vector<Point2>> polygons;
-	for (int i = 0; i < p_polygons.size(); i++) {
-		polygons.push_back(p_polygons[i]);
-	}
-	Vector<Vector<Vector2>> solution = GoostGeometry2D::clip_multiple_polylines_with_polygons(polylines, polygons, p_params);
+Array _GoostGeometry2D::inflate_polygon(const Vector<Point2> &p_polygon, real_t p_delta) const {
+	Vector<Vector<Vector2>> solution = GoostGeometry2D::inflate_polygon(p_polygon, p_delta);
 	Array ret;
 	for (int i = 0; i < solution.size(); ++i) {
 		ret.push_back(solution[i]);
@@ -170,16 +66,8 @@ Array _GoostGeometry2D::clip_multiple_polylines_with_polygons(const Array &p_pol
 	return ret;
 }
 
-Array _GoostGeometry2D::intersect_multiple_polylines_with_polygons(const Array &p_polylines, const Array &p_polygons, Ref<PolyBooleanParameters2D> p_params) const {
-	Vector<Vector<Point2>> polylines;
-	for (int i = 0; i < p_polylines.size(); i++) {
-		polylines.push_back(p_polylines[i]);
-	}
-	Vector<Vector<Point2>> polygons;
-	for (int i = 0; i < p_polygons.size(); i++) {
-		polygons.push_back(p_polygons[i]);
-	}
-	Vector<Vector<Vector2>> solution = GoostGeometry2D::intersect_multiple_polylines_with_polygons(polylines, polygons, p_params);
+Array _GoostGeometry2D::deflate_polygon(const Vector<Point2> &p_polygon, real_t p_delta) const {
+	Vector<Vector<Vector2>> solution = GoostGeometry2D::deflate_polygon(p_polygon, p_delta);
 	Array ret;
 	for (int i = 0; i < solution.size(); ++i) {
 		ret.push_back(solution[i]);
@@ -187,8 +75,8 @@ Array _GoostGeometry2D::intersect_multiple_polylines_with_polygons(const Array &
 	return ret;
 }
 
-Array _GoostGeometry2D::inflate_polygon(const Vector<Point2> &p_polygon, real_t p_delta, Ref<PolyOffsetParameters2D> p_params) const {
-	Vector<Vector<Vector2>> solution = GoostGeometry2D::inflate_polygon(p_polygon, p_delta, p_params);
+Array _GoostGeometry2D::deflate_polyline(const Vector<Point2> &p_polyline, real_t p_delta) const {
+	Vector<Vector<Vector2>> solution = GoostGeometry2D::deflate_polyline(p_polyline, p_delta);
 	Array ret;
 	for (int i = 0; i < solution.size(); ++i) {
 		ret.push_back(solution[i]);
@@ -196,8 +84,8 @@ Array _GoostGeometry2D::inflate_polygon(const Vector<Point2> &p_polygon, real_t 
 	return ret;
 }
 
-Array _GoostGeometry2D::deflate_polygon(const Vector<Point2> &p_polygon, real_t p_delta, Ref<PolyOffsetParameters2D> p_params) const {
-	Vector<Vector<Vector2>> solution = GoostGeometry2D::deflate_polygon(p_polygon, p_delta, p_params);
+Array _GoostGeometry2D::triangulate_polygon(const Vector<Point2> &p_polygon) const {
+	Vector<Vector<Vector2>> solution = GoostGeometry2D::triangulate_polygon(p_polygon);
 	Array ret;
 	for (int i = 0; i < solution.size(); ++i) {
 		ret.push_back(solution[i]);
@@ -205,126 +93,8 @@ Array _GoostGeometry2D::deflate_polygon(const Vector<Point2> &p_polygon, real_t 
 	return ret;
 }
 
-Array _GoostGeometry2D::inflate_multiple_polygons(const Array &p_polygons, real_t p_delta, Ref<PolyOffsetParameters2D> p_params) const {
-	Vector<Vector<Point2>> polygons;
-	for (int i = 0; i < p_polygons.size(); i++) {
-		polygons.push_back(p_polygons[i]);
-	}
-	Vector<Vector<Vector2>> solution = GoostGeometry2D::inflate_multiple_polygons(polygons, p_delta, p_params);
-	Array ret;
-	for (int i = 0; i < solution.size(); ++i) {
-		ret.push_back(solution[i]);
-	}
-	return ret;
-}
-
-Array _GoostGeometry2D::deflate_multiple_polygons(const Array &p_polygons, real_t p_delta, Ref<PolyOffsetParameters2D> p_params) const {
-	Vector<Vector<Point2>> polygons;
-	for (int i = 0; i < p_polygons.size(); i++) {
-		polygons.push_back(p_polygons[i]);
-	}
-	Vector<Vector<Vector2>> solution = GoostGeometry2D::deflate_multiple_polygons(polygons, p_delta, p_params);
-	Array ret;
-	for (int i = 0; i < solution.size(); ++i) {
-		ret.push_back(solution[i]);
-	}
-	return ret;
-}
-
-Array _GoostGeometry2D::deflate_polyline(const Vector<Point2> &p_polyline, real_t p_delta, Ref<PolyOffsetParameters2D> p_params) const {
-	Vector<Vector<Vector2>> solution = GoostGeometry2D::deflate_polyline(p_polyline, p_delta, p_params);
-	Array ret;
-	for (int i = 0; i < solution.size(); ++i) {
-		ret.push_back(solution[i]);
-	}
-	return ret;
-}
-
-Array _GoostGeometry2D::deflate_multiple_polylines(const Array &p_polylines, real_t p_delta, Ref<PolyOffsetParameters2D> p_params) const {
-	Vector<Vector<Point2>> polylines;
-	for (int i = 0; i < p_polylines.size(); i++) {
-		polylines.push_back(p_polylines[i]);
-	}
-	Vector<Vector<Vector2>> solution = GoostGeometry2D::deflate_multiple_polylines(polylines, p_delta, p_params);
-	Array ret;
-	for (int i = 0; i < solution.size(); ++i) {
-		ret.push_back(solution[i]);
-	}
-	return ret;
-}
-
-Array _GoostGeometry2D::offset_polygon(const Vector<Point2> &p_polygon, real_t p_delta, Ref<PolyOffsetParameters2D> p_params) const {
-	Vector<Vector<Vector2>> solution = GoostGeometry2D::offset_polygon(p_polygon, p_delta, p_params);
-	Array ret;
-	for (int i = 0; i < solution.size(); ++i) {
-		ret.push_back(solution[i]);
-	}
-	return ret;
-}
-
-Array _GoostGeometry2D::offset_multiple_polygons(const Array &p_polygons, real_t p_delta, Ref<PolyOffsetParameters2D> p_params) const {
-	Vector<Vector<Point2>> polygons;
-	for (int i = 0; i < p_polygons.size(); i++) {
-		polygons.push_back(p_polygons[i]);
-	}
-	Vector<Vector<Vector2>> solution = GoostGeometry2D::offset_multiple_polygons(polygons, p_delta, p_params);
-	Array ret;
-	for (int i = 0; i < solution.size(); ++i) {
-		ret.push_back(solution[i]);
-	}
-	return ret;
-}
-
-Array _GoostGeometry2D::triangulate_polygon(const Vector<Point2> &p_polygon, Ref<PolyDecompParameters2D> p_params) const {
-	Vector<Vector<Vector2>> solution = GoostGeometry2D::triangulate_polygon(p_polygon, p_params);
-	Array ret;
-	for (int i = 0; i < solution.size(); ++i) {
-		ret.push_back(solution[i]);
-	}
-	return ret;
-}
-
-Array _GoostGeometry2D::decompose_polygon_into_convex(const Vector<Point2> &p_polygon, Ref<PolyDecompParameters2D> p_params) const {
-	Vector<Vector<Vector2>> solution = GoostGeometry2D::decompose_polygon_into_convex(p_polygon, p_params);
-	Array ret;
-	for (int i = 0; i < solution.size(); ++i) {
-		ret.push_back(solution[i]);
-	}
-	return ret;
-}
-
-Array _GoostGeometry2D::triangulate_multiple_polygons(const Array &p_polygons, Ref<PolyDecompParameters2D> p_params) const {
-	Vector<Vector<Point2>> polygons;
-	for (int i = 0; i < p_polygons.size(); i++) {
-		polygons.push_back(p_polygons[i]);
-	}
-	Vector<Vector<Vector2>> solution = GoostGeometry2D::triangulate_multiple_polygons(polygons, p_params);
-	Array ret;
-	for (int i = 0; i < solution.size(); ++i) {
-		ret.push_back(solution[i]);
-	}
-	return ret;
-}
-
-Array _GoostGeometry2D::decompose_multiple_polygons_into_convex(const Array &p_polygons, Ref<PolyDecompParameters2D> p_params) const {
-	Vector<Vector<Point2>> polygons;
-	for (int i = 0; i < p_polygons.size(); i++) {
-		polygons.push_back(p_polygons[i]);
-	}
-	Vector<Vector<Vector2>> solution = GoostGeometry2D::decompose_multiple_polygons_into_convex(polygons, p_params);
-	Array ret;
-	for (int i = 0; i < solution.size(); ++i) {
-		ret.push_back(solution[i]);
-	}
-	return ret;
-}
-
-Array _GoostGeometry2D::decompose_polygons(PolyDecompType p_type, const Array &p_polygons, Ref<PolyDecompParameters2D> p_params) const {
-	Vector<Vector<Point2>> polygons;
-	for (int i = 0; i < p_polygons.size(); i++) {
-		polygons.push_back(p_polygons[i]);
-	}
-	Vector<Vector<Vector2>> solution = GoostGeometry2D::decompose_polygons(GoostGeometry2D::PolyDecompType(p_type), polygons, p_params);
+Array _GoostGeometry2D::decompose_polygon(const Vector<Point2> &p_polygon) const {
+	Vector<Vector<Vector2>> solution = GoostGeometry2D::decompose_polygon(p_polygon);
 	Array ret;
 	for (int i = 0; i < solution.size(); ++i) {
 		ret.push_back(solution[i]);
@@ -361,39 +131,19 @@ Vector<Point2> _GoostGeometry2D::circle(real_t p_radius, real_t p_max_error) con
 }
 
 void _GoostGeometry2D::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("merge_polygons", "polygon_a", "polygon_b", "params"), &_GoostGeometry2D::merge_polygons, DEFVAL(Variant()));
-	ClassDB::bind_method(D_METHOD("clip_polygons", "polygon_a", "polygon_b", "params"), &_GoostGeometry2D::clip_polygons, DEFVAL(Variant()));
-	ClassDB::bind_method(D_METHOD("intersect_polygons", "polygon_a", "polygon_b", "params"), &_GoostGeometry2D::intersect_polygons, DEFVAL(Variant()));
-	ClassDB::bind_method(D_METHOD("exclude_polygons", "polygon_a", "polygon_b", "params"), &_GoostGeometry2D::exclude_polygons, DEFVAL(Variant()));
+	ClassDB::bind_method(D_METHOD("merge_polygons", "polygon_a", "polygon_b"), &_GoostGeometry2D::merge_polygons);
+	ClassDB::bind_method(D_METHOD("clip_polygons", "polygon_a", "polygon_b"), &_GoostGeometry2D::clip_polygons);
+	ClassDB::bind_method(D_METHOD("intersect_polygons", "polygon_a", "polygon_b"), &_GoostGeometry2D::intersect_polygons);
+	ClassDB::bind_method(D_METHOD("exclude_polygons", "polygon_a", "polygon_b"), &_GoostGeometry2D::exclude_polygons);
+	ClassDB::bind_method(D_METHOD("clip_polyline_with_polygon", "polyline", "polygon"), &_GoostGeometry2D::clip_polyline_with_polygon);
+	ClassDB::bind_method(D_METHOD("intersect_polyline_with_polygon", "polyline", "polygon"), &_GoostGeometry2D::intersect_polyline_with_polygon);
 
-	ClassDB::bind_method(D_METHOD("merge_multiple_polygons", "polygons_a", "polygons_b", "params"), &_GoostGeometry2D::merge_multiple_polygons, DEFVAL(Variant()), DEFVAL(Variant()));
-	ClassDB::bind_method(D_METHOD("clip_multiple_polygons", "polygons_a", "polygons_b", "params"), &_GoostGeometry2D::clip_multiple_polygons, DEFVAL(Variant()));
-	ClassDB::bind_method(D_METHOD("intersect_multiple_polygons", "polygons_a", "polygons_b", "params"), &_GoostGeometry2D::intersect_multiple_polygons, DEFVAL(Variant()));
-	ClassDB::bind_method(D_METHOD("exclude_multiple_polygons", "polygons_a", "polygons_b", "params"), &_GoostGeometry2D::exclude_multiple_polygons, DEFVAL(Variant()));
+	ClassDB::bind_method(D_METHOD("inflate_polygon", "polygon", "delta"), &_GoostGeometry2D::inflate_polygon);
+	ClassDB::bind_method(D_METHOD("deflate_polygon", "polygon", "delta"), &_GoostGeometry2D::deflate_polygon);
+	ClassDB::bind_method(D_METHOD("deflate_polyline", "polyline", "delta"), &_GoostGeometry2D::deflate_polyline);
 
-	ClassDB::bind_method(D_METHOD("polygons_boolean", "operation", "polygons_a", "polygons_b", "params"), &_GoostGeometry2D::polygons_boolean, DEFVAL(Variant()), DEFVAL(Variant()));
-	ClassDB::bind_method(D_METHOD("polygons_boolean_tree", "operation", "polygons_a", "polygons_b", "params"), &_GoostGeometry2D::polygons_boolean_tree, DEFVAL(Variant()), DEFVAL(Variant()));
-
-	ClassDB::bind_method(D_METHOD("clip_polyline_with_polygon", "polyline", "polygon", "params"), &_GoostGeometry2D::clip_polyline_with_polygon, DEFVAL(Variant()));
-	ClassDB::bind_method(D_METHOD("intersect_polyline_with_polygon", "polyline", "polygon", "params"), &_GoostGeometry2D::intersect_polyline_with_polygon, DEFVAL(Variant()));
-	ClassDB::bind_method(D_METHOD("clip_multiple_polylines_with_polygons", "polylines", "polygons", "params"), &_GoostGeometry2D::clip_multiple_polylines_with_polygons, DEFVAL(Variant()));
-	ClassDB::bind_method(D_METHOD("intersect_multiple_polylines_with_polygons", "polylines", "polygons", "params"), &_GoostGeometry2D::intersect_multiple_polylines_with_polygons, DEFVAL(Variant()));
-
-	ClassDB::bind_method(D_METHOD("inflate_polygon", "polygon", "delta", "params"), &_GoostGeometry2D::inflate_polygon, DEFVAL(Variant()));
-	ClassDB::bind_method(D_METHOD("deflate_polygon", "polygon", "delta", "params"), &_GoostGeometry2D::deflate_polygon, DEFVAL(Variant()));
-	ClassDB::bind_method(D_METHOD("inflate_multiple_polygons", "polygons", "delta", "params"), &_GoostGeometry2D::inflate_multiple_polygons, DEFVAL(Variant()));
-	ClassDB::bind_method(D_METHOD("deflate_multiple_polygons", "polygons", "delta", "params"), &_GoostGeometry2D::deflate_multiple_polygons, DEFVAL(Variant()));
-	ClassDB::bind_method(D_METHOD("deflate_polyline", "polyline", "delta", "params"), &_GoostGeometry2D::deflate_polyline, DEFVAL(Variant()));
-	ClassDB::bind_method(D_METHOD("deflate_multiple_polylines", "polylines", "delta", "params"), &_GoostGeometry2D::deflate_multiple_polylines, DEFVAL(Variant()));
-	ClassDB::bind_method(D_METHOD("offset_polygon", "polygon", "delta", "params"), &_GoostGeometry2D::offset_polygon, DEFVAL(Variant()));
-	ClassDB::bind_method(D_METHOD("offset_multiple_polygons", "polygons", "delta", "params"), &_GoostGeometry2D::offset_multiple_polygons, DEFVAL(Variant()));
-
-	ClassDB::bind_method(D_METHOD("triangulate_polygon", "polygon", "params"), &_GoostGeometry2D::triangulate_polygon, DEFVAL(Variant()));
-	ClassDB::bind_method(D_METHOD("triangulate_multiple_polygons", "polygon", "params"), &_GoostGeometry2D::triangulate_multiple_polygons, DEFVAL(Variant()));
-	ClassDB::bind_method(D_METHOD("decompose_polygon_into_convex", "polygon", "params"), &_GoostGeometry2D::decompose_polygon_into_convex, DEFVAL(Variant()));
-	ClassDB::bind_method(D_METHOD("decompose_multiple_polygons_into_convex", "polygon", "params"), &_GoostGeometry2D::decompose_multiple_polygons_into_convex, DEFVAL(Variant()));
-
-	ClassDB::bind_method(D_METHOD("decompose_polygons", "type", "polygons", "params"), &_GoostGeometry2D::decompose_polygons, DEFVAL(Variant()));
+	ClassDB::bind_method(D_METHOD("triangulate_polygon", "polygon"), &_GoostGeometry2D::triangulate_polygon);
+	ClassDB::bind_method(D_METHOD("decompose_polygon", "polygon"), &_GoostGeometry2D::decompose_polygon);
 
 	ClassDB::bind_method(D_METHOD("polygon_centroid", "polygon"), &_GoostGeometry2D::polygon_centroid);
 	ClassDB::bind_method(D_METHOD("polygon_area", "polygon"), &_GoostGeometry2D::polygon_area);
@@ -404,18 +154,6 @@ void _GoostGeometry2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("regular_polygon", "sides", "size"), &_GoostGeometry2D::regular_polygon);
 	ClassDB::bind_method(D_METHOD("circle", "radius", "max_error"), &_GoostGeometry2D::circle, DEFVAL(0.25));
-
-	BIND_ENUM_CONSTANT(OPERATION_NONE);
-	BIND_ENUM_CONSTANT(OPERATION_UNION);
-	BIND_ENUM_CONSTANT(OPERATION_DIFFERENCE);
-	BIND_ENUM_CONSTANT(OPERATION_INTERSECTION);
-	BIND_ENUM_CONSTANT(OPERATION_XOR);
-
-	BIND_ENUM_CONSTANT(DECOMP_TRIANGLES_EC);
-	BIND_ENUM_CONSTANT(DECOMP_TRIANGLES_OPT);
-	BIND_ENUM_CONSTANT(DECOMP_TRIANGLES_MONO);
-	BIND_ENUM_CONSTANT(DECOMP_CONVEX_HM);
-	BIND_ENUM_CONSTANT(DECOMP_CONVEX_OPT);
 }
 
 _GoostGeometry2D::_GoostGeometry2D() {

--- a/core/math/2d/geometry/goost_geometry_2d_bind.h
+++ b/core/math/2d/geometry/goost_geometry_2d_bind.h
@@ -1,7 +1,7 @@
-#ifndef GOOST_GEOMETRY_EXTENSION_BIND_H
-#define GOOST_GEOMETRY_EXTENSION_BIND_H
+#ifndef GOOST_GEOMETRY_2D_BIND_H
+#define GOOST_GEOMETRY_2D_BIND_H
 
-#include "goost_geometry_2d.h"
+#include "core/object.h"
 
 class _GoostGeometry2D : public Object {
 	GDCLASS(_GoostGeometry2D, Object);
@@ -16,55 +16,19 @@ public:
 	static _GoostGeometry2D *get_singleton() { return singleton; }
 
 public:
-	enum PolyBooleanOperation {
-		OPERATION_NONE,
-		OPERATION_UNION,
-		OPERATION_DIFFERENCE,
-		OPERATION_INTERSECTION,
-		OPERATION_XOR,
-	};
-	Array merge_polygons(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b, Ref<PolyBooleanParameters2D> p_params) const;
-	Array clip_polygons(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b, Ref<PolyBooleanParameters2D> p_params) const;
-	Array intersect_polygons(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b, Ref<PolyBooleanParameters2D> p_params) const;
-	Array exclude_polygons(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b, Ref<PolyBooleanParameters2D> p_params) const;
+	Array merge_polygons(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b) const;
+	Array clip_polygons(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b) const;
+	Array intersect_polygons(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b) const;
+	Array exclude_polygons(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b) const;
+	Array clip_polyline_with_polygon(const Vector<Point2> &p_polyline, const Vector<Point2> &p_polygon) const;
+	Array intersect_polyline_with_polygon(const Vector<Point2> &p_polyline, const Vector<Point2> &p_polygon) const;
 
-	Array merge_multiple_polygons(Array p_polygons_a, Array p_polygons_b, Ref<PolyBooleanParameters2D> p_params) const;
-	Array clip_multiple_polygons(Array p_polygons_a, Array p_polygons_b, Ref<PolyBooleanParameters2D> p_params) const;
-	Array intersect_multiple_polygons(Array p_polygons_a, Array p_polygons_b, Ref<PolyBooleanParameters2D> p_params) const;
-	Array exclude_multiple_polygons(Array p_polygons_a, Array p_polygons_b, Ref<PolyBooleanParameters2D> p_params) const;
+	Array inflate_polygon(const Vector<Point2> &p_polygon, real_t p_delta) const;
+	Array deflate_polygon(const Vector<Point2> &p_polygon, real_t p_delta) const;
+	Array deflate_polyline(const Vector<Point2> &p_polyline, real_t p_delta) const;
 
-	Array polygons_boolean(PolyBooleanOperation p_op, Array p_polygons_a, Array p_polygons_b, Ref<PolyBooleanParameters2D> p_params) const;
-	Ref<PolyNode2D> polygons_boolean_tree(PolyBooleanOperation p_op, Array p_polygons_a, Array p_polygons_b, Ref<PolyBooleanParameters2D> p_params) const;
-
-	Array clip_polyline_with_polygon(const Vector<Point2> &p_polyline, const Vector<Point2> &p_polygon, Ref<PolyBooleanParameters2D> p_params) const;
-	Array intersect_polyline_with_polygon(const Vector<Point2> &p_polyline, const Vector<Point2> &p_polygon, Ref<PolyBooleanParameters2D> p_params) const;
-	Array clip_multiple_polylines_with_polygons(const Array &p_polylines, const Array &p_polygons, Ref<PolyBooleanParameters2D> p_params) const;
-	Array intersect_multiple_polylines_with_polygons(const Array &p_polylines, const Array &p_polygons, Ref<PolyBooleanParameters2D> p_params) const;
-
-	Array inflate_polygon(const Vector<Point2> &p_polygon, real_t p_delta, Ref<PolyOffsetParameters2D> p_params) const;
-	Array deflate_polygon(const Vector<Point2> &p_polygon, real_t p_delta, Ref<PolyOffsetParameters2D> p_params) const;
-	Array inflate_multiple_polygons(const Array &p_polygons, real_t p_delta, Ref<PolyOffsetParameters2D> p_params) const;
-	Array deflate_multiple_polygons(const Array &p_polygons, real_t p_delta, Ref<PolyOffsetParameters2D> p_params) const;
-
-	Array deflate_polyline(const Vector<Point2> &p_polyline, real_t p_delta, Ref<PolyOffsetParameters2D> p_params) const;
-	Array deflate_multiple_polylines(const Array &p_polylines, real_t p_delta, Ref<PolyOffsetParameters2D> p_params) const;
-
-	Array offset_polygon(const Vector<Point2> &p_polygon, real_t p_delta, Ref<PolyOffsetParameters2D> p_params) const;
-	Array offset_multiple_polygons(const Array &p_polygons, real_t p_delta, Ref<PolyOffsetParameters2D> p_params) const;
-
-	enum PolyDecompType {
-		DECOMP_TRIANGLES_EC,
-		DECOMP_TRIANGLES_OPT,
-		DECOMP_TRIANGLES_MONO,
-		DECOMP_CONVEX_HM,
-		DECOMP_CONVEX_OPT,
-	};
-	Array triangulate_polygon(const Vector<Point2> &p_polygon, Ref<PolyDecompParameters2D> p_params) const;
-	Array triangulate_multiple_polygons(const Array &p_polygons, Ref<PolyDecompParameters2D> p_params) const;
-	Array decompose_polygon_into_convex(const Vector<Point2> &p_polygon, Ref<PolyDecompParameters2D> p_params) const;
-	Array decompose_multiple_polygons_into_convex(const Array &p_polygons, Ref<PolyDecompParameters2D> p_params) const;
-
-	Array decompose_polygons(PolyDecompType p_type, const Array &p_polygons, Ref<PolyDecompParameters2D> p_params) const;
+	Array triangulate_polygon(const Vector<Point2> &p_polygon) const;
+	Array decompose_polygon(const Vector<Point2> &p_polygon) const;
 
 	Vector2 polygon_centroid(const Vector<Vector2> &p_polygon) const;
 	real_t polygon_area(const Vector<Vector2> &p_polygon) const;
@@ -79,7 +43,4 @@ public:
 	_GoostGeometry2D();
 };
 
-VARIANT_ENUM_CAST(_GoostGeometry2D::PolyBooleanOperation);
-VARIANT_ENUM_CAST(_GoostGeometry2D::PolyDecompType);
-
-#endif // GOOST_GEOMETRY_EXTENSION_BIND_H
+#endif // GOOST_GEOMETRY_2D_BIND_H

--- a/core/math/2d/geometry/poly/SCsub
+++ b/core/math/2d/geometry/poly/SCsub
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-import os
-
 Import("env")
 Import("env_goost")
 
@@ -22,3 +20,5 @@ source_dirs = [
 ]
 sources = [Glob(d + "/" + "*.cpp") for d in source_dirs]
 env_goost.add_source_files(env.modules_sources, sources)
+
+env_goost.add_source_files(env.modules_sources, "*.cpp")

--- a/core/math/2d/geometry/poly/boolean/clipper10/poly_boolean_clipper10.cpp
+++ b/core/math/2d/geometry/poly/boolean/clipper10/poly_boolean_clipper10.cpp
@@ -2,7 +2,7 @@
 #include "goost/core/math/2d/geometry/goost_geometry_2d.h"
 #include "goost/core/math/2d/geometry/poly/utils/godot_clipper10_path_convert.h"
 
-Vector<Vector<Point2>> PolyBoolean2DClipper10::polypaths_boolean(Operation p_op, const Vector<Vector<Point2>> &p_polypaths_a, const Vector<Vector<Point2>> &p_polypaths_b) {
+Vector<Vector<Point2>> PolyBoolean2DClipper10::boolean_polypaths(const Vector<Vector<Point2>> &p_polypaths_a, const Vector<Vector<Point2>> &p_polypaths_b, Operation p_op) {
 	clipperlib::Clipper clp = configure(p_op, parameters);
 
 	clipperlib::Paths subject;
@@ -24,7 +24,7 @@ Vector<Vector<Point2>> PolyBoolean2DClipper10::polypaths_boolean(Operation p_op,
 	return ret;
 }
 
-Ref<PolyNode2D> PolyBoolean2DClipper10::polypaths_boolean_tree(Operation p_op, const Vector<Vector<Point2>> &p_polypaths_a, const Vector<Vector<Point2>> &p_polypaths_b) {
+Ref<PolyNode2D> PolyBoolean2DClipper10::boolean_polypaths_tree(const Vector<Vector<Point2>> &p_polypaths_a, const Vector<Vector<Point2>> &p_polypaths_b, Operation p_op) {
 	clipperlib::Clipper clp = configure(p_op, parameters);
 
 	clipperlib::Paths subject;

--- a/core/math/2d/geometry/poly/boolean/clipper10/poly_boolean_clipper10.cpp
+++ b/core/math/2d/geometry/poly/boolean/clipper10/poly_boolean_clipper10.cpp
@@ -3,7 +3,7 @@
 #include "goost/core/math/2d/geometry/poly/utils/godot_clipper10_path_convert.h"
 
 Vector<Vector<Point2>> PolyBoolean2DClipper10::polypaths_boolean(Operation p_op, const Vector<Vector<Point2>> &p_polypaths_a, const Vector<Vector<Point2>> &p_polypaths_b) {
-	clipperlib::Clipper clp = configure(p_op, params);
+	clipperlib::Clipper clp = configure(p_op, parameters);
 
 	clipperlib::Paths subject;
 	GodotClipperUtils::scale_up_polypaths(p_polypaths_a, subject);
@@ -25,7 +25,7 @@ Vector<Vector<Point2>> PolyBoolean2DClipper10::polypaths_boolean(Operation p_op,
 }
 
 Ref<PolyNode2D> PolyBoolean2DClipper10::polypaths_boolean_tree(Operation p_op, const Vector<Vector<Point2>> &p_polypaths_a, const Vector<Vector<Point2>> &p_polypaths_b) {
-	clipperlib::Clipper clp = configure(p_op, params);
+	clipperlib::Clipper clp = configure(p_op, parameters);
 
 	clipperlib::Paths subject;
 	GodotClipperUtils::scale_up_polypaths(p_polypaths_a, subject);
@@ -66,7 +66,7 @@ Ref<PolyNode2D> PolyBoolean2DClipper10::polypaths_boolean_tree(Operation p_op, c
 	return root;
 }
 
-clipperlib::Clipper PolyBoolean2DClipper10::configure(Operation p_op, const Ref<PolyBooleanParameters2D> &p_params) {
+clipperlib::Clipper PolyBoolean2DClipper10::configure(Operation p_op, const Ref<PolyBooleanParameters2D> &p_parameters) {
 	using namespace clipperlib;
 
 	switch (p_op) {
@@ -86,9 +86,9 @@ clipperlib::Clipper PolyBoolean2DClipper10::configure(Operation p_op, const Ref<
 			clip_type = ctXor;
 			break;
 	}
-	subject_fill_rule = FillRule(p_params->subject_fill_rule);
-	clip_fill_rule = FillRule(p_params->clip_fill_rule);
-	subject_open = p_params->subject_open;
+	subject_fill_rule = FillRule(p_parameters->subject_fill_rule);
+	clip_fill_rule = FillRule(p_parameters->clip_fill_rule);
+	subject_open = p_parameters->subject_open;
 
 	return Clipper();
 }

--- a/core/math/2d/geometry/poly/boolean/clipper10/poly_boolean_clipper10.h
+++ b/core/math/2d/geometry/poly/boolean/clipper10/poly_boolean_clipper10.h
@@ -1,18 +1,16 @@
 #ifndef GOOST_GEOMETRY_POLY_BOOLEAN_CLIPPER10
 #define GOOST_GEOMETRY_POLY_BOOLEAN_CLIPPER10
 
-#include "goost/core/math/2d/geometry/poly/boolean/poly_boolean.h"
+#include "../poly_boolean.h"
 #include "goost/thirdparty/clipper/clipper.h"
 
-class PolyBoolean2DClipper10 : public PolyBoolean2D {
+class PolyBoolean2DClipper10 : public PolyBoolean2DBackend {
 public:
 	virtual Vector<Vector<Point2>> polypaths_boolean(Operation p_op, const Vector<Vector<Point2>> &p_polypaths_a, const Vector<Vector<Point2>> &p_polypaths_b) override;
 	virtual Ref<PolyNode2D> polypaths_boolean_tree(Operation p_op, const Vector<Vector<Point2>> &p_polypaths_a, const Vector<Vector<Point2>> &p_polypaths_b) override;
 
-protected:
-	clipperlib::Clipper configure(Operation p_op, const Ref<PolyBooleanParameters2D> &p_params);
-
 private:
+	clipperlib::Clipper configure(Operation p_op, const Ref<PolyBooleanParameters2D> &p_params);
 	clipperlib::ClipType clip_type;
 	clipperlib::FillRule subject_fill_rule;
 	clipperlib::FillRule clip_fill_rule;

--- a/core/math/2d/geometry/poly/boolean/clipper10/poly_boolean_clipper10.h
+++ b/core/math/2d/geometry/poly/boolean/clipper10/poly_boolean_clipper10.h
@@ -6,8 +6,8 @@
 
 class PolyBoolean2DClipper10 : public PolyBoolean2DBackend {
 public:
-	virtual Vector<Vector<Point2>> polypaths_boolean(Operation p_op, const Vector<Vector<Point2>> &p_polypaths_a, const Vector<Vector<Point2>> &p_polypaths_b) override;
-	virtual Ref<PolyNode2D> polypaths_boolean_tree(Operation p_op, const Vector<Vector<Point2>> &p_polypaths_a, const Vector<Vector<Point2>> &p_polypaths_b) override;
+	virtual Vector<Vector<Point2>> boolean_polypaths(const Vector<Vector<Point2>> &p_polypaths_a, const Vector<Vector<Point2>> &p_polypaths_b, Operation p_op) override;
+	virtual Ref<PolyNode2D> boolean_polypaths_tree(const Vector<Vector<Point2>> &p_polypaths_a, const Vector<Vector<Point2>> &p_polypaths_b, Operation p_op) override;
 
 private:
 	clipperlib::Clipper configure(Operation p_op, const Ref<PolyBooleanParameters2D> &p_params);

--- a/core/math/2d/geometry/poly/boolean/clipper6/poly_boolean_clipper6.cpp
+++ b/core/math/2d/geometry/poly/boolean/clipper6/poly_boolean_clipper6.cpp
@@ -3,7 +3,7 @@
 #include "goost/core/math/2d/geometry/poly/utils/godot_clipper6_path_convert.h"
 
 Vector<Vector<Point2>> PolyBoolean2DClipper6::polypaths_boolean(Operation p_op, const Vector<Vector<Point2>> &p_polypaths_a, const Vector<Vector<Point2>> &p_polypaths_b) {
-	ClipperLib::Clipper clp = configure(p_op, params);
+	ClipperLib::Clipper clp = configure(p_op, parameters);
 
 	ClipperLib::Paths subject;
 	GodotClipperUtils::scale_up_polypaths(p_polypaths_a, subject);
@@ -31,7 +31,7 @@ Vector<Vector<Point2>> PolyBoolean2DClipper6::polypaths_boolean(Operation p_op, 
 }
 
 Ref<PolyNode2D> PolyBoolean2DClipper6::polypaths_boolean_tree(Operation p_op, const Vector<Vector<Point2>> &p_polypaths_a, const Vector<Vector<Point2>> &p_polypaths_b) {
-	ClipperLib::Clipper clp = configure(p_op, params);
+	ClipperLib::Clipper clp = configure(p_op, parameters);
 
 	ClipperLib::Paths subject;
 	GodotClipperUtils::scale_up_polypaths(p_polypaths_a, subject);
@@ -71,7 +71,7 @@ Ref<PolyNode2D> PolyBoolean2DClipper6::polypaths_boolean_tree(Operation p_op, co
 	return root;
 }
 
-ClipperLib::Clipper PolyBoolean2DClipper6::configure(Operation p_op, const Ref<PolyBooleanParameters2D> &p_params) {
+ClipperLib::Clipper PolyBoolean2DClipper6::configure(Operation p_op, const Ref<PolyBooleanParameters2D> &p_parameters) {
 	using namespace ClipperLib;
 
 	switch (p_op) {
@@ -95,12 +95,12 @@ ClipperLib::Clipper PolyBoolean2DClipper6::configure(Operation p_op, const Ref<P
 
 	int init_options = 0;
 
-	subject_fill_type = PolyFillType(p_params->subject_fill_rule);
-	clip_fill_type = PolyFillType(p_params->clip_fill_rule);
-	init_options |= p_params->reverse_solution ? InitOptions::ioReverseSolution : 0;
-	init_options |= p_params->strictly_simple ? InitOptions::ioStrictlySimple : 0;
-	init_options |= p_params->preserve_collinear ? InitOptions::ioPreserveCollinear : 0;
-	subject_open = p_params->subject_open;
+	subject_fill_type = PolyFillType(p_parameters->subject_fill_rule);
+	clip_fill_type = PolyFillType(p_parameters->clip_fill_rule);
+	init_options |= p_parameters->reverse_solution ? InitOptions::ioReverseSolution : 0;
+	init_options |= p_parameters->strictly_simple ? InitOptions::ioStrictlySimple : 0;
+	init_options |= p_parameters->preserve_collinear ? InitOptions::ioPreserveCollinear : 0;
+	subject_open = p_parameters->subject_open;
 
 	return Clipper(init_options);
 }

--- a/core/math/2d/geometry/poly/boolean/clipper6/poly_boolean_clipper6.cpp
+++ b/core/math/2d/geometry/poly/boolean/clipper6/poly_boolean_clipper6.cpp
@@ -2,7 +2,7 @@
 #include "goost/core/math/2d/geometry/goost_geometry_2d.h"
 #include "goost/core/math/2d/geometry/poly/utils/godot_clipper6_path_convert.h"
 
-Vector<Vector<Point2>> PolyBoolean2DClipper6::polypaths_boolean(Operation p_op, const Vector<Vector<Point2>> &p_polypaths_a, const Vector<Vector<Point2>> &p_polypaths_b) {
+Vector<Vector<Point2>> PolyBoolean2DClipper6::boolean_polypaths(const Vector<Vector<Point2>> &p_polypaths_a, const Vector<Vector<Point2>> &p_polypaths_b, Operation p_op) {
 	ClipperLib::Clipper clp = configure(p_op, parameters);
 
 	ClipperLib::Paths subject;
@@ -30,7 +30,7 @@ Vector<Vector<Point2>> PolyBoolean2DClipper6::polypaths_boolean(Operation p_op, 
 	return ret;
 }
 
-Ref<PolyNode2D> PolyBoolean2DClipper6::polypaths_boolean_tree(Operation p_op, const Vector<Vector<Point2>> &p_polypaths_a, const Vector<Vector<Point2>> &p_polypaths_b) {
+Ref<PolyNode2D> PolyBoolean2DClipper6::boolean_polypaths_tree(const Vector<Vector<Point2>> &p_polypaths_a, const Vector<Vector<Point2>> &p_polypaths_b, Operation p_op) {
 	ClipperLib::Clipper clp = configure(p_op, parameters);
 
 	ClipperLib::Paths subject;

--- a/core/math/2d/geometry/poly/boolean/clipper6/poly_boolean_clipper6.h
+++ b/core/math/2d/geometry/poly/boolean/clipper6/poly_boolean_clipper6.h
@@ -1,18 +1,16 @@
 #ifndef GOOST_GEOMETRY_POLY_BOOLEAN_CLIPPER6_H
 #define GOOST_GEOMETRY_POLY_BOOLEAN_CLIPPER6_H
 
-#include "goost/core/math/2d/geometry/poly/boolean/poly_boolean.h"
+#include "../poly_boolean.h"
 #include "thirdparty/misc/clipper.hpp"
 
-class PolyBoolean2DClipper6 : public PolyBoolean2D {
+class PolyBoolean2DClipper6 : public PolyBoolean2DBackend {
 public:
 	virtual Vector<Vector<Point2>> polypaths_boolean(Operation p_op, const Vector<Vector<Point2>> &p_polypaths_a, const Vector<Vector<Point2>> &p_polypaths_b) override;
 	virtual Ref<PolyNode2D> polypaths_boolean_tree(Operation p_op, const Vector<Vector<Point2>> &p_polypaths_a, const Vector<Vector<Point2>> &p_polypaths_b) override;
 
-protected:
-	ClipperLib::Clipper configure(Operation p_op, const Ref<PolyBooleanParameters2D> &p_params);
-
 private:
+	ClipperLib::Clipper configure(Operation p_op, const Ref<PolyBooleanParameters2D> &p_params);
 	ClipperLib::ClipType clip_type;
 	ClipperLib::PolyFillType subject_fill_type;
 	ClipperLib::PolyFillType clip_fill_type;

--- a/core/math/2d/geometry/poly/boolean/clipper6/poly_boolean_clipper6.h
+++ b/core/math/2d/geometry/poly/boolean/clipper6/poly_boolean_clipper6.h
@@ -6,8 +6,8 @@
 
 class PolyBoolean2DClipper6 : public PolyBoolean2DBackend {
 public:
-	virtual Vector<Vector<Point2>> polypaths_boolean(Operation p_op, const Vector<Vector<Point2>> &p_polypaths_a, const Vector<Vector<Point2>> &p_polypaths_b) override;
-	virtual Ref<PolyNode2D> polypaths_boolean_tree(Operation p_op, const Vector<Vector<Point2>> &p_polypaths_a, const Vector<Vector<Point2>> &p_polypaths_b) override;
+	virtual Vector<Vector<Point2>> boolean_polypaths(const Vector<Vector<Point2>> &p_polypaths_a, const Vector<Vector<Point2>> &p_polypaths_b, Operation p_op) override;
+	virtual Ref<PolyNode2D> boolean_polypaths_tree(const Vector<Vector<Point2>> &p_polypaths_a, const Vector<Vector<Point2>> &p_polypaths_b, Operation p_op) override;
 
 private:
 	ClipperLib::Clipper configure(Operation p_op, const Ref<PolyBooleanParameters2D> &p_params);

--- a/core/math/2d/geometry/poly/boolean/poly_boolean.cpp
+++ b/core/math/2d/geometry/poly/boolean/poly_boolean.cpp
@@ -1,5 +1,232 @@
 #include "poly_boolean.h"
 
+PolyBoolean2DBackend *PolyBoolean2D::backend = nullptr;
+
+void PolyBoolean2DBackend::set_parameters(const Ref<PolyBooleanParameters2D> &p_parameters) {
+	if (p_parameters.is_valid()) {
+		parameters = p_parameters;
+	} else {
+		parameters = Ref<PolyBooleanParameters2D>();
+		parameters = default_parameters;
+		parameters->reset();
+	}
+}
+
+Vector<Vector<Point2>> PolyBoolean2D::merge_polygons(const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b, const Ref<PolyBooleanParameters2D> &p_parameters) {
+	backend->set_parameters(p_parameters);
+	backend->get_parameters()->subject_open = false;
+	return backend->polypaths_boolean(PolyBoolean2DBackend::OPERATION_UNION, p_polygons_a, p_polygons_b);
+}
+
+Vector<Vector<Point2>> PolyBoolean2D::clip_polygons(const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b, const Ref<PolyBooleanParameters2D> &p_parameters) {
+	backend->set_parameters(p_parameters);
+	backend->get_parameters()->subject_open = false;
+	return backend->polypaths_boolean(PolyBoolean2DBackend::OPERATION_DIFFERENCE, p_polygons_a, p_polygons_b);
+}
+
+Vector<Vector<Point2>> PolyBoolean2D::intersect_polygons(const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b, const Ref<PolyBooleanParameters2D> &p_parameters) {
+	backend->set_parameters(p_parameters);
+	backend->get_parameters()->subject_open = false;
+	return backend->polypaths_boolean(PolyBoolean2DBackend::OPERATION_INTERSECTION, p_polygons_a, p_polygons_b);
+}
+
+Vector<Vector<Point2>> PolyBoolean2D::exclude_polygons(const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b, const Ref<PolyBooleanParameters2D> &p_parameters) {
+	backend->set_parameters(p_parameters);
+	backend->get_parameters()->subject_open = false;
+	return backend->polypaths_boolean(PolyBoolean2DBackend::OPERATION_XOR, p_polygons_a, p_polygons_b);
+}
+
+Vector<Vector<Point2>> PolyBoolean2D::polygons_boolean(Operation p_op, const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b, const Ref<PolyBooleanParameters2D> &p_parameters) {
+	backend->set_parameters(p_parameters);
+	backend->get_parameters()->subject_open = false;
+	return backend->polypaths_boolean(PolyBoolean2DBackend::Operation(p_op), p_polygons_a, p_polygons_b);
+}
+
+Ref<PolyNode2D> PolyBoolean2D::polygons_boolean_tree(Operation p_op, const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b, const Ref<PolyBooleanParameters2D> &p_parameters) {
+	backend->set_parameters(p_parameters);
+	backend->get_parameters()->subject_open = false;
+	return backend->polypaths_boolean_tree(PolyBoolean2DBackend::Operation(p_op), p_polygons_a, p_polygons_b);
+}
+
+Vector<Vector<Point2>> PolyBoolean2D::clip_polylines_with_polygons(const Vector<Vector<Point2>> &p_polylines, const Vector<Vector<Point2>> &p_polygons, const Ref<PolyBooleanParameters2D> &p_parameters) {
+	backend->set_parameters(p_parameters);
+	backend->get_parameters()->subject_open = true;
+	return backend->polypaths_boolean(PolyBoolean2DBackend::OPERATION_DIFFERENCE, p_polylines, p_polygons);
+}
+
+Vector<Vector<Point2>> PolyBoolean2D::intersect_polylines_with_polygons(const Vector<Vector<Point2>> &p_polylines, const Vector<Vector<Point2>> &p_polygons, const Ref<PolyBooleanParameters2D> &p_parameters) {
+	backend->set_parameters(p_parameters);
+	backend->get_parameters()->subject_open = true;
+	return backend->polypaths_boolean(PolyBoolean2DBackend::OPERATION_INTERSECTION, p_polylines, p_polygons);
+}
+
+// BIND
+
+_PolyBoolean2D *_PolyBoolean2D::singleton = nullptr;
+
+Array _PolyBoolean2D::merge_polygons(Array p_polygons_a, Array p_polygons_b) const {
+	Vector<Vector<Vector2>> polygons_a;
+	for (int i = 0; i < p_polygons_a.size(); ++i) {
+		polygons_a.push_back(p_polygons_a[i]);
+	}
+	Vector<Vector<Vector2>> polygons_b;
+	for (int i = 0; i < p_polygons_b.size(); ++i) {
+		polygons_b.push_back(p_polygons_b[i]);
+	}
+	const auto &params = singleton == this ? Ref<PolyBooleanParameters2D>() : parameters;
+	Vector<Vector<Vector2>> solution = PolyBoolean2D::merge_polygons(polygons_a, polygons_b, params);
+	Array ret;
+	for (int i = 0; i < solution.size(); ++i) {
+		ret.push_back(solution[i]);
+	}
+	return ret;
+}
+
+Array _PolyBoolean2D::clip_polygons(Array p_polygons_a, Array p_polygons_b) const {
+	Vector<Vector<Vector2>> polygons_a;
+	for (int i = 0; i < p_polygons_a.size(); ++i) {
+		polygons_a.push_back(p_polygons_a[i]);
+	}
+	Vector<Vector<Vector2>> polygons_b;
+	for (int i = 0; i < p_polygons_b.size(); ++i) {
+		polygons_b.push_back(p_polygons_b[i]);
+	}
+	const auto &params = singleton == this ? Ref<PolyBooleanParameters2D>() : parameters;
+	Vector<Vector<Vector2>> solution = PolyBoolean2D::clip_polygons(polygons_a, polygons_b, params);
+	Array ret;
+	for (int i = 0; i < solution.size(); ++i) {
+		ret.push_back(solution[i]);
+	}
+	return ret;
+}
+
+Array _PolyBoolean2D::intersect_polygons(Array p_polygons_a, Array p_polygons_b) const {
+	Vector<Vector<Vector2>> polygons_a;
+	for (int i = 0; i < p_polygons_a.size(); ++i) {
+		polygons_a.push_back(p_polygons_a[i]);
+	}
+	Vector<Vector<Vector2>> polygons_b;
+	for (int i = 0; i < p_polygons_b.size(); ++i) {
+		polygons_b.push_back(p_polygons_b[i]);
+	}
+	const auto &params = singleton == this ? Ref<PolyBooleanParameters2D>() : parameters;
+	Vector<Vector<Vector2>> solution = PolyBoolean2D::intersect_polygons(polygons_a, polygons_b, params);
+	Array ret;
+	for (int i = 0; i < solution.size(); ++i) {
+		ret.push_back(solution[i]);
+	}
+	return ret;
+}
+
+Array _PolyBoolean2D::exclude_polygons(Array p_polygons_a, Array p_polygons_b) const {
+	Vector<Vector<Vector2>> polygons_a;
+	for (int i = 0; i < p_polygons_a.size(); ++i) {
+		polygons_a.push_back(p_polygons_a[i]);
+	}
+	Vector<Vector<Vector2>> polygons_b;
+	for (int i = 0; i < p_polygons_b.size(); ++i) {
+		polygons_b.push_back(p_polygons_b[i]);
+	}
+	const auto &params = singleton == this ? Ref<PolyBooleanParameters2D>() : parameters;
+	Vector<Vector<Vector2>> solution = PolyBoolean2D::exclude_polygons(polygons_a, polygons_b, params);
+	Array ret;
+	for (int i = 0; i < solution.size(); ++i) {
+		ret.push_back(solution[i]);
+	}
+	return ret;
+}
+
+Array _PolyBoolean2D::polygons_boolean(Operation p_op, Array p_polygons_a, Array p_polygons_b) const {
+	Vector<Vector<Vector2>> polygons_a;
+	for (int i = 0; i < p_polygons_a.size(); ++i) {
+		polygons_a.push_back(p_polygons_a[i]);
+	}
+	Vector<Vector<Vector2>> polygons_b;
+	for (int i = 0; i < p_polygons_b.size(); ++i) {
+		polygons_b.push_back(p_polygons_b[i]);
+	}
+	const auto &params = singleton == this ? Ref<PolyBooleanParameters2D>() : parameters;
+	Vector<Vector<Vector2>> solution = PolyBoolean2D::polygons_boolean(PolyBoolean2D::Operation(p_op), polygons_a, polygons_b, params);
+	Array ret;
+	for (int i = 0; i < solution.size(); ++i) {
+		ret.push_back(solution[i]);
+	}
+	return ret;
+}
+
+Ref<PolyNode2D> _PolyBoolean2D::polygons_boolean_tree(Operation p_op, Array p_polygons_a, Array p_polygons_b) const {
+	Vector<Vector<Point2>> polygons_a;
+	for (int i = 0; i < p_polygons_a.size(); i++) {
+		polygons_a.push_back(p_polygons_a[i]);
+	}
+	Vector<Vector<Point2>> polygons_b;
+	for (int i = 0; i < p_polygons_b.size(); i++) {
+		polygons_b.push_back(p_polygons_b[i]);
+	}
+	const auto &params = singleton == this ? Ref<PolyBooleanParameters2D>() : parameters;
+	return PolyBoolean2D::polygons_boolean_tree(PolyBoolean2D::Operation(p_op), polygons_a, polygons_b, params);
+}
+
+Array _PolyBoolean2D::clip_polylines_with_polygons(Array p_polylines, Array p_polygons) const {
+	Vector<Vector<Point2>> polylines;
+	for (int i = 0; i < p_polylines.size(); i++) {
+		polylines.push_back(p_polylines[i]);
+	}
+	Vector<Vector<Point2>> polygons;
+	for (int i = 0; i < p_polygons.size(); i++) {
+		polygons.push_back(p_polygons[i]);
+	}
+	const auto &params = singleton == this ? Ref<PolyBooleanParameters2D>() : parameters;
+	Vector<Vector<Vector2>> solution = PolyBoolean2D::clip_polylines_with_polygons(polylines, polygons, params);
+	Array ret;
+	for (int i = 0; i < solution.size(); ++i) {
+		ret.push_back(solution[i]);
+	}
+	return ret;
+}
+
+Array _PolyBoolean2D::intersect_polylines_with_polygons(Array p_polylines, Array p_polygons) const {
+	Vector<Vector<Point2>> polylines;
+	for (int i = 0; i < p_polylines.size(); i++) {
+		polylines.push_back(p_polylines[i]);
+	}
+	Vector<Vector<Point2>> polygons;
+	for (int i = 0; i < p_polygons.size(); i++) {
+		polygons.push_back(p_polygons[i]);
+	}
+	const auto &params = singleton == this ? Ref<PolyBooleanParameters2D>() : parameters;
+	Vector<Vector<Vector2>> solution = PolyBoolean2D::intersect_polylines_with_polygons(polylines, polygons, params);
+	Array ret;
+	for (int i = 0; i < solution.size(); ++i) {
+		ret.push_back(solution[i]);
+	}
+	return ret;
+}
+
+void _PolyBoolean2D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_parameters", "parameters"), &_PolyBoolean2D::set_parameters);
+	ClassDB::bind_method(D_METHOD("get_parameters"), &_PolyBoolean2D::get_parameters);
+
+	ClassDB::bind_method(D_METHOD("merge_polygons", "polygons_a", "polygons_b"), &_PolyBoolean2D::merge_polygons, DEFVAL(Variant()));
+	ClassDB::bind_method(D_METHOD("clip_polygons", "polygons_a", "polygons_b"), &_PolyBoolean2D::clip_polygons);
+	ClassDB::bind_method(D_METHOD("intersect_polygons", "polygons_a", "polygons_b"), &_PolyBoolean2D::intersect_polygons);
+	ClassDB::bind_method(D_METHOD("exclude_polygons", "polygons_a", "polygons_b"), &_PolyBoolean2D::exclude_polygons);
+
+	ClassDB::bind_method(D_METHOD("polygons_boolean", "operation", "polygons_a", "polygons_b"), &_PolyBoolean2D::polygons_boolean, DEFVAL(Variant()));
+	ClassDB::bind_method(D_METHOD("polygons_boolean_tree", "operation", "polygons_a", "polygons_b"), &_PolyBoolean2D::polygons_boolean_tree, DEFVAL(Variant()));
+
+	ClassDB::bind_method(D_METHOD("clip_polylines_with_polygons", "polylines", "polygons"), &_PolyBoolean2D::clip_polylines_with_polygons);
+	ClassDB::bind_method(D_METHOD("intersect_polylines_with_polygons", "polylines", "polygons"), &_PolyBoolean2D::intersect_polylines_with_polygons);
+
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "parameters"), "set_parameters", "get_parameters");
+
+	BIND_ENUM_CONSTANT(OPERATION_NONE);
+	BIND_ENUM_CONSTANT(OPERATION_UNION);
+	BIND_ENUM_CONSTANT(OPERATION_DIFFERENCE);
+	BIND_ENUM_CONSTANT(OPERATION_INTERSECTION);
+	BIND_ENUM_CONSTANT(OPERATION_XOR);
+}
+
 void PolyBooleanParameters2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_subject_fill_rule", "subject_fill_rule"), &PolyBooleanParameters2D::set_subject_fill_rule);
 	ClassDB::bind_method(D_METHOD("get_subject_fill_rule"), &PolyBooleanParameters2D::get_subject_fill_rule);

--- a/core/math/2d/geometry/poly/boolean/poly_boolean.cpp
+++ b/core/math/2d/geometry/poly/boolean/poly_boolean.cpp
@@ -15,49 +15,49 @@ void PolyBoolean2DBackend::set_parameters(const Ref<PolyBooleanParameters2D> &p_
 Vector<Vector<Point2>> PolyBoolean2D::merge_polygons(const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b, const Ref<PolyBooleanParameters2D> &p_parameters) {
 	backend->set_parameters(p_parameters);
 	backend->get_parameters()->subject_open = false;
-	return backend->polypaths_boolean(PolyBoolean2DBackend::OPERATION_UNION, p_polygons_a, p_polygons_b);
+	return backend->boolean_polypaths(p_polygons_a, p_polygons_b, PolyBoolean2DBackend::OPERATION_UNION);
 }
 
 Vector<Vector<Point2>> PolyBoolean2D::clip_polygons(const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b, const Ref<PolyBooleanParameters2D> &p_parameters) {
 	backend->set_parameters(p_parameters);
 	backend->get_parameters()->subject_open = false;
-	return backend->polypaths_boolean(PolyBoolean2DBackend::OPERATION_DIFFERENCE, p_polygons_a, p_polygons_b);
+	return backend->boolean_polypaths(p_polygons_a, p_polygons_b, PolyBoolean2DBackend::OPERATION_DIFFERENCE);
 }
 
 Vector<Vector<Point2>> PolyBoolean2D::intersect_polygons(const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b, const Ref<PolyBooleanParameters2D> &p_parameters) {
 	backend->set_parameters(p_parameters);
 	backend->get_parameters()->subject_open = false;
-	return backend->polypaths_boolean(PolyBoolean2DBackend::OPERATION_INTERSECTION, p_polygons_a, p_polygons_b);
+	return backend->boolean_polypaths(p_polygons_a, p_polygons_b, PolyBoolean2DBackend::OPERATION_INTERSECTION);
 }
 
 Vector<Vector<Point2>> PolyBoolean2D::exclude_polygons(const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b, const Ref<PolyBooleanParameters2D> &p_parameters) {
 	backend->set_parameters(p_parameters);
 	backend->get_parameters()->subject_open = false;
-	return backend->polypaths_boolean(PolyBoolean2DBackend::OPERATION_XOR, p_polygons_a, p_polygons_b);
+	return backend->boolean_polypaths( p_polygons_a, p_polygons_b, PolyBoolean2DBackend::OPERATION_XOR);
 }
 
-Vector<Vector<Point2>> PolyBoolean2D::polygons_boolean(Operation p_op, const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b, const Ref<PolyBooleanParameters2D> &p_parameters) {
+Vector<Vector<Point2>> PolyBoolean2D::boolean_polygons(const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b, Operation p_op, const Ref<PolyBooleanParameters2D> &p_parameters) {
 	backend->set_parameters(p_parameters);
 	backend->get_parameters()->subject_open = false;
-	return backend->polypaths_boolean(PolyBoolean2DBackend::Operation(p_op), p_polygons_a, p_polygons_b);
+	return backend->boolean_polypaths(p_polygons_a, p_polygons_b, PolyBoolean2DBackend::Operation(p_op));
 }
 
-Ref<PolyNode2D> PolyBoolean2D::polygons_boolean_tree(Operation p_op, const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b, const Ref<PolyBooleanParameters2D> &p_parameters) {
+Ref<PolyNode2D> PolyBoolean2D::boolean_polygons_tree(const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b, Operation p_op, const Ref<PolyBooleanParameters2D> &p_parameters) {
 	backend->set_parameters(p_parameters);
 	backend->get_parameters()->subject_open = false;
-	return backend->polypaths_boolean_tree(PolyBoolean2DBackend::Operation(p_op), p_polygons_a, p_polygons_b);
+	return backend->boolean_polypaths_tree(p_polygons_a, p_polygons_b, PolyBoolean2DBackend::Operation(p_op));
 }
 
 Vector<Vector<Point2>> PolyBoolean2D::clip_polylines_with_polygons(const Vector<Vector<Point2>> &p_polylines, const Vector<Vector<Point2>> &p_polygons, const Ref<PolyBooleanParameters2D> &p_parameters) {
 	backend->set_parameters(p_parameters);
 	backend->get_parameters()->subject_open = true;
-	return backend->polypaths_boolean(PolyBoolean2DBackend::OPERATION_DIFFERENCE, p_polylines, p_polygons);
+	return backend->boolean_polypaths(p_polylines, p_polygons, PolyBoolean2DBackend::OPERATION_DIFFERENCE);
 }
 
 Vector<Vector<Point2>> PolyBoolean2D::intersect_polylines_with_polygons(const Vector<Vector<Point2>> &p_polylines, const Vector<Vector<Point2>> &p_polygons, const Ref<PolyBooleanParameters2D> &p_parameters) {
 	backend->set_parameters(p_parameters);
 	backend->get_parameters()->subject_open = true;
-	return backend->polypaths_boolean(PolyBoolean2DBackend::OPERATION_INTERSECTION, p_polylines, p_polygons);
+	return backend->boolean_polypaths(p_polylines, p_polygons, PolyBoolean2DBackend::OPERATION_INTERSECTION);
 }
 
 // BIND
@@ -136,7 +136,7 @@ Array _PolyBoolean2D::exclude_polygons(Array p_polygons_a, Array p_polygons_b) c
 	return ret;
 }
 
-Array _PolyBoolean2D::polygons_boolean(Operation p_op, Array p_polygons_a, Array p_polygons_b) const {
+Array _PolyBoolean2D::boolean_polygons(Array p_polygons_a, Array p_polygons_b, Operation p_op) const {
 	Vector<Vector<Vector2>> polygons_a;
 	for (int i = 0; i < p_polygons_a.size(); ++i) {
 		polygons_a.push_back(p_polygons_a[i]);
@@ -146,7 +146,7 @@ Array _PolyBoolean2D::polygons_boolean(Operation p_op, Array p_polygons_a, Array
 		polygons_b.push_back(p_polygons_b[i]);
 	}
 	const auto &params = singleton == this ? Ref<PolyBooleanParameters2D>() : parameters;
-	Vector<Vector<Vector2>> solution = PolyBoolean2D::polygons_boolean(PolyBoolean2D::Operation(p_op), polygons_a, polygons_b, params);
+	Vector<Vector<Vector2>> solution = PolyBoolean2D::boolean_polygons(polygons_a, polygons_b, PolyBoolean2D::Operation(p_op), params);
 	Array ret;
 	for (int i = 0; i < solution.size(); ++i) {
 		ret.push_back(solution[i]);
@@ -154,7 +154,7 @@ Array _PolyBoolean2D::polygons_boolean(Operation p_op, Array p_polygons_a, Array
 	return ret;
 }
 
-Ref<PolyNode2D> _PolyBoolean2D::polygons_boolean_tree(Operation p_op, Array p_polygons_a, Array p_polygons_b) const {
+Ref<PolyNode2D> _PolyBoolean2D::boolean_polygons_tree(Array p_polygons_a, Array p_polygons_b, Operation p_op) const {
 	Vector<Vector<Point2>> polygons_a;
 	for (int i = 0; i < p_polygons_a.size(); i++) {
 		polygons_a.push_back(p_polygons_a[i]);
@@ -164,7 +164,7 @@ Ref<PolyNode2D> _PolyBoolean2D::polygons_boolean_tree(Operation p_op, Array p_po
 		polygons_b.push_back(p_polygons_b[i]);
 	}
 	const auto &params = singleton == this ? Ref<PolyBooleanParameters2D>() : parameters;
-	return PolyBoolean2D::polygons_boolean_tree(PolyBoolean2D::Operation(p_op), polygons_a, polygons_b, params);
+	return PolyBoolean2D::boolean_polygons_tree(polygons_a, polygons_b, PolyBoolean2D::Operation(p_op), params);
 }
 
 Array _PolyBoolean2D::clip_polylines_with_polygons(Array p_polylines, Array p_polygons) const {
@@ -212,8 +212,8 @@ void _PolyBoolean2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("intersect_polygons", "polygons_a", "polygons_b"), &_PolyBoolean2D::intersect_polygons);
 	ClassDB::bind_method(D_METHOD("exclude_polygons", "polygons_a", "polygons_b"), &_PolyBoolean2D::exclude_polygons);
 
-	ClassDB::bind_method(D_METHOD("polygons_boolean", "operation", "polygons_a", "polygons_b"), &_PolyBoolean2D::polygons_boolean, DEFVAL(Variant()));
-	ClassDB::bind_method(D_METHOD("polygons_boolean_tree", "operation", "polygons_a", "polygons_b"), &_PolyBoolean2D::polygons_boolean_tree, DEFVAL(Variant()));
+	ClassDB::bind_method(D_METHOD("boolean_polygons", "polygons_a", "polygons_b", "operation"), &_PolyBoolean2D::boolean_polygons);
+	ClassDB::bind_method(D_METHOD("boolean_polygons_tree", "polygons_a", "polygons_b", "operation"), &_PolyBoolean2D::boolean_polygons_tree);
 
 	ClassDB::bind_method(D_METHOD("clip_polylines_with_polygons", "polylines", "polygons"), &_PolyBoolean2D::clip_polylines_with_polygons);
 	ClassDB::bind_method(D_METHOD("intersect_polylines_with_polygons", "polylines", "polygons"), &_PolyBoolean2D::intersect_polylines_with_polygons);

--- a/core/math/2d/geometry/poly/boolean/poly_boolean.cpp
+++ b/core/math/2d/geometry/poly/boolean/poly_boolean.cpp
@@ -33,7 +33,7 @@ Vector<Vector<Point2>> PolyBoolean2D::intersect_polygons(const Vector<Vector<Poi
 Vector<Vector<Point2>> PolyBoolean2D::exclude_polygons(const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b, const Ref<PolyBooleanParameters2D> &p_parameters) {
 	backend->set_parameters(p_parameters);
 	backend->get_parameters()->subject_open = false;
-	return backend->boolean_polypaths( p_polygons_a, p_polygons_b, PolyBoolean2DBackend::OPERATION_XOR);
+	return backend->boolean_polypaths(p_polygons_a, p_polygons_b, PolyBoolean2DBackend::OPERATION_XOR);
 }
 
 Vector<Vector<Point2>> PolyBoolean2D::boolean_polygons(const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b, Operation p_op, const Ref<PolyBooleanParameters2D> &p_parameters) {
@@ -63,6 +63,24 @@ Vector<Vector<Point2>> PolyBoolean2D::intersect_polylines_with_polygons(const Ve
 // BIND
 
 _PolyBoolean2D *_PolyBoolean2D::singleton = nullptr;
+
+void _PolyBoolean2D::set_parameters(const Ref<PolyBooleanParameters2D> &p_parameters) {
+#ifdef DEBUG_ENABLED
+	if (singleton == this) {
+		ERR_FAIL_MSG("Configuring parameters is forbidden for a global instance. Please create a new local instance of PolyBoolean2D with `new_instance()` method");
+	}
+#endif
+	parameters = p_parameters;
+}
+
+Ref<PolyBooleanParameters2D> _PolyBoolean2D::get_parameters() const {
+#ifdef DEBUG_ENABLED
+	if (singleton == this) {
+		ERR_FAIL_V_MSG(Ref<PolyBooleanParameters2D>(), "Configuring parameters is forbidden for a global instance. Please create a new local instance of PolyBoolean2D with `new_instance()` method");
+	}
+#endif
+	return parameters;
+}
 
 Array _PolyBoolean2D::merge_polygons(Array p_polygons_a, Array p_polygons_b) const {
 	Vector<Vector<Vector2>> polygons_a;
@@ -204,6 +222,8 @@ Array _PolyBoolean2D::intersect_polylines_with_polygons(Array p_polylines, Array
 }
 
 void _PolyBoolean2D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("new_instance"), &_PolyBoolean2D::new_instance);
+
 	ClassDB::bind_method(D_METHOD("set_parameters", "parameters"), &_PolyBoolean2D::set_parameters);
 	ClassDB::bind_method(D_METHOD("get_parameters"), &_PolyBoolean2D::get_parameters);
 

--- a/core/math/2d/geometry/poly/boolean/poly_boolean.h
+++ b/core/math/2d/geometry/poly/boolean/poly_boolean.h
@@ -96,7 +96,7 @@ public:
 	Array clip_polylines_with_polygons(Array p_polylines, Array p_polygons) const;
 	Array intersect_polylines_with_polygons(Array p_polylines, Array p_polygons) const;
 
-	_PolyBoolean2D::_PolyBoolean2D() {
+	_PolyBoolean2D() {
 		if (!singleton) {
 			singleton = this;
 		}

--- a/core/math/2d/geometry/poly/boolean/poly_boolean.h
+++ b/core/math/2d/geometry/poly/boolean/poly_boolean.h
@@ -73,9 +73,10 @@ protected:
 
 public:
 	static _PolyBoolean2D *get_singleton() { return singleton; }
+	virtual Ref<_PolyBoolean2D> new_instance() const { return memnew(_PolyBoolean2D); }
 
-	void set_parameters(const Ref<PolyBooleanParameters2D> &p_parameters) { parameters = p_parameters; }
-	Ref<PolyBooleanParameters2D> get_parameters() const { return parameters; }
+	void set_parameters(const Ref<PolyBooleanParameters2D> &p_parameters);
+	Ref<PolyBooleanParameters2D> get_parameters() const;
 
 	enum Operation {
 		OPERATION_NONE,

--- a/core/math/2d/geometry/poly/boolean/poly_boolean.h
+++ b/core/math/2d/geometry/poly/boolean/poly_boolean.h
@@ -73,7 +73,8 @@ protected:
 
 public:
 	static _PolyBoolean2D *get_singleton() { return singleton; }
-	virtual Ref<_PolyBoolean2D> new_instance() const { return memnew(_PolyBoolean2D); }
+	// Not using Ref<_PolyBoolean2D> as return type due to namespace issues in Godot.
+	virtual Ref<Reference> new_instance() const { return memnew(_PolyBoolean2D); }
 
 	void set_parameters(const Ref<PolyBooleanParameters2D> &p_parameters);
 	Ref<PolyBooleanParameters2D> get_parameters() const;

--- a/core/math/2d/geometry/poly/boolean/poly_boolean.h
+++ b/core/math/2d/geometry/poly/boolean/poly_boolean.h
@@ -19,8 +19,8 @@ public:
 		OPERATION_INTERSECTION,
 		OPERATION_XOR,
 	};
-	virtual Vector<Vector<Point2>> polypaths_boolean(Operation p_op, const Vector<Vector<Point2>> &p_polypaths_A, const Vector<Vector<Point2>> &p_polypaths_B) = 0;
-	virtual Ref<PolyNode2D> polypaths_boolean_tree(Operation p_op, const Vector<Vector<Point2>> &p_polypaths_A, const Vector<Vector<Point2>> &p_polypaths_B) = 0;
+	virtual Vector<Vector<Point2>> boolean_polypaths(const Vector<Vector<Point2>> &p_polypaths_A, const Vector<Vector<Point2>> &p_polypaths_B, Operation p_op) = 0;
+	virtual Ref<PolyNode2D> boolean_polypaths_tree(const Vector<Vector<Point2>> &p_polypaths_A, const Vector<Vector<Point2>> &p_polypaths_B, Operation p_op) = 0;
 
 	PolyBoolean2DBackend() {
 		default_parameters.instance();
@@ -47,8 +47,8 @@ public:
 	static Vector<Vector<Point2>> intersect_polygons(const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b, const Ref<PolyBooleanParameters2D> &p_parameters = Ref<PolyBooleanParameters2D>());
 	static Vector<Vector<Point2>> exclude_polygons(const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b, const Ref<PolyBooleanParameters2D> &p_parameters = Ref<PolyBooleanParameters2D>());
 
-	static Vector<Vector<Point2>> polygons_boolean(Operation p_op, const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b = Vector<Vector<Point2>>(), const Ref<PolyBooleanParameters2D> &p_parameters = Ref<PolyBooleanParameters2D>());
-	static Ref<PolyNode2D> polygons_boolean_tree(Operation p_op, const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b = Vector<Vector<Point2>>(), const Ref<PolyBooleanParameters2D> &p_parameters = Ref<PolyBooleanParameters2D>());
+	static Vector<Vector<Point2>> boolean_polygons(const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b, Operation p_op, const Ref<PolyBooleanParameters2D> &p_parameters = Ref<PolyBooleanParameters2D>());
+	static Ref<PolyNode2D> boolean_polygons_tree(const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b, Operation p_op, const Ref<PolyBooleanParameters2D> &p_parameters = Ref<PolyBooleanParameters2D>());
 
 	static Vector<Vector<Point2>> clip_polylines_with_polygons(const Vector<Vector<Point2>> &p_polylines, const Vector<Vector<Point2>> &p_polygons, const Ref<PolyBooleanParameters2D> &p_parameters = Ref<PolyBooleanParameters2D>());
 	static Vector<Vector<Point2>> intersect_polylines_with_polygons(const Vector<Vector<Point2>> &p_polylines, const Vector<Vector<Point2>> &p_polygons, const Ref<PolyBooleanParameters2D> &p_parameters = Ref<PolyBooleanParameters2D>());
@@ -89,8 +89,8 @@ public:
 	Array intersect_polygons(Array p_polygons_a, Array p_polygons_b) const;
 	Array exclude_polygons(Array p_polygons_a, Array p_polygons_b) const;
 
-	Array polygons_boolean(Operation p_op, Array p_polygons_a, Array p_polygons_b) const;
-	Ref<PolyNode2D> polygons_boolean_tree(Operation p_op, Array p_polygons_a, Array p_polygons_b) const;
+	Array boolean_polygons(Array p_polygons_a, Array p_polygons_b, Operation p_op) const;
+	Ref<PolyNode2D> boolean_polygons_tree(Array p_polygons_a, Array p_polygons_b, Operation p_op) const;
 
 	Array clip_polylines_with_polygons(Array p_polylines, Array p_polygons) const;
 	Array intersect_polylines_with_polygons(Array p_polylines, Array p_polygons) const;

--- a/core/math/2d/geometry/poly/decomp/clipper10/poly_decomp_clipper10.cpp
+++ b/core/math/2d/geometry/poly/decomp/clipper10/poly_decomp_clipper10.cpp
@@ -4,7 +4,7 @@
 Vector<Vector<Point2>> PolyDecomp2DClipper10::triangulate_mono(const Vector<Vector<Point2>> &p_polygons) {
 	using namespace clipperlib;
 
-	ClipperTri clp = configure(params);
+	ClipperTri clp = configure(parameters);
 
 	Paths subject;
 	GodotClipperUtils::scale_up_polypaths(p_polygons, subject);
@@ -19,10 +19,10 @@ Vector<Vector<Point2>> PolyDecomp2DClipper10::triangulate_mono(const Vector<Vect
 	return ret;
 }
 
-clipperlib::ClipperTri PolyDecomp2DClipper10::configure(const Ref<PolyDecompParameters2D> &p_params) {
+clipperlib::ClipperTri PolyDecomp2DClipper10::configure(const Ref<PolyDecompParameters2D> &p_parameters) {
 	using namespace clipperlib;
 
-	fill_rule = FillRule(p_params->fill_rule);
+	fill_rule = FillRule(p_parameters->fill_rule);
 
 	return ClipperTri();
 }

--- a/core/math/2d/geometry/poly/decomp/clipper10/poly_decomp_clipper10.h
+++ b/core/math/2d/geometry/poly/decomp/clipper10/poly_decomp_clipper10.h
@@ -1,18 +1,15 @@
 #ifndef GOOST_GEOMETRY_POLY_DECOMP_CLIPPER10
 #define GOOST_GEOMETRY_POLY_DECOMP_CLIPPER10
 
-#include "goost/core/math/2d/geometry/poly/decomp/polypartition/poly_decomp_polypartition.h"
+#include "../polypartition/poly_decomp_polypartition.h"
 #include "goost/thirdparty/clipper/clipper_triangulation.h"
 
 class PolyDecomp2DClipper10 : public PolyDecomp2DPolyPartition {
 public:
-	// Seems like Clipper 10.0.0 uses monotone partitioning (?)
 	virtual Vector<Vector<Point2>> triangulate_mono(const Vector<Vector<Point2>> &p_polygons) override;
 
-protected:
-	clipperlib::ClipperTri configure(const Ref<PolyDecompParameters2D> &p_params);
-
 private:
+	clipperlib::ClipperTri configure(const Ref<PolyDecompParameters2D> &p_params);
 	clipperlib::FillRule fill_rule;
 };
 

--- a/core/math/2d/geometry/poly/decomp/poly_decomp.cpp
+++ b/core/math/2d/geometry/poly/decomp/poly_decomp.cpp
@@ -53,6 +53,24 @@ Vector<Vector<Point2>> PolyDecomp2D::decompose_polygons(const Vector<Vector<Poin
 
 _PolyDecomp2D *_PolyDecomp2D::singleton = nullptr;
 
+void _PolyDecomp2D::set_parameters(const Ref<PolyDecompParameters2D> &p_parameters) {
+#ifdef DEBUG_ENABLED
+	if (singleton == this) {
+		ERR_FAIL_MSG("Configuring parameters is forbidden for a global instance. Please create a new local instance of PolyDecomp2D with `new_instance()` method");
+	}
+#endif
+	parameters = p_parameters;
+}
+
+Ref<PolyDecompParameters2D> _PolyDecomp2D::get_parameters() const {
+#ifdef DEBUG_ENABLED
+	if (singleton == this) {
+		ERR_FAIL_V_MSG(Ref<PolyDecompParameters2D>(), "Configuring parameters is forbidden for a global instance. Please create a new local instance of PolyDecomp2D with `new_instance()` method");
+	}
+#endif
+	return parameters;
+}
+
 Array _PolyDecomp2D::triangulate_polygons(Array p_polygons) const {
 	Vector<Vector<Point2>> polygons;
 	for (int i = 0; i < p_polygons.size(); i++) {
@@ -96,9 +114,11 @@ Array _PolyDecomp2D::decompose_polygons(Array p_polygons, Decomposition p_type) 
 }
 
 void _PolyDecomp2D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("new_instance"), &_PolyDecomp2D::new_instance);
+
 	ClassDB::bind_method(D_METHOD("set_parameters", "parameters"), &_PolyDecomp2D::set_parameters);
 	ClassDB::bind_method(D_METHOD("get_parameters"), &_PolyDecomp2D::get_parameters);
-	
+
 	ClassDB::bind_method(D_METHOD("triangulate_polygons", "polygons"), &_PolyDecomp2D::triangulate_polygons);
 	ClassDB::bind_method(D_METHOD("decompose_polygons_into_convex", "polygons"), &_PolyDecomp2D::decompose_polygons_into_convex);
 	ClassDB::bind_method(D_METHOD("decompose_polygons", "polygons", "type"), &_PolyDecomp2D::decompose_polygons);

--- a/core/math/2d/geometry/poly/decomp/poly_decomp.cpp
+++ b/core/math/2d/geometry/poly/decomp/poly_decomp.cpp
@@ -1,9 +1,19 @@
 #include "poly_decomp.h"
-#include "goost/core/math/2d/geometry/goost_geometry_2d.h"
 
-Vector<Vector<Point2>> PolyDecomp2D::decompose_polygons(DecompType p_type, const Vector<Vector<Point2>> &p_polygons) {
+PolyDecomp2DBackend *PolyDecomp2D::backend = nullptr;
+
+void PolyDecomp2DBackend::set_parameters(const Ref<PolyDecompParameters2D> &p_parameters) {
+	if (p_parameters.is_valid()) {
+		parameters = p_parameters;
+	} else {
+		parameters = Ref<PolyDecompParameters2D>();
+		parameters = default_parameters;
+		parameters->reset();
+	}
+}
+
+Vector<Vector<Point2>> PolyDecomp2DBackend::decompose_polygons(DecompType p_type, const Vector<Vector<Point2>> &p_polygons) {
 	Vector<Vector<Point2>> polys;
-
 	switch (p_type) {
 		case DECOMP_TRIANGLES_EC: {
 			polys = triangulate_ec(p_polygons);
@@ -22,6 +32,84 @@ Vector<Vector<Point2>> PolyDecomp2D::decompose_polygons(DecompType p_type, const
 		} break;
 	}
 	return polys;
+}
+
+Vector<Vector<Point2>> PolyDecomp2D::triangulate_polygons(const Vector<Vector<Point2>> &p_polygons, const Ref<PolyDecompParameters2D> &p_parameters) {
+	backend->set_parameters(p_parameters);
+	return backend->triangulate_mono(p_polygons);
+}
+
+Vector<Vector<Point2>> PolyDecomp2D::decompose_polygons_into_convex(const Vector<Vector<Point2>> &p_polygons, const Ref<PolyDecompParameters2D> &p_parameters) {
+	backend->set_parameters(p_parameters);
+	return backend->decompose_convex_hm(p_polygons);
+}
+
+Vector<Vector<Point2>> PolyDecomp2D::decompose_polygons(DecompType p_type, const Vector<Vector<Point2>> &p_polygons, const Ref<PolyDecompParameters2D> &p_parameters) {
+	backend->set_parameters(p_parameters);
+	return backend->decompose_polygons(PolyDecomp2DBackend::DecompType(p_type), p_polygons);
+}
+
+// BIND
+
+_PolyDecomp2D *_PolyDecomp2D::singleton = nullptr;
+
+Array _PolyDecomp2D::triangulate_polygons(Array p_polygons) const {
+	Vector<Vector<Point2>> polygons;
+	for (int i = 0; i < p_polygons.size(); i++) {
+		polygons.push_back(p_polygons[i]);
+	}
+	const auto &params = singleton == this ? Ref<PolyDecompParameters2D>() : parameters;
+	Vector<Vector<Vector2>> solution = PolyDecomp2D::triangulate_polygons(polygons, params);
+	Array ret;
+	for (int i = 0; i < solution.size(); ++i) {
+		ret.push_back(solution[i]);
+	}
+	return ret;
+}
+
+Array _PolyDecomp2D::decompose_polygons_into_convex(Array p_polygons) const {
+	Vector<Vector<Point2>> polygons;
+	for (int i = 0; i < p_polygons.size(); i++) {
+		polygons.push_back(p_polygons[i]);
+	}
+	const auto &params = singleton == this ? Ref<PolyDecompParameters2D>() : parameters;
+	Vector<Vector<Vector2>> solution = PolyDecomp2D::decompose_polygons_into_convex(polygons, params);
+	Array ret;
+	for (int i = 0; i < solution.size(); ++i) {
+		ret.push_back(solution[i]);
+	}
+	return ret;
+}
+
+Array _PolyDecomp2D::decompose_polygons(DecompType p_type, Array p_polygons) const {
+	Vector<Vector<Point2>> polygons;
+	for (int i = 0; i < p_polygons.size(); i++) {
+		polygons.push_back(p_polygons[i]);
+	}
+	const auto &params = singleton == this ? Ref<PolyDecompParameters2D>() : parameters;
+	Vector<Vector<Vector2>> solution = PolyDecomp2D::decompose_polygons(PolyDecomp2D::DecompType(p_type), polygons, params);
+	Array ret;
+	for (int i = 0; i < solution.size(); ++i) {
+		ret.push_back(solution[i]);
+	}
+	return ret;
+}
+
+void _PolyDecomp2D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_parameters", "parameters"), &_PolyDecomp2D::set_parameters);
+	ClassDB::bind_method(D_METHOD("get_parameters"), &_PolyDecomp2D::get_parameters);
+	
+	ClassDB::bind_method(D_METHOD("triangulate_polygons", "polygons"), &_PolyDecomp2D::triangulate_polygons);
+	ClassDB::bind_method(D_METHOD("decompose_polygons_into_convex", "polygons"), &_PolyDecomp2D::decompose_polygons_into_convex);
+	ClassDB::bind_method(D_METHOD("decompose_polygons", "type", "polygons"), &_PolyDecomp2D::decompose_polygons);
+
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "parameters"), "set_parameters", "get_parameters");
+
+	BIND_ENUM_CONSTANT(DECOMP_TRIANGLES_EC);
+	BIND_ENUM_CONSTANT(DECOMP_TRIANGLES_OPT);
+	BIND_ENUM_CONSTANT(DECOMP_TRIANGLES_MONO);
+	BIND_ENUM_CONSTANT(DECOMP_CONVEX_HM);
+	BIND_ENUM_CONSTANT(DECOMP_CONVEX_OPT);
 }
 
 void PolyDecompParameters2D::_bind_methods() {

--- a/core/math/2d/geometry/poly/decomp/poly_decomp.cpp
+++ b/core/math/2d/geometry/poly/decomp/poly_decomp.cpp
@@ -12,7 +12,7 @@ void PolyDecomp2DBackend::set_parameters(const Ref<PolyDecompParameters2D> &p_pa
 	}
 }
 
-Vector<Vector<Point2>> PolyDecomp2DBackend::decompose_polygons(DecompType p_type, const Vector<Vector<Point2>> &p_polygons) {
+Vector<Vector<Point2>> PolyDecomp2DBackend::decompose_polygons(const Vector<Vector<Point2>> &p_polygons, Decomposition p_type) {
 	Vector<Vector<Point2>> polys;
 	switch (p_type) {
 		case DECOMP_TRIANGLES_EC: {
@@ -44,9 +44,9 @@ Vector<Vector<Point2>> PolyDecomp2D::decompose_polygons_into_convex(const Vector
 	return backend->decompose_convex_hm(p_polygons);
 }
 
-Vector<Vector<Point2>> PolyDecomp2D::decompose_polygons(DecompType p_type, const Vector<Vector<Point2>> &p_polygons, const Ref<PolyDecompParameters2D> &p_parameters) {
+Vector<Vector<Point2>> PolyDecomp2D::decompose_polygons(const Vector<Vector<Point2>> &p_polygons, Decomposition p_type, const Ref<PolyDecompParameters2D> &p_parameters) {
 	backend->set_parameters(p_parameters);
-	return backend->decompose_polygons(PolyDecomp2DBackend::DecompType(p_type), p_polygons);
+	return backend->decompose_polygons(p_polygons, PolyDecomp2DBackend::Decomposition(p_type));
 }
 
 // BIND
@@ -81,13 +81,13 @@ Array _PolyDecomp2D::decompose_polygons_into_convex(Array p_polygons) const {
 	return ret;
 }
 
-Array _PolyDecomp2D::decompose_polygons(DecompType p_type, Array p_polygons) const {
+Array _PolyDecomp2D::decompose_polygons(Array p_polygons, Decomposition p_type) const {
 	Vector<Vector<Point2>> polygons;
 	for (int i = 0; i < p_polygons.size(); i++) {
 		polygons.push_back(p_polygons[i]);
 	}
 	const auto &params = singleton == this ? Ref<PolyDecompParameters2D>() : parameters;
-	Vector<Vector<Vector2>> solution = PolyDecomp2D::decompose_polygons(PolyDecomp2D::DecompType(p_type), polygons, params);
+	Vector<Vector<Vector2>> solution = PolyDecomp2D::decompose_polygons(polygons, PolyDecomp2D::Decomposition(p_type), params);
 	Array ret;
 	for (int i = 0; i < solution.size(); ++i) {
 		ret.push_back(solution[i]);
@@ -101,7 +101,7 @@ void _PolyDecomp2D::_bind_methods() {
 	
 	ClassDB::bind_method(D_METHOD("triangulate_polygons", "polygons"), &_PolyDecomp2D::triangulate_polygons);
 	ClassDB::bind_method(D_METHOD("decompose_polygons_into_convex", "polygons"), &_PolyDecomp2D::decompose_polygons_into_convex);
-	ClassDB::bind_method(D_METHOD("decompose_polygons", "type", "polygons"), &_PolyDecomp2D::decompose_polygons);
+	ClassDB::bind_method(D_METHOD("decompose_polygons", "polygons", "type"), &_PolyDecomp2D::decompose_polygons);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "parameters"), "set_parameters", "get_parameters");
 

--- a/core/math/2d/geometry/poly/decomp/poly_decomp.h
+++ b/core/math/2d/geometry/poly/decomp/poly_decomp.h
@@ -11,14 +11,14 @@ public:
 	virtual void set_parameters(const Ref<PolyDecompParameters2D> &p_parameters);
 	virtual Ref<PolyDecompParameters2D> get_parameters() { return parameters; }
 
-	enum DecompType {
+	enum Decomposition {
 		DECOMP_TRIANGLES_EC,
 		DECOMP_TRIANGLES_OPT,
 		DECOMP_TRIANGLES_MONO,
 		DECOMP_CONVEX_HM,
 		DECOMP_CONVEX_OPT,
 	};
-	virtual Vector<Vector<Point2>> decompose_polygons(DecompType p_type, const Vector<Vector<Point2>> &p_polygons);
+	virtual Vector<Vector<Point2>> decompose_polygons(const Vector<Vector<Point2>> &p_polygons, Decomposition p_type);
 
 	virtual Vector<Vector<Point2>> triangulate_ec(const Vector<Vector<Point2>> &p_polygons) = 0;
 	virtual Vector<Vector<Point2>> triangulate_opt(const Vector<Vector<Point2>> &p_polygons) = 0;
@@ -39,7 +39,7 @@ protected:
 
 class PolyDecomp2D {
 public:
-	enum DecompType {
+	enum Decomposition {
 		DECOMP_TRIANGLES_EC,
 		DECOMP_TRIANGLES_OPT,
 		DECOMP_TRIANGLES_MONO,
@@ -48,7 +48,7 @@ public:
 	};
 	static Vector<Vector<Point2>> triangulate_polygons(const Vector<Vector<Point2>> &p_polygons, const Ref<PolyDecompParameters2D> &p_parameters = Ref<PolyDecompParameters2D>());
 	static Vector<Vector<Point2>> decompose_polygons_into_convex(const Vector<Vector<Point2>> &p_polygons, const Ref<PolyDecompParameters2D> &p_parameters = Ref<PolyDecompParameters2D>());
-	static Vector<Vector<Point2>> decompose_polygons(DecompType p_type, const Vector<Vector<Point2>> &p_polygons, const Ref<PolyDecompParameters2D> &p_parameters = Ref<PolyDecompParameters2D>());
+	static Vector<Vector<Point2>> decompose_polygons(const Vector<Vector<Point2>> &p_polygons, Decomposition p_type, const Ref<PolyDecompParameters2D> &p_parameters = Ref<PolyDecompParameters2D>());
 
 	static void set_backend(PolyDecomp2DBackend *p_backend) { backend = p_backend; }
 	static PolyDecomp2DBackend *get_backend() { return backend; }
@@ -74,7 +74,7 @@ public:
 	void set_parameters(const Ref<PolyDecompParameters2D> &p_parameters) { parameters = p_parameters; }
 	Ref<PolyDecompParameters2D> get_parameters() const { return parameters; }
 
-	enum DecompType {
+	enum Decomposition {
 		DECOMP_TRIANGLES_EC,
 		DECOMP_TRIANGLES_OPT,
 		DECOMP_TRIANGLES_MONO,
@@ -83,7 +83,7 @@ public:
 	};
 	Array triangulate_polygons(Array p_polygons) const;
 	Array decompose_polygons_into_convex(Array p_polygons) const;
-	Array decompose_polygons(DecompType p_type, Array p_polygons) const;
+	Array decompose_polygons(Array p_polygons, Decomposition p_type) const;
 
 	_PolyDecomp2D::_PolyDecomp2D() {
 		if (!singleton) {
@@ -96,7 +96,7 @@ protected:
 	Ref<PolyDecompParameters2D> parameters;
 };
 
-VARIANT_ENUM_CAST(_PolyDecomp2D::DecompType);
+VARIANT_ENUM_CAST(_PolyDecomp2D::Decomposition);
 
 class PolyDecompParameters2D : public Reference {
 	GDCLASS(PolyDecompParameters2D, Reference);

--- a/core/math/2d/geometry/poly/decomp/poly_decomp.h
+++ b/core/math/2d/geometry/poly/decomp/poly_decomp.h
@@ -86,7 +86,7 @@ public:
 	Array decompose_polygons_into_convex(Array p_polygons) const;
 	Array decompose_polygons(Array p_polygons, Decomposition p_type) const;
 
-	_PolyDecomp2D::_PolyDecomp2D() {
+	_PolyDecomp2D() {
 		if (!singleton) {
 			singleton = this;
 		}

--- a/core/math/2d/geometry/poly/decomp/poly_decomp.h
+++ b/core/math/2d/geometry/poly/decomp/poly_decomp.h
@@ -3,10 +3,14 @@
 
 #include "core/reference.h"
 
+class PolyDecomp2D;
 class PolyDecompParameters2D;
 
-class PolyDecomp2D {
+class PolyDecomp2DBackend {
 public:
+	virtual void set_parameters(const Ref<PolyDecompParameters2D> &p_parameters);
+	virtual Ref<PolyDecompParameters2D> get_parameters() { return parameters; }
+
 	enum DecompType {
 		DECOMP_TRIANGLES_EC,
 		DECOMP_TRIANGLES_OPT,
@@ -22,14 +26,77 @@ public:
 	virtual Vector<Vector<Point2>> decompose_convex_hm(const Vector<Vector<Point2>> &p_polygons) = 0;
 	virtual Vector<Vector<Point2>> decompose_convex_opt(const Vector<Vector<Point2>> &p_polygons) = 0;
 
-	virtual ~PolyDecomp2D() {}
-
-public:
-	void set_params(const Ref<PolyDecompParameters2D> &p_params) { params = p_params; }
+	PolyDecomp2DBackend() {
+		default_parameters.instance();
+		parameters.instance();
+	}
+	virtual ~PolyDecomp2DBackend() {}
 
 protected:
-	Ref<PolyDecompParameters2D> params;
+	Ref<PolyDecompParameters2D> default_parameters;
+	Ref<PolyDecompParameters2D> parameters;
 };
+
+class PolyDecomp2D {
+public:
+	enum DecompType {
+		DECOMP_TRIANGLES_EC,
+		DECOMP_TRIANGLES_OPT,
+		DECOMP_TRIANGLES_MONO,
+		DECOMP_CONVEX_HM,
+		DECOMP_CONVEX_OPT,
+	};
+	static Vector<Vector<Point2>> triangulate_polygons(const Vector<Vector<Point2>> &p_polygons, const Ref<PolyDecompParameters2D> &p_parameters = Ref<PolyDecompParameters2D>());
+	static Vector<Vector<Point2>> decompose_polygons_into_convex(const Vector<Vector<Point2>> &p_polygons, const Ref<PolyDecompParameters2D> &p_parameters = Ref<PolyDecompParameters2D>());
+	static Vector<Vector<Point2>> decompose_polygons(DecompType p_type, const Vector<Vector<Point2>> &p_polygons, const Ref<PolyDecompParameters2D> &p_parameters = Ref<PolyDecompParameters2D>());
+
+	static void set_backend(PolyDecomp2DBackend *p_backend) { backend = p_backend; }
+	static PolyDecomp2DBackend *get_backend() { return backend; }
+
+private:
+	static PolyDecomp2DBackend *backend;
+};
+
+// BIND
+
+class _PolyDecomp2D : public Reference {
+	GDCLASS(_PolyDecomp2D, Reference);
+
+private:
+	static _PolyDecomp2D *singleton;
+
+protected:
+	static void _bind_methods();
+
+public:
+	static _PolyDecomp2D *get_singleton() { return singleton; }
+
+	void set_parameters(const Ref<PolyDecompParameters2D> &p_parameters) { parameters = p_parameters; }
+	Ref<PolyDecompParameters2D> get_parameters() const { return parameters; }
+
+	enum DecompType {
+		DECOMP_TRIANGLES_EC,
+		DECOMP_TRIANGLES_OPT,
+		DECOMP_TRIANGLES_MONO,
+		DECOMP_CONVEX_HM,
+		DECOMP_CONVEX_OPT,
+	};
+	Array triangulate_polygons(Array p_polygons) const;
+	Array decompose_polygons_into_convex(Array p_polygons) const;
+	Array decompose_polygons(DecompType p_type, Array p_polygons) const;
+
+	_PolyDecomp2D::_PolyDecomp2D() {
+		if (!singleton) {
+			singleton = this;
+		}
+		parameters.instance();
+	}
+
+protected:
+	Ref<PolyDecompParameters2D> parameters;
+};
+
+VARIANT_ENUM_CAST(_PolyDecomp2D::DecompType);
 
 class PolyDecompParameters2D : public Reference {
 	GDCLASS(PolyDecompParameters2D, Reference);

--- a/core/math/2d/geometry/poly/decomp/poly_decomp.h
+++ b/core/math/2d/geometry/poly/decomp/poly_decomp.h
@@ -70,7 +70,8 @@ protected:
 
 public:
 	static _PolyDecomp2D *get_singleton() { return singleton; }
-	virtual Ref<_PolyDecomp2D> new_instance() const { return memnew(_PolyDecomp2D); }
+	// Not using Ref<_PolyDecomp2D> as return type due to namespace issues in Godot.
+	virtual Ref<Reference> new_instance() const { return memnew(_PolyDecomp2D); }
 
 	void set_parameters(const Ref<PolyDecompParameters2D> &p_parameters);
 	Ref<PolyDecompParameters2D> get_parameters() const;

--- a/core/math/2d/geometry/poly/decomp/poly_decomp.h
+++ b/core/math/2d/geometry/poly/decomp/poly_decomp.h
@@ -70,9 +70,10 @@ protected:
 
 public:
 	static _PolyDecomp2D *get_singleton() { return singleton; }
+	virtual Ref<_PolyDecomp2D> new_instance() const { return memnew(_PolyDecomp2D); }
 
-	void set_parameters(const Ref<PolyDecompParameters2D> &p_parameters) { parameters = p_parameters; }
-	Ref<PolyDecompParameters2D> get_parameters() const { return parameters; }
+	void set_parameters(const Ref<PolyDecompParameters2D> &p_parameters);
+	Ref<PolyDecompParameters2D> get_parameters() const;
 
 	enum Decomposition {
 		DECOMP_TRIANGLES_EC,

--- a/core/math/2d/geometry/poly/decomp/polypartition/poly_decomp_polypartition.cpp
+++ b/core/math/2d/geometry/poly/decomp/polypartition/poly_decomp_polypartition.cpp
@@ -2,7 +2,7 @@
 #include "goost/core/math/2d/geometry/goost_geometry_2d.h"
 #include "thirdparty/misc/triangulator.h"
 
-List<TriangulatorPoly> configure(PolyDecomp2DPolyPartition::DecompType p_type, const Vector<Vector<Point2>> &p_polygons) {
+List<TriangulatorPoly> configure(PolyDecomp2DPolyPartition::Decomposition p_type, const Vector<Vector<Point2>> &p_polygons) {
 	List<TriangulatorPoly> in_poly;
 
 	// Split between inner and outer polygons first.

--- a/core/math/2d/geometry/poly/decomp/polypartition/poly_decomp_polypartition.h
+++ b/core/math/2d/geometry/poly/decomp/polypartition/poly_decomp_polypartition.h
@@ -6,7 +6,7 @@
 
 class PolyDecompParameters2D;
 
-class PolyDecomp2DPolyPartition : public PolyDecomp2D {
+class PolyDecomp2DPolyPartition : public PolyDecomp2DBackend {
 public:
 	virtual Vector<Vector<Point2>> triangulate_ec(const Vector<Vector<Point2>> &p_polygons) override;
 	virtual Vector<Vector<Point2>> triangulate_opt(const Vector<Vector<Point2>> &p_polygons) override;

--- a/core/math/2d/geometry/poly/offset/clipper10/poly_offset_clipper10.cpp
+++ b/core/math/2d/geometry/poly/offset/clipper10/poly_offset_clipper10.cpp
@@ -2,7 +2,7 @@
 #include "goost/core/math/2d/geometry/poly/utils/godot_clipper10_path_convert.h"
 
 Vector<Vector<Point2>> PolyOffset2DClipper10::offset_polypaths(const Vector<Vector<Point2>> &p_polypaths, real_t p_delta) {
-	clipperlib::ClipperOffset clp = configure(params);
+	clipperlib::ClipperOffset clp = configure(parameters);
 
 	clipperlib::Paths subject;
 	GodotClipperUtils::scale_up_polypaths(p_polypaths, subject);
@@ -17,10 +17,10 @@ Vector<Vector<Point2>> PolyOffset2DClipper10::offset_polypaths(const Vector<Vect
 	return ret;
 }
 
-clipperlib::ClipperOffset PolyOffset2DClipper10::configure(const Ref<PolyOffsetParameters2D> &p_params) {
+clipperlib::ClipperOffset PolyOffset2DClipper10::configure(const Ref<PolyOffsetParameters2D> &p_parameters) {
 	using namespace clipperlib;
 
-	switch (p_params->join_type) {
+	switch (p_parameters->join_type) {
 		case PolyOffsetParameters2D::JOIN_SQUARE:
 			join_type = kSquare;
 			break;
@@ -31,7 +31,7 @@ clipperlib::ClipperOffset PolyOffset2DClipper10::configure(const Ref<PolyOffsetP
 			join_type = kMiter;
 			break;
 	}
-	switch (p_params->end_type) {
+	switch (p_parameters->end_type) {
 		case PolyOffsetParameters2D::END_POLYGON:
 			end_type = kPolygon;
 			break;
@@ -48,5 +48,5 @@ clipperlib::ClipperOffset PolyOffset2DClipper10::configure(const Ref<PolyOffsetP
 			end_type = kOpenRound;
 			break;
 	}
-	return ClipperOffset(p_params->miter_limit, p_params->arc_tolerance * SCALE_FACTOR);
+	return ClipperOffset(p_parameters->miter_limit, p_parameters->arc_tolerance * SCALE_FACTOR);
 }

--- a/core/math/2d/geometry/poly/offset/clipper10/poly_offset_clipper10.h
+++ b/core/math/2d/geometry/poly/offset/clipper10/poly_offset_clipper10.h
@@ -1,17 +1,15 @@
 #ifndef GOOST_GEOMETRY_POLY_OFFSET_CLIPPER10
 #define GOOST_GEOMETRY_POLY_OFFSET_CLIPPER10
 
-#include "goost/core/math/2d/geometry/poly/offset/poly_offset.h"
+#include "../poly_offset.h"
 #include "goost/thirdparty/clipper/clipper_offset.h"
 
-class PolyOffset2DClipper10 : public PolyOffset2D {
+class PolyOffset2DClipper10 : public PolyOffset2DBackend {
 public:
 	virtual Vector<Vector<Point2>> offset_polypaths(const Vector<Vector<Point2>> &p_polypaths, real_t p_delta) override;
 
-protected:
-	clipperlib::ClipperOffset configure(const Ref<PolyOffsetParameters2D> &p_params);
-
 private:
+	clipperlib::ClipperOffset configure(const Ref<PolyOffsetParameters2D> &p_parameters);
 	clipperlib::JoinType join_type;
 	clipperlib::EndType end_type;
 };

--- a/core/math/2d/geometry/poly/offset/clipper6/poly_offset_clipper6.cpp
+++ b/core/math/2d/geometry/poly/offset/clipper6/poly_offset_clipper6.cpp
@@ -2,7 +2,7 @@
 #include "goost/core/math/2d/geometry/poly/utils/godot_clipper6_path_convert.h"
 
 Vector<Vector<Point2>> PolyOffset2DClipper6::offset_polypaths(const Vector<Vector<Point2>> &p_polypaths, real_t p_delta) {
-	ClipperLib::ClipperOffset clp = configure(params);
+	ClipperLib::ClipperOffset clp = configure(parameters);
 
 	ClipperLib::Paths subject;
 	GodotClipperUtils::scale_up_polypaths(p_polypaths, subject);
@@ -17,10 +17,10 @@ Vector<Vector<Point2>> PolyOffset2DClipper6::offset_polypaths(const Vector<Vecto
 	return ret;
 }
 
-ClipperLib::ClipperOffset PolyOffset2DClipper6::configure(const Ref<PolyOffsetParameters2D> &p_params) {
+ClipperLib::ClipperOffset PolyOffset2DClipper6::configure(const Ref<PolyOffsetParameters2D> &p_parameters) {
 	using namespace ClipperLib;
 
-	switch (p_params->join_type) {
+	switch (p_parameters->join_type) {
 		case PolyOffsetParameters2D::JOIN_SQUARE:
 			join_type = jtSquare;
 			break;
@@ -31,7 +31,7 @@ ClipperLib::ClipperOffset PolyOffset2DClipper6::configure(const Ref<PolyOffsetPa
 			join_type = jtMiter;
 			break;
 	}
-	switch (p_params->end_type) {
+	switch (p_parameters->end_type) {
 		case PolyOffsetParameters2D::END_POLYGON:
 			end_type = etClosedPolygon;
 			break;
@@ -48,5 +48,5 @@ ClipperLib::ClipperOffset PolyOffset2DClipper6::configure(const Ref<PolyOffsetPa
 			end_type = etOpenRound;
 			break;
 	}
-	return ClipperOffset(p_params->miter_limit, p_params->arc_tolerance * SCALE_FACTOR);
+	return ClipperOffset(p_parameters->miter_limit, p_parameters->arc_tolerance * SCALE_FACTOR);
 }

--- a/core/math/2d/geometry/poly/offset/clipper6/poly_offset_clipper6.h
+++ b/core/math/2d/geometry/poly/offset/clipper6/poly_offset_clipper6.h
@@ -1,17 +1,15 @@
 #ifndef GOOST_GEOMETRY_POLY_OFFSET_CLIPPER6
 #define GOOST_GEOMETRY_POLY_OFFSET_CLIPPER6
 
-#include "goost/core/math/2d/geometry/poly/offset/poly_offset.h"
+#include "../poly_offset.h"
 #include "thirdparty/misc/clipper.hpp"
 
-class PolyOffset2DClipper6 : public PolyOffset2D {
+class PolyOffset2DClipper6 : public PolyOffset2DBackend {
 public:
 	virtual Vector<Vector<Point2>> offset_polypaths(const Vector<Vector<Point2>> &p_polypaths, real_t p_delta) override;
 
-protected:
-	ClipperLib::ClipperOffset configure(const Ref<PolyOffsetParameters2D> &p_params);
-
 private:
+	ClipperLib::ClipperOffset configure(const Ref<PolyOffsetParameters2D> &p_parameters);
 	ClipperLib::JoinType join_type;
 	ClipperLib::EndType end_type;
 };

--- a/core/math/2d/geometry/poly/offset/poly_offset.cpp
+++ b/core/math/2d/geometry/poly/offset/poly_offset.cpp
@@ -40,6 +40,24 @@ Vector<Vector<Point2>> PolyOffset2D::deflate_polylines(const Vector<Vector<Point
 
 _PolyOffset2D *_PolyOffset2D::singleton = nullptr;
 
+void _PolyOffset2D::set_parameters(const Ref<PolyOffsetParameters2D> &p_parameters) {
+#ifdef DEBUG_ENABLED
+	if (singleton == this) {
+		ERR_FAIL_MSG("Configuring parameters is forbidden for a global instance. Please create a new local instance of PolyOffset2D with `new_instance()` method");
+	}
+#endif
+	parameters = p_parameters;
+}
+
+Ref<PolyOffsetParameters2D> _PolyOffset2D::get_parameters() const {
+#ifdef DEBUG_ENABLED
+	if (singleton == this) {
+		ERR_FAIL_V_MSG(Ref<PolyOffsetParameters2D>(), "Configuring parameters is forbidden for a global instance. Please create a new local instance of PolyOffset2D with `new_instance()` method");
+	}
+#endif
+	return parameters;
+}
+
 Array _PolyOffset2D::inflate_polygons(Array p_polygons, real_t p_delta) const {
 	Vector<Vector<Point2>> polygons;
 	for (int i = 0; i < p_polygons.size(); i++) {
@@ -83,6 +101,8 @@ Array _PolyOffset2D::deflate_polylines(Array p_polylines, real_t p_delta) const 
 }
 
 void _PolyOffset2D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("new_instance"), &_PolyOffset2D::new_instance);
+
 	ClassDB::bind_method(D_METHOD("set_parameters", "parameters"), &_PolyOffset2D::set_parameters);
 	ClassDB::bind_method(D_METHOD("get_parameters"), &_PolyOffset2D::get_parameters);
 

--- a/core/math/2d/geometry/poly/offset/poly_offset.cpp
+++ b/core/math/2d/geometry/poly/offset/poly_offset.cpp
@@ -1,5 +1,98 @@
 #include "poly_offset.h"
 
+PolyOffset2DBackend *PolyOffset2D::backend = nullptr;
+
+void PolyOffset2DBackend::set_parameters(const Ref<PolyOffsetParameters2D> &p_parameters) {
+	if (p_parameters.is_valid()) {
+		parameters = p_parameters;
+	} else {
+		parameters = Ref<PolyOffsetParameters2D>();
+		parameters = default_parameters;
+		parameters->reset();
+	}
+}
+
+Vector<Vector<Point2>> PolyOffset2D::inflate_polygons(const Vector<Vector<Point2>> &p_polygons, real_t p_delta, const Ref<PolyOffsetParameters2D> &p_parameters) {
+	ERR_FAIL_COND_V(p_delta < 0, Vector<Vector<Point2>>());
+	backend->set_parameters(p_parameters);
+	backend->get_parameters()->end_type = PolyOffsetParameters2D::END_POLYGON;
+	return backend->offset_polypaths(p_polygons, -p_delta);
+}
+
+Vector<Vector<Point2>> PolyOffset2D::deflate_polygons(const Vector<Vector<Point2>> &p_polygons, real_t p_delta, const Ref<PolyOffsetParameters2D> &p_parameters) {
+	ERR_FAIL_COND_V(p_delta < 0, Vector<Vector<Point2>>());
+	backend->set_parameters(p_parameters);
+	backend->get_parameters()->end_type = PolyOffsetParameters2D::END_POLYGON;
+	return backend->offset_polypaths(p_polygons, p_delta);
+}
+
+Vector<Vector<Point2>> PolyOffset2D::deflate_polylines(const Vector<Vector<Point2>> &p_polylines, real_t p_delta, const Ref<PolyOffsetParameters2D> &p_parameters) {
+	ERR_FAIL_COND_V(p_delta < 0, Vector<Vector<Point2>>());
+	backend->set_parameters(p_parameters);
+	if (backend->get_parameters()->end_type == PolyOffsetParameters2D::END_POLYGON) {
+		WARN_PRINT_ONCE("END_POLYGON does not apply for polyline deflating, fallback to END_JOINED.");
+		backend->get_parameters()->end_type = PolyOffsetParameters2D::END_JOINED;
+	}
+	return backend->offset_polypaths(p_polylines, p_delta);
+}
+
+// BIND
+
+_PolyOffset2D *_PolyOffset2D::singleton = nullptr;
+
+Array _PolyOffset2D::inflate_polygons(Array p_polygons, real_t p_delta) const {
+	Vector<Vector<Point2>> polygons;
+	for (int i = 0; i < p_polygons.size(); i++) {
+		polygons.push_back(p_polygons[i]);
+	}
+	const auto &params = singleton == this ? Ref<PolyOffsetParameters2D>() : parameters;
+	Vector<Vector<Vector2>> solution = PolyOffset2D::inflate_polygons(polygons, p_delta, params);
+	Array ret;
+	for (int i = 0; i < solution.size(); ++i) {
+		ret.push_back(solution[i]);
+	}
+	return ret;
+}
+
+Array _PolyOffset2D::deflate_polygons(Array p_polygons, real_t p_delta) const {
+	Vector<Vector<Point2>> polygons;
+	for (int i = 0; i < p_polygons.size(); i++) {
+		polygons.push_back(p_polygons[i]);
+	}
+	const auto &params = singleton == this ? Ref<PolyOffsetParameters2D>() : parameters;
+	Vector<Vector<Vector2>> solution = PolyOffset2D::deflate_polygons(polygons, p_delta, params);
+	Array ret;
+	for (int i = 0; i < solution.size(); ++i) {
+		ret.push_back(solution[i]);
+	}
+	return ret;
+}
+
+Array _PolyOffset2D::deflate_polylines(Array p_polylines, real_t p_delta) const {
+	Vector<Vector<Point2>> polylines;
+	for (int i = 0; i < p_polylines.size(); i++) {
+		polylines.push_back(p_polylines[i]);
+	}
+	const auto &params = singleton == this ? Ref<PolyOffsetParameters2D>() : parameters;
+	Vector<Vector<Vector2>> solution = PolyOffset2D::deflate_polylines(polylines, p_delta, params);
+	Array ret;
+	for (int i = 0; i < solution.size(); ++i) {
+		ret.push_back(solution[i]);
+	}
+	return ret;
+}
+
+void _PolyOffset2D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_parameters", "parameters"), &_PolyOffset2D::set_parameters);
+	ClassDB::bind_method(D_METHOD("get_parameters"), &_PolyOffset2D::get_parameters);
+
+	ClassDB::bind_method(D_METHOD("inflate_polygons", "polygons", "delta"), &_PolyOffset2D::inflate_polygons);
+	ClassDB::bind_method(D_METHOD("deflate_polygons", "polygons", "delta"), &_PolyOffset2D::deflate_polygons);
+	ClassDB::bind_method(D_METHOD("deflate_polylines", "polylines", "delta"), &_PolyOffset2D::deflate_polylines);
+
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "parameters"), "set_parameters", "get_parameters");
+}
+
 void PolyOffsetParameters2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_join_type", "join_type"), &PolyOffsetParameters2D::set_join_type);
 	ClassDB::bind_method(D_METHOD("get_join_type"), &PolyOffsetParameters2D::get_join_type);

--- a/core/math/2d/geometry/poly/offset/poly_offset.h
+++ b/core/math/2d/geometry/poly/offset/poly_offset.h
@@ -51,9 +51,10 @@ protected:
 
 public:
 	static _PolyOffset2D *get_singleton() { return singleton; }
+	virtual Ref<_PolyOffset2D> new_instance() const { return memnew(_PolyOffset2D); }
 
-	void set_parameters(const Ref<PolyOffsetParameters2D> &p_parameters) { parameters = p_parameters; }
-	Ref<PolyOffsetParameters2D> get_parameters() const { return parameters; }
+	void set_parameters(const Ref<PolyOffsetParameters2D> &p_parameters);
+	Ref<PolyOffsetParameters2D> get_parameters() const;
 
 	Array inflate_polygons(Array p_polygons, real_t p_delta) const;
 	Array deflate_polygons(Array p_polygons, real_t p_delta) const;

--- a/core/math/2d/geometry/poly/offset/poly_offset.h
+++ b/core/math/2d/geometry/poly/offset/poly_offset.h
@@ -51,7 +51,8 @@ protected:
 
 public:
 	static _PolyOffset2D *get_singleton() { return singleton; }
-	virtual Ref<_PolyOffset2D> new_instance() const { return memnew(_PolyOffset2D); }
+	// Not using Ref<_PolyOffset2D> as return type due to namespace issues in Godot.
+	virtual Ref<Reference> new_instance() const { return memnew(_PolyOffset2D); }
 
 	void set_parameters(const Ref<PolyOffsetParameters2D> &p_parameters);
 	Ref<PolyOffsetParameters2D> get_parameters() const;

--- a/core/math/2d/geometry/poly/offset/poly_offset.h
+++ b/core/math/2d/geometry/poly/offset/poly_offset.h
@@ -60,7 +60,7 @@ public:
 	Array deflate_polygons(Array p_polygons, real_t p_delta) const;
 	Array deflate_polylines(Array p_polylines, real_t p_delta) const;
 
-	_PolyOffset2D::_PolyOffset2D() {
+	_PolyOffset2D() {
 		if (!singleton) {
 			singleton = this;
 		}

--- a/core/math/2d/geometry/poly/poly_backends.cpp
+++ b/core/math/2d/geometry/poly/poly_backends.cpp
@@ -1,0 +1,5 @@
+#include "poly_backends.h"
+
+PolyBackend2DManager<PolyBoolean2DBackend *> PolyBackends2D::poly_boolean = PolyBackend2DManager<PolyBoolean2DBackend *>();
+PolyBackend2DManager<PolyOffset2DBackend *> PolyBackends2D::poly_offset = PolyBackend2DManager<PolyOffset2DBackend *>();
+PolyBackend2DManager<PolyDecomp2DBackend *> PolyBackends2D::poly_decomp = PolyBackend2DManager<PolyDecomp2DBackend *>();

--- a/core/math/2d/geometry/poly/poly_backends.h
+++ b/core/math/2d/geometry/poly/poly_backends.h
@@ -1,0 +1,151 @@
+#ifndef GOOST_POLY_BACKENDS_2D_H
+#define GOOST_POLY_BACKENDS_2D_H
+
+#include "core/project_settings.h"
+
+#include "boolean/poly_boolean.h"
+#include "decomp/poly_decomp.h"
+#include "offset/poly_offset.h"
+
+#include "boolean/clipper10/poly_boolean_clipper10.h"
+#include "boolean/clipper6/poly_boolean_clipper6.h"
+#include "decomp/clipper10/poly_decomp_clipper10.h"
+#include "decomp/polypartition/poly_decomp_polypartition.h"
+#include "offset/clipper10/poly_offset_clipper10.h"
+#include "offset/clipper6/poly_offset_clipper6.h"
+
+template <class T>
+class PolyBackend2DManager {
+	struct Backend {
+		String name = "";
+		T instance = nullptr;
+
+		Backend() :
+				name(""),
+				instance(nullptr) {}
+
+		Backend(String p_name, T p_instance) :
+				name(p_name),
+				instance(p_instance) {}
+	};
+
+	Vector<Backend> backends;
+	int default_backend_id = -1;
+	String default_backend_name;
+
+public:
+	String setting_name;
+
+public:
+	void register_backend(const String &p_name, T p_instance, bool p_default = false) {
+		backends.push_back(Backend(p_name, p_instance));
+		if (p_default) {
+			set_default_backend(p_name);
+		}
+	}
+	void set_default_backend(const String &p_name) {
+		default_backend_name = p_name;
+		default_backend_id = find_backend_id(p_name);
+	}
+
+	T get_default_backend_instance() const {
+		if (default_backend_id != -1) {
+			return backends[default_backend_id].instance;
+		}
+		return nullptr;
+	}
+
+	int find_backend_id(const String &p_name) const {
+		for (int i = 0; i < backends.size(); ++i) {
+			if (p_name == backends[i].name) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	T get_backend_instance(const String &p_name) const {
+		int id = find_backend_id(p_name);
+		if (id != -1) {
+			return backends[id].instance;
+		}
+		return nullptr;
+	}
+
+	int get_backends_count() const { return backends.size(); }
+
+	String get_backend_name(int p_id) const {
+		CRASH_BAD_INDEX(p_id, backends.size());
+		return backends[p_id].name;
+	}
+
+	String update() {
+		String backends_list;
+
+		for (int i = 0; i < get_backends_count(); ++i) {
+			backends_list += get_backend_name(i);
+			if (i < get_backends_count() - 1) {
+				backends_list += ",";
+			}
+		}
+		T default_backend = get_default_backend_instance();
+		if (default_backend) {
+			// Suggest restart because the singleton can also be used in extension mode.
+			GLOBAL_DEF_RST(setting_name, default_backend_name);
+		}
+		if (!backends_list.empty()) {
+			ProjectSettings::get_singleton()->set_custom_property_info(
+					setting_name,
+					PropertyInfo(Variant::STRING, setting_name, PROPERTY_HINT_ENUM, backends_list));
+		}
+		return ProjectSettings::get_singleton()->has_setting(setting_name) ? GLOBAL_GET(setting_name) : "";
+	}
+
+	void finalize() {
+		for (int i = 0; i < backends.size(); ++i) {
+			if (backends[i].instance) {
+				memdelete(backends[i].instance);
+			}
+		}
+	}
+};
+
+class PolyBackends2D {
+public:
+	static PolyBackend2DManager<PolyBoolean2DBackend *> poly_boolean;
+	static PolyBackend2DManager<PolyOffset2DBackend *> poly_offset;
+	static PolyBackend2DManager<PolyDecomp2DBackend *> poly_decomp;
+
+	static void initialize() {
+		poly_boolean.setting_name = "goost/geometry/2d/backends/poly_boolean";
+		poly_boolean.register_backend("clipper6", memnew(PolyBoolean2DClipper6), true);
+		poly_boolean.register_backend("clipper10", memnew(PolyBoolean2DClipper10));
+
+		poly_offset.setting_name = "goost/geometry/2d/backends/poly_offset";
+		poly_offset.register_backend("clipper6", memnew(PolyOffset2DClipper6), true);
+		poly_offset.register_backend("clipper10", memnew(PolyOffset2DClipper10));
+
+		poly_decomp.setting_name = "goost/geometry/2d/backends/poly_decomp";
+		poly_decomp.register_backend("polypartition", memnew(PolyDecomp2DPolyPartition));
+		poly_decomp.register_backend("clipper10:polypartition", memnew(PolyDecomp2DClipper10), true);
+		
+		update();
+	}
+
+	static void update() {
+		String selected;
+		selected = poly_boolean.update();
+		PolyBoolean2D::set_backend(poly_boolean.get_backend_instance(selected));
+		selected = poly_offset.update();
+		PolyOffset2D::set_backend(poly_offset.get_backend_instance(selected));
+		selected = poly_decomp.update();
+		PolyDecomp2D::set_backend(poly_decomp.get_backend_instance(selected));
+	}
+	static void finalize() {
+		poly_boolean.finalize();
+		poly_offset.finalize();
+		poly_decomp.finalize();
+	}
+};
+
+#endif // GOOST_POLY_BACKENDS_2D_H

--- a/core/math/register_math_types.cpp
+++ b/core/math/register_math_types.cpp
@@ -2,14 +2,23 @@
 
 #include "core/engine.h"
 
-#include "2d/geometry/goost_geometry_2d.h"
-#include "2d/geometry/goost_geometry_2d_bind.h"
 #include "2d/random_2d.h"
 #include "random.h"
 
+#include "2d/geometry/goost_geometry_2d.h"
+#include "2d/geometry/goost_geometry_2d_bind.h"
+#include "2d/geometry/poly/boolean/poly_boolean.h"
+#include "2d/geometry/poly/decomp/poly_decomp.h"
+#include "2d/geometry/poly/offset/poly_offset.h"
+#include "2d/geometry/poly/poly_backends.h"
+
 static Ref<Random> _random;
 static Ref<Random2D> _random_2d;
+
 static _GoostGeometry2D *_goost_geometry_2d = nullptr;
+static Ref<_PolyBoolean2D> _poly_boolean_2d;
+static Ref<_PolyOffset2D> _poly_offset_2d;
+static Ref<_PolyDecomp2D> _poly_decomp_2d;
 
 namespace goost {
 
@@ -24,24 +33,49 @@ void register_math_types() {
 	Object *random_2d = Object::cast_to<Object>(Random2D::get_singleton());
 	Engine::get_singleton()->add_singleton(Engine::Singleton("Random2D", random_2d));
 
+	// GoostGeometry2D
 	_goost_geometry_2d = memnew(_GoostGeometry2D);
-	GoostGeometry2D::initialize();
-
 	ClassDB::register_class<_GoostGeometry2D>();
 	Engine::get_singleton()->add_singleton(Engine::Singleton("GoostGeometry2D", _GoostGeometry2D::get_singleton()));
+	
+	PolyBackends2D::initialize();
+
+	// PolyBoolean2D
+	_poly_boolean_2d.instance();
+	ClassDB::register_class<_PolyBoolean2D>();
+	Object *poly_boolean_2d = Object::cast_to<Object>(_PolyBoolean2D::get_singleton());
+	Engine::get_singleton()->add_singleton(Engine::Singleton("PolyBoolean2D", poly_boolean_2d));
 
 	ClassDB::register_class<PolyBooleanParameters2D>();
-	ClassDB::register_class<PolyOffsetParameters2D>();
-	ClassDB::register_class<PolyDecompParameters2D>();
-
 	ClassDB::register_class<PolyNode2D>();
+
+	// PolyOffset2D
+	_poly_offset_2d.instance();
+	ClassDB::register_class<_PolyOffset2D>();
+	Object *poly_offset_2d = Object::cast_to<Object>(_PolyOffset2D::get_singleton());
+	Engine::get_singleton()->add_singleton(Engine::Singleton("PolyOffset2D", poly_offset_2d));
+
+	ClassDB::register_class<PolyOffsetParameters2D>();
+
+	// PolyOffset2D
+	_poly_decomp_2d.instance();
+	ClassDB::register_class<_PolyDecomp2D>();
+	Object *poly_decomp_2d = Object::cast_to<Object>(_PolyDecomp2D::get_singleton());
+	Engine::get_singleton()->add_singleton(Engine::Singleton("PolyDecomp2D", poly_decomp_2d));
+
+	ClassDB::register_class<PolyDecompParameters2D>();
 }
 
 void unregister_math_types() {
 	_random.unref();
 	_random_2d.unref();
+
 	memdelete(_goost_geometry_2d);
-	GoostGeometry2D::finalize();
+	PolyBackends2D::finalize();
+
+	_poly_boolean_2d.unref();
+	_poly_offset_2d.unref();
+	_poly_decomp_2d.unref();
 }
 
 } // namespace goost

--- a/doc/GoostGeometry2D.xml
+++ b/doc/GoostGeometry2D.xml
@@ -4,7 +4,8 @@
 		[Geometry] singleton extension.
 	</brief_description>
 	<description>
-		Performs polygon clipping, offsetting and decomposition, and other geometry utility operations mostly revolving around polygons and polylines.
+		Performs various geometry-related operations. Provides simple polygon clipping, offsetting and decomposition functionality, and other geometry utility operations mostly revolving around polygons and polylines.
+		The methods for polygon operations in this class operate on single polygons only. For more advanced operations on multiple polygons, refer to [PolyBoolean2D], [PolyOffset2D], [PolyDecomp2D] classes instead.
 	</description>
 	<tutorials>
 		<link>https://goost.readthedocs.io/en/gd3/components/geometry.html</link>
@@ -22,32 +23,6 @@
 				The [code]max_error[/code] parameter represents the maximum gap in pixels allowed between a circle segment and the boundary of the mathematical circle, with low values increasing the number of vertices. The maximum number of vertices returned is 4096. See also [method regular_polygon].
 			</description>
 		</method>
-		<method name="clip_multiple_polygons" qualifiers="const">
-			<return type="Array">
-			</return>
-			<argument index="0" name="polygons_a" type="Array">
-			</argument>
-			<argument index="1" name="polygons_b" type="Array">
-			</argument>
-			<argument index="2" name="params" type="PolyBooleanParameters2D" default="null">
-			</argument>
-			<description>
-				Similar to [method boolean_polygons], but performs [constant OPERATION_DIFFERENCE] between the polygons specifically.
-			</description>
-		</method>
-		<method name="clip_multiple_polylines_with_polygons" qualifiers="const">
-			<return type="Array">
-			</return>
-			<argument index="0" name="polylines" type="Array">
-			</argument>
-			<argument index="1" name="polygons" type="Array">
-			</argument>
-			<argument index="2" name="params" type="PolyBooleanParameters2D" default="null">
-			</argument>
-			<description>
-				Similar to [method clip_polyline_with_polygon], but operates on multiple polylines in batch.
-			</description>
-		</method>
 		<method name="clip_polygons" qualifiers="const">
 			<return type="Array">
 			</return>
@@ -55,10 +30,8 @@
 			</argument>
 			<argument index="1" name="polygon_b" type="PoolVector2Array">
 			</argument>
-			<argument index="2" name="params" type="PolyBooleanParameters2D" default="null">
-			</argument>
 			<description>
-				Similar to [method boolean_polygons], but performs [constant OPERATION_DIFFERENCE] between the polygons specifically, and accepts individual polygons only.
+				Performs [constant PolyBoolean2D.OPERATION_DIFFERENCE] between individual polygons.
 			</description>
 		</method>
 		<method name="clip_polyline_with_polygon" qualifiers="const">
@@ -68,73 +41,17 @@
 			</argument>
 			<argument index="1" name="polygon" type="PoolVector2Array">
 			</argument>
-			<argument index="2" name="params" type="PolyBooleanParameters2D" default="null">
-			</argument>
 			<description>
-				Clips a single [code]polyline[/code] against a single [code]polygon[/code] and returns an array of clipped polylines. This performs [constant OPERATION_DIFFERENCE] between the polyline and the polygon. Returns an empty array if the [code]polygon[/code] completely encloses [code]polyline[/code]. This operation can be thought of as cutting a line with a closed shape.
+				Clips a single [code]polyline[/code] against a single [code]polygon[/code] and returns an array of clipped polylines. This performs [constant PolyBoolean2D.OPERATION_DIFFERENCE] between the polyline and the polygon. Returns an empty array if the [code]polygon[/code] completely encloses [code]polyline[/code]. This operation can be thought of as cutting a line with a closed shape.
 			</description>
 		</method>
-		<method name="decompose_multiple_polygons_into_convex" qualifiers="const">
-			<return type="Array">
-			</return>
-			<argument index="0" name="polygon" type="Array">
-			</argument>
-			<argument index="1" name="params" type="PolyDecompParameters2D" default="null">
-			</argument>
-			<description>
-				Similar to [method decompose_polygons], but partitions multiple polygons with the [constant DECOMP_CONVEX_HM].
-			</description>
-		</method>
-		<method name="decompose_polygon_into_convex" qualifiers="const">
+		<method name="decompose_polygon" qualifiers="const">
 			<return type="Array">
 			</return>
 			<argument index="0" name="polygon" type="PoolVector2Array">
 			</argument>
-			<argument index="1" name="params" type="PolyDecompParameters2D" default="null">
-			</argument>
 			<description>
-				Similar to [method decompose_polygons], but partitions a single polygon with the [constant DECOMP_CONVEX_HM].
-			</description>
-		</method>
-		<method name="decompose_polygons" qualifiers="const">
-			<return type="Array">
-			</return>
-			<argument index="0" name="type" type="int" enum="GoostGeometry2D.PolyDecompType">
-			</argument>
-			<argument index="1" name="polygons" type="Array">
-			</argument>
-			<argument index="2" name="params" type="PolyDecompParameters2D" default="null">
-			</argument>
-			<description>
-				Partitions polygons into several other convex polygons. The exact algorithm used depends on the type from [enum PolyDecompType].
-				Both outer and inner polygons can be passed to cut holes during decomposition and are distinguished automatically, with potential performance cost.
-				[b]Note:[/b] [constant DECOMP_TRIANGLES_OPT] and [constant DECOMP_TRIANGLES_OPT] do not support partitioning of a polygon with holes.
-			</description>
-		</method>
-		<method name="deflate_multiple_polygons" qualifiers="const">
-			<return type="Array">
-			</return>
-			<argument index="0" name="polygons" type="Array">
-			</argument>
-			<argument index="1" name="delta" type="float">
-			</argument>
-			<argument index="2" name="params" type="PolyOffsetParameters2D" default="null">
-			</argument>
-			<description>
-				Similar to [method offset_multiple_polygons], but allows to grow polygons by the absolute value of [code]delta[/code].
-			</description>
-		</method>
-		<method name="deflate_multiple_polylines" qualifiers="const">
-			<return type="Array">
-			</return>
-			<argument index="0" name="polylines" type="Array">
-			</argument>
-			<argument index="1" name="delta" type="float">
-			</argument>
-			<argument index="2" name="params" type="PolyOffsetParameters2D" default="null">
-			</argument>
-			<description>
-				Similar to [method deflate_polyline], but operates on multiple polylines simultaneously.
+				Partitions a single polygon into a set of convex polygons with [constant PolyDecomp2D.DECOMP_CONVEX_HM].
 			</description>
 		</method>
 		<method name="deflate_polygon" qualifiers="const">
@@ -144,11 +61,8 @@
 			</argument>
 			<argument index="1" name="delta" type="float">
 			</argument>
-			<argument index="2" name="params" type="PolyOffsetParameters2D" default="null">
-			</argument>
 			<description>
-				Deflates (grows) a single [code]polygon[/code] by [code]delta[/code] pixels.
-				Each polygon's vertices will be rounded as determined by [member PolyOffsetParameters2D.join_type].
+				Grows a polygon by [code]delta[/code] pixels. See also [method PolyOffset2D.deflate_polygons].
 			</description>
 		</method>
 		<method name="deflate_polyline" qualifiers="const">
@@ -158,25 +72,8 @@
 			</argument>
 			<argument index="1" name="delta" type="float">
 			</argument>
-			<argument index="2" name="params" type="PolyOffsetParameters2D" default="null">
-			</argument>
 			<description>
-				Deflates (grows) [code]polylines[/code] into polygons by [code]delta[/code] pixels.
-				Each polygon's vertices will be rounded as determined by [member PolyOffsetParameters2D.join_type].
-				Each polygon's endpoints will be rounded as determined by [member PolyOffsetParameters2D.end_type], except for the [constant PolyOffsetParameters2D.END_POLYGON] as it's used by polygon offsetting specifically, use [constant PolyOffsetParameters2D.END_JOINED] to grow a polyline like a closed donut instead.
-			</description>
-		</method>
-		<method name="exclude_multiple_polygons" qualifiers="const">
-			<return type="Array">
-			</return>
-			<argument index="0" name="polygons_a" type="Array">
-			</argument>
-			<argument index="1" name="polygons_b" type="Array">
-			</argument>
-			<argument index="2" name="params" type="PolyBooleanParameters2D" default="null">
-			</argument>
-			<description>
-				Similar to [method boolean_polygons], but performs [constant OPERATION_XOR] between the polygons specifically.
+				Grows a single non-closed path into a polygon by [code]delta[/code] pixels. See also [method PolyOffset2D.deflate_polylines].
 			</description>
 		</method>
 		<method name="exclude_polygons" qualifiers="const">
@@ -186,23 +83,8 @@
 			</argument>
 			<argument index="1" name="polygon_b" type="PoolVector2Array">
 			</argument>
-			<argument index="2" name="params" type="PolyBooleanParameters2D" default="null">
-			</argument>
 			<description>
-				Similar to [method boolean_polygons], but performs [constant OPERATION_XOR] between the polygons specifically, and accepts individual polygons only.
-			</description>
-		</method>
-		<method name="inflate_multiple_polygons" qualifiers="const">
-			<return type="Array">
-			</return>
-			<argument index="0" name="polygons" type="Array">
-			</argument>
-			<argument index="1" name="delta" type="float">
-			</argument>
-			<argument index="2" name="params" type="PolyOffsetParameters2D" default="null">
-			</argument>
-			<description>
-				Similar to [method offset_multiple_polygons], but allows to shrink polygons by the absolute value of [code]delta[/code].
+				Performs [constant PolyBoolean2D.OPERATION_XOR] between individual polygons.
 			</description>
 		</method>
 		<method name="inflate_polygon" qualifiers="const">
@@ -212,36 +94,8 @@
 			</argument>
 			<argument index="1" name="delta" type="float">
 			</argument>
-			<argument index="2" name="params" type="PolyOffsetParameters2D" default="null">
-			</argument>
 			<description>
-				Similar to [method offset_polygon], but allows to shrink a single polygon by the absolute value of [code]delta[/code].
-			</description>
-		</method>
-		<method name="intersect_multiple_polygons" qualifiers="const">
-			<return type="Array">
-			</return>
-			<argument index="0" name="polygons_a" type="Array">
-			</argument>
-			<argument index="1" name="polygons_b" type="Array">
-			</argument>
-			<argument index="2" name="params" type="PolyBooleanParameters2D" default="null">
-			</argument>
-			<description>
-				Similar to [method boolean_polygons], but performs [constant OPERATION_INTERSECTION] between the polygons specifically.
-			</description>
-		</method>
-		<method name="intersect_multiple_polylines_with_polygons" qualifiers="const">
-			<return type="Array">
-			</return>
-			<argument index="0" name="polylines" type="Array">
-			</argument>
-			<argument index="1" name="polygons" type="Array">
-			</argument>
-			<argument index="2" name="params" type="PolyBooleanParameters2D" default="null">
-			</argument>
-			<description>
-				Similar to [method intersect_polyline_with_polygon], but operates on multiple polylines in batch.
+				Shrinks a polygon by [code]delta[/code] pixels. See also [method PolyOffset2D.inflate_polygons].
 			</description>
 		</method>
 		<method name="intersect_polygons" qualifiers="const">
@@ -251,10 +105,8 @@
 			</argument>
 			<argument index="1" name="polygon_b" type="PoolVector2Array">
 			</argument>
-			<argument index="2" name="params" type="PolyBooleanParameters2D" default="null">
-			</argument>
 			<description>
-				Similar to [method boolean_polygons], but performs [constant OPERATION_INTERSECTION] between the polygons specifically, and accepts individual polygons only.
+				Performs [constant PolyBoolean2D.OPERATION_INTERSECTION] between individual polygons.
 			</description>
 		</method>
 		<method name="intersect_polyline_with_polygon" qualifiers="const">
@@ -264,23 +116,8 @@
 			</argument>
 			<argument index="1" name="polygon" type="PoolVector2Array">
 			</argument>
-			<argument index="2" name="params" type="PolyBooleanParameters2D" default="null">
-			</argument>
 			<description>
-				Intersects polyline with polygon and returns an array of intersected polylines. This performs OPERATION_INTERSECTION between the polyline and the polygon. This operation can be thought of as chopping a line with a closed shape.
-			</description>
-		</method>
-		<method name="merge_multiple_polygons" qualifiers="const">
-			<return type="Array">
-			</return>
-			<argument index="0" name="polygons_a" type="Array">
-			</argument>
-			<argument index="1" name="polygons_b" type="Array" default="null">
-			</argument>
-			<argument index="2" name="params" type="PolyBooleanParameters2D" default="null">
-			</argument>
-			<description>
-				Similar to [method boolean_polygons], but performs [constant OPERATION_UNION] between the polygons specifically.
+				Intersects polyline with polygon and returns an array of intersected polylines. This performs [constant PolyBoolean2D.OPERATION_INTERSECTION] between the polyline and the polygon. This operation can be thought of as chopping a line with a closed shape.
 			</description>
 		</method>
 		<method name="merge_polygons" qualifiers="const">
@@ -290,38 +127,8 @@
 			</argument>
 			<argument index="1" name="polygon_b" type="PoolVector2Array">
 			</argument>
-			<argument index="2" name="params" type="PolyBooleanParameters2D" default="null">
-			</argument>
 			<description>
-				Similar to [method boolean_polygons], but performs [constant OPERATION_UNION] between the polygons specifically, and accepts individual polygons only.
-			</description>
-		</method>
-		<method name="offset_multiple_polygons" qualifiers="const">
-			<return type="Array">
-			</return>
-			<argument index="0" name="polygons" type="Array">
-			</argument>
-			<argument index="1" name="delta" type="float">
-			</argument>
-			<argument index="2" name="params" type="PolyOffsetParameters2D" default="null">
-			</argument>
-			<description>
-				Inflates or deflates an array of [code]polygons[/code] by [code]delta[/code] pixels. If [code]delta[/code] is positive, makes the polygons grow outward. If [code]delta[/code] is negative, shrinks the polygons inward. Returns an empty array if [code]delta[/code] is negative and the absolute value of it approximately exceeds the minimum bounding rectangle dimensions of each of the polygons.
-				Each polygon's vertices will be rounded as determined by [member PolyOffsetParameters2D.join_type].
-			</description>
-		</method>
-		<method name="offset_polygon" qualifiers="const">
-			<return type="Array">
-			</return>
-			<argument index="0" name="polygon" type="PoolVector2Array">
-			</argument>
-			<argument index="1" name="delta" type="float">
-			</argument>
-			<argument index="2" name="params" type="PolyOffsetParameters2D" default="null">
-			</argument>
-			<description>
-				Inflates or deflates a single [code]polygon[/code] by [code]delta[/code] pixels. If [code]delta[/code] is positive, makes the polygon grow outward. If [code]delta[/code] is negative, shrinks the polygon inward. Returns an empty array if [code]delta[/code] is negative and the absolute value of it approximately exceeds the minimum bounding rectangle dimensions of the polygon.
-				Each polygon's vertices will be rounded as determined by [member PolyOffsetParameters2D.join_type].
+				Performs [constant PolyBoolean2D.OPERATION_UNION] between individual polygons. If you need to merge multiple polygons, use [method PolyBoolean2D.merge_polygons] instead.
 			</description>
 		</method>
 		<method name="point_in_polygon" qualifiers="const">
@@ -362,52 +169,6 @@
 				Returns the perimeter of an arbitrary polygon. See also [method polyline_length].
 			</description>
 		</method>
-		<method name="boolean_polygons" qualifiers="const">
-			<return type="Array">
-			</return>
-			<argument index="0" name="operation" type="int" enum="GoostGeometry2D.PolyBooleanOperation">
-			</argument>
-			<argument index="1" name="polygons_a" type="Array">
-			</argument>
-			<argument index="2" name="polygons_b" type="Array" default="null">
-			</argument>
-			<argument index="3" name="params" type="PolyBooleanParameters2D" default="null">
-			</argument>
-			<description>
-				Performs a boolean operation between an array of polygons, with the [code]polygons_a[/code] acting as the [i]subject[/i] of the operation. Returns an array of resulting polygons with vertices in either clockwise or counterclockwise order, which determines whether a polygon is an outer polygon (boundary) or an inner polygon (hole). The orientation of returned polygons can be checked with [method Geometry.is_polygon_clockwise]. If you need to retain the hierarchy of nested outer and inner polygons, use [method boolean_polygons_tree] instead.
-				[b]Operations:[/b]
-				[constant OPERATION_UNION]:
-				Merges polygons into one if they overlap in any way. Passing [code]polygons_b[/code] is optional in this case, but you can specify a different [member PolyBooleanParameters2D.clip_fill_rule] for these polygons, producing different results.
-				This operation can also be used to convert arbitrary polygons into strictly simple ones (no self-intersections):
-				[codeblock]
-				var params = PolyBooleanParameters2D.new()
-				# May not be required on some backends, but provides an explicit intention.
-				params.strictly_simple = true
-				var solution = GoostGeometry2D.boolean_polygons(GoostGeometry2D.OPERATION_UNION, polygons, params)
-				[/codeblock]
-				[constant OPERATION_DIFFERENCE]:
-				Clips polygons, the [i]subject[/i] remains intact if neither polygons overlap. Returns an empty array if [code]polygons_b[/code] completely covers [code]polygons_a[/code]. If [code]polygons_b[/code] are enclosed by [code]polygons_a[/code], returns an array of boundary and hole polygons.
-				[constant OPERATION_INTERSECTION]:
-				Intersects polygons, effectively returning the common area shared by these polygons. Returns an empty array if no intersection occurs.
-				[constant OPERATION_XOR]:
-				Mutually excludes common area defined by the intersection of the polygons. In other words, returns all but common area between the polygons.
-			</description>
-		</method>
-		<method name="boolean_polygons_tree" qualifiers="const">
-			<return type="PolyNode2D">
-			</return>
-			<argument index="0" name="operation" type="int" enum="GoostGeometry2D.PolyBooleanOperation">
-			</argument>
-			<argument index="1" name="polygons_a" type="Array">
-			</argument>
-			<argument index="2" name="polygons_b" type="Array" default="null">
-			</argument>
-			<argument index="3" name="params" type="PolyBooleanParameters2D" default="null">
-			</argument>
-			<description>
-				Similar to [method boolean_polygons], but builds an hierarchy of clipped polygons and returns a top-level root node representing the tree of polygons, which has some performance cost. Whether a polygon is an outer or an inner path can be checked with [method PolyNode2D.is_hole] more easily and effectively compared to calculating polygon area to determine orientation, see [method polygon_area].
-			</description>
-		</method>
 		<method name="polyline_length" qualifiers="const">
 			<return type="float">
 			</return>
@@ -429,64 +190,16 @@
 				The order of vertices returned is counterclockwise which makes it an outer polygon by default. To convert it to an inner polygon specifically, use [method PoolVector2Array.invert].
 			</description>
 		</method>
-		<method name="triangulate_multiple_polygons" qualifiers="const">
-			<return type="Array">
-			</return>
-			<argument index="0" name="polygon" type="Array">
-			</argument>
-			<argument index="1" name="params" type="PolyDecompParameters2D" default="null">
-			</argument>
-			<description>
-				Similar to [method decompose_polygons], but triangulates multiple polygons with the [constant DECOMP_TRIANGLES_EC].
-			</description>
-		</method>
 		<method name="triangulate_polygon" qualifiers="const">
 			<return type="Array">
 			</return>
 			<argument index="0" name="polygon" type="PoolVector2Array">
 			</argument>
-			<argument index="1" name="params" type="PolyDecompParameters2D" default="null">
-			</argument>
 			<description>
-				Similar to [method decompose_polygons], but triangulates a single polygon with the [constant DECOMP_TRIANGLES_EC].
+				Decomposes the polygon into individual triangles using [constant PolyDecomp2D.DECOMP_TRIANGLES_MONO].
 			</description>
 		</method>
 	</methods>
 	<constants>
-		<constant name="OPERATION_NONE" value="0" enum="PolyBooleanOperation">
-			No-op, but may perform polygons fixup, build hierarchy, depending on the poly_boolean implementation.
-		</constant>
-		<constant name="OPERATION_UNION" value="1" enum="PolyBooleanOperation">
-			Merge (combine) polygons.
-		</constant>
-		<constant name="OPERATION_DIFFERENCE" value="2" enum="PolyBooleanOperation">
-			Clip (cut) polygons or polylines.
-		</constant>
-		<constant name="OPERATION_INTERSECTION" value="3" enum="PolyBooleanOperation">
-			Intersect polygons or polylines.
-		</constant>
-		<constant name="OPERATION_XOR" value="4" enum="PolyBooleanOperation">
-			Mutually exclude polygons.
-		</constant>
-		<constant name="DECOMP_TRIANGLES_EC" value="0" enum="PolyDecompType">
-			Triangulate a polygon using the ear clipping algorithm.
-			Time/Space complexity: O(n^2)/O(n).
-		</constant>
-		<constant name="DECOMP_TRIANGLES_OPT" value="1" enum="PolyDecompType">
-			Optimal triangulation in terms of edge length using dynamic programming algorithm.
-			Time/Space complexity: O(n^3)/O(n^2).
-		</constant>
-		<constant name="DECOMP_TRIANGLES_MONO" value="2" enum="PolyDecompType">
-			Partition the polygon into monotone polygons, then triangulate.
-			Time/Space complexity: O(n*log(n))/O(n).
-		</constant>
-		<constant name="DECOMP_CONVEX_HM" value="3" enum="PolyDecompType">
-			Convex polygon partitioning using Hertel-Mehlhorn algorithm.
-			Time/Space complexity: O(n^2)/O(n).
-		</constant>
-		<constant name="DECOMP_CONVEX_OPT" value="4" enum="PolyDecompType">
-			Optimal convex partition using dynamic programming algorithm by Keil and Snoeyink.
-			Time/Space complexity: O(n^3)/O(n^3).
-		</constant>
 	</constants>
 </class>

--- a/doc/GoostGeometry2D.xml
+++ b/doc/GoostGeometry2D.xml
@@ -32,7 +32,7 @@
 			<argument index="2" name="params" type="PolyBooleanParameters2D" default="null">
 			</argument>
 			<description>
-				Similar to [method polygons_boolean], but performs [constant OPERATION_DIFFERENCE] between the polygons specifically.
+				Similar to [method boolean_polygons], but performs [constant OPERATION_DIFFERENCE] between the polygons specifically.
 			</description>
 		</method>
 		<method name="clip_multiple_polylines_with_polygons" qualifiers="const">
@@ -58,7 +58,7 @@
 			<argument index="2" name="params" type="PolyBooleanParameters2D" default="null">
 			</argument>
 			<description>
-				Similar to [method polygons_boolean], but performs [constant OPERATION_DIFFERENCE] between the polygons specifically, and accepts individual polygons only.
+				Similar to [method boolean_polygons], but performs [constant OPERATION_DIFFERENCE] between the polygons specifically, and accepts individual polygons only.
 			</description>
 		</method>
 		<method name="clip_polyline_with_polygon" qualifiers="const">
@@ -176,7 +176,7 @@
 			<argument index="2" name="params" type="PolyBooleanParameters2D" default="null">
 			</argument>
 			<description>
-				Similar to [method polygons_boolean], but performs [constant OPERATION_XOR] between the polygons specifically.
+				Similar to [method boolean_polygons], but performs [constant OPERATION_XOR] between the polygons specifically.
 			</description>
 		</method>
 		<method name="exclude_polygons" qualifiers="const">
@@ -189,7 +189,7 @@
 			<argument index="2" name="params" type="PolyBooleanParameters2D" default="null">
 			</argument>
 			<description>
-				Similar to [method polygons_boolean], but performs [constant OPERATION_XOR] between the polygons specifically, and accepts individual polygons only.
+				Similar to [method boolean_polygons], but performs [constant OPERATION_XOR] between the polygons specifically, and accepts individual polygons only.
 			</description>
 		</method>
 		<method name="inflate_multiple_polygons" qualifiers="const">
@@ -228,7 +228,7 @@
 			<argument index="2" name="params" type="PolyBooleanParameters2D" default="null">
 			</argument>
 			<description>
-				Similar to [method polygons_boolean], but performs [constant OPERATION_INTERSECTION] between the polygons specifically.
+				Similar to [method boolean_polygons], but performs [constant OPERATION_INTERSECTION] between the polygons specifically.
 			</description>
 		</method>
 		<method name="intersect_multiple_polylines_with_polygons" qualifiers="const">
@@ -254,7 +254,7 @@
 			<argument index="2" name="params" type="PolyBooleanParameters2D" default="null">
 			</argument>
 			<description>
-				Similar to [method polygons_boolean], but performs [constant OPERATION_INTERSECTION] between the polygons specifically, and accepts individual polygons only.
+				Similar to [method boolean_polygons], but performs [constant OPERATION_INTERSECTION] between the polygons specifically, and accepts individual polygons only.
 			</description>
 		</method>
 		<method name="intersect_polyline_with_polygon" qualifiers="const">
@@ -280,7 +280,7 @@
 			<argument index="2" name="params" type="PolyBooleanParameters2D" default="null">
 			</argument>
 			<description>
-				Similar to [method polygons_boolean], but performs [constant OPERATION_UNION] between the polygons specifically.
+				Similar to [method boolean_polygons], but performs [constant OPERATION_UNION] between the polygons specifically.
 			</description>
 		</method>
 		<method name="merge_polygons" qualifiers="const">
@@ -293,7 +293,7 @@
 			<argument index="2" name="params" type="PolyBooleanParameters2D" default="null">
 			</argument>
 			<description>
-				Similar to [method polygons_boolean], but performs [constant OPERATION_UNION] between the polygons specifically, and accepts individual polygons only.
+				Similar to [method boolean_polygons], but performs [constant OPERATION_UNION] between the polygons specifically, and accepts individual polygons only.
 			</description>
 		</method>
 		<method name="offset_multiple_polygons" qualifiers="const">
@@ -362,7 +362,7 @@
 				Returns the perimeter of an arbitrary polygon. See also [method polyline_length].
 			</description>
 		</method>
-		<method name="polygons_boolean" qualifiers="const">
+		<method name="boolean_polygons" qualifiers="const">
 			<return type="Array">
 			</return>
 			<argument index="0" name="operation" type="int" enum="GoostGeometry2D.PolyBooleanOperation">
@@ -374,7 +374,7 @@
 			<argument index="3" name="params" type="PolyBooleanParameters2D" default="null">
 			</argument>
 			<description>
-				Performs a boolean operation between an array of polygons, with the [code]polygons_a[/code] acting as the [i]subject[/i] of the operation. Returns an array of resulting polygons with vertices in either clockwise or counterclockwise order, which determines whether a polygon is an outer polygon (boundary) or an inner polygon (hole). The orientation of returned polygons can be checked with [method Geometry.is_polygon_clockwise]. If you need to retain the hierarchy of nested outer and inner polygons, use [method polygons_boolean_tree] instead.
+				Performs a boolean operation between an array of polygons, with the [code]polygons_a[/code] acting as the [i]subject[/i] of the operation. Returns an array of resulting polygons with vertices in either clockwise or counterclockwise order, which determines whether a polygon is an outer polygon (boundary) or an inner polygon (hole). The orientation of returned polygons can be checked with [method Geometry.is_polygon_clockwise]. If you need to retain the hierarchy of nested outer and inner polygons, use [method boolean_polygons_tree] instead.
 				[b]Operations:[/b]
 				[constant OPERATION_UNION]:
 				Merges polygons into one if they overlap in any way. Passing [code]polygons_b[/code] is optional in this case, but you can specify a different [member PolyBooleanParameters2D.clip_fill_rule] for these polygons, producing different results.
@@ -383,7 +383,7 @@
 				var params = PolyBooleanParameters2D.new()
 				# May not be required on some backends, but provides an explicit intention.
 				params.strictly_simple = true
-				var solution = GoostGeometry2D.polygons_boolean(GoostGeometry2D.OPERATION_UNION, polygons, params)
+				var solution = GoostGeometry2D.boolean_polygons(GoostGeometry2D.OPERATION_UNION, polygons, params)
 				[/codeblock]
 				[constant OPERATION_DIFFERENCE]:
 				Clips polygons, the [i]subject[/i] remains intact if neither polygons overlap. Returns an empty array if [code]polygons_b[/code] completely covers [code]polygons_a[/code]. If [code]polygons_b[/code] are enclosed by [code]polygons_a[/code], returns an array of boundary and hole polygons.
@@ -393,7 +393,7 @@
 				Mutually excludes common area defined by the intersection of the polygons. In other words, returns all but common area between the polygons.
 			</description>
 		</method>
-		<method name="polygons_boolean_tree" qualifiers="const">
+		<method name="boolean_polygons_tree" qualifiers="const">
 			<return type="PolyNode2D">
 			</return>
 			<argument index="0" name="operation" type="int" enum="GoostGeometry2D.PolyBooleanOperation">
@@ -405,7 +405,7 @@
 			<argument index="3" name="params" type="PolyBooleanParameters2D" default="null">
 			</argument>
 			<description>
-				Similar to [method polygons_boolean], but builds an hierarchy of clipped polygons and returns a top-level root node representing the tree of polygons, which has some performance cost. Whether a polygon is an outer or an inner path can be checked with [method PolyNode2D.is_hole] more easily and effectively compared to calculating polygon area to determine orientation, see [method polygon_area].
+				Similar to [method boolean_polygons], but builds an hierarchy of clipped polygons and returns a top-level root node representing the tree of polygons, which has some performance cost. Whether a polygon is an outer or an inner path can be checked with [method PolyNode2D.is_hole] more easily and effectively compared to calculating polygon area to determine orientation, see [method polygon_area].
 			</description>
 		</method>
 		<method name="polyline_length" qualifiers="const">

--- a/doc/PolyBoolean2D.xml
+++ b/doc/PolyBoolean2D.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="PolyBoolean2D" inherits="Reference" version="3.2">
+	<brief_description>
+		Polygon and polyline boolean operations.
+	</brief_description>
+	<description>
+		A singleton which provides various "polygon vs. polygon" and "polyline vs. polygon" methods.
+		A new local instance must be created manually with [method new_instance] method if you need to override the default [member parameters], else the methods in this class are available globally:
+		[codeblock]
+		var polygons = []
+		# Globally.
+		polygons = PolyBoolean2D.merge_polygons([poly_a, poly_b])
+		# Locally.
+		var pb = PolyBoolean2D.new_instance()
+		pb.parameters.strictly_simple = true
+		polygons = pb.merge_polygons([poly_a, poly_b])
+		[/codeblock]
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="boolean_polygons" qualifiers="const">
+			<return type="Array">
+			</return>
+			<argument index="0" name="polygons_a" type="Array">
+			</argument>
+			<argument index="1" name="polygons_b" type="Array">
+			</argument>
+			<argument index="2" name="operation" type="int" enum="PolyBoolean2D.Operation">
+			</argument>
+			<description>
+				Performs a boolean operation between an array of polygons, with the [code]polygons_a[/code] acting as the [i]subject[/i] of the operation. Returns an array of resulting polygons with vertices in either clockwise or counterclockwise order, which determines whether a polygon is an outer polygon (boundary) or an inner polygon (hole). The orientation of returned polygons can be checked with [method Geometry.is_polygon_clockwise]. If you need to retain the hierarchy of nested outer and inner polygons, use [method boolean_polygons_tree] instead.
+				[b]Operations:[/b]
+				[constant OPERATION_UNION]:
+				Merges polygons into one if they overlap in any way. Passing [code]polygons_b[/code] is optional in this case, but you can specify a different [member PolyBooleanParameters2D.clip_fill_rule] for these polygons, producing different results.
+				This operation can also be used to convert arbitrary polygons into strictly simple ones (no self-intersections).
+				[constant OPERATION_DIFFERENCE]:
+				Clips polygons, the [i]subject[/i] remains intact if neither polygons overlap. Returns an empty array if [code]polygons_b[/code] completely covers [code]polygons_a[/code]. If [code]polygons_b[/code] are enclosed by [code]polygons_a[/code], returns an array of boundary and hole polygons.
+				[constant OPERATION_INTERSECTION]:
+				Intersects polygons, effectively returning the common area shared by these polygons. Returns an empty array if no intersection occurs.
+				[constant OPERATION_XOR]:
+				Mutually excludes common area defined by the intersection of the polygons. In other words, returns all but common area between the polygons.
+			</description>
+		</method>
+		<method name="boolean_polygons_tree" qualifiers="const">
+			<return type="PolyNode2D">
+			</return>
+			<argument index="0" name="polygons_a" type="Array">
+			</argument>
+			<argument index="1" name="polygons_b" type="Array">
+			</argument>
+			<argument index="2" name="operation" type="int" enum="PolyBoolean2D.Operation">
+			</argument>
+			<description>
+				Similar to [method boolean_polygons], but builds an hierarchy of clipped polygons and returns a top-level root node representing the tree of polygons, which has some performance cost. Whether a polygon is an outer or an inner path can be checked with [method PolyNode2D.is_hole] more easily and effectively compared to calculating polygon area to determine orientation, see [method GoostGeometry2D.polygon_area].
+			</description>
+		</method>
+		<method name="clip_polygons" qualifiers="const">
+			<return type="Array">
+			</return>
+			<argument index="0" name="polygons_a" type="Array">
+			</argument>
+			<argument index="1" name="polygons_b" type="Array">
+			</argument>
+			<description>
+				Similar to [method boolean_polygons], but performs [constant OPERATION_DIFFERENCE] between the polygons specifically.
+			</description>
+		</method>
+		<method name="clip_polylines_with_polygons" qualifiers="const">
+			<return type="Array">
+			</return>
+			<argument index="0" name="polylines" type="Array">
+			</argument>
+			<argument index="1" name="polygons" type="Array">
+			</argument>
+			<description>
+				Clips multiple polylines against polygons and returns an array of clipped polylines. This performs [constant OPERATION_DIFFERENCE] between the polylines and the polygons. Returns an empty array if polygons completely enclose polylines.
+			</description>
+		</method>
+		<method name="exclude_polygons" qualifiers="const">
+			<return type="Array">
+			</return>
+			<argument index="0" name="polygons_a" type="Array">
+			</argument>
+			<argument index="1" name="polygons_b" type="Array">
+			</argument>
+			<description>
+				Similar to [method boolean_polygons], but performs [constant OPERATION_XOR] between the polygons specifically.
+			</description>
+		</method>
+		<method name="intersect_polygons" qualifiers="const">
+			<return type="Array">
+			</return>
+			<argument index="0" name="polygons_a" type="Array">
+			</argument>
+			<argument index="1" name="polygons_b" type="Array">
+			</argument>
+			<description>
+				Similar to [method boolean_polygons], but performs [constant OPERATION_INTERSECTION] between the polygons specifically.
+			</description>
+		</method>
+		<method name="intersect_polylines_with_polygons" qualifiers="const">
+			<return type="Array">
+			</return>
+			<argument index="0" name="polylines" type="Array">
+			</argument>
+			<argument index="1" name="polygons" type="Array">
+			</argument>
+			<description>
+				Intersects multiple polylines with polygons and returns an array of intersected polylines. This performs [constant OPERATION_INTERSECTION] between the polylines and the polygons.
+			</description>
+		</method>
+		<method name="merge_polygons" qualifiers="const">
+			<return type="Array">
+			</return>
+			<argument index="0" name="polygons_a" type="Array">
+			</argument>
+			<argument index="1" name="polygons_b" type="Array" default="null">
+			</argument>
+			<description>
+				Similar to [method boolean_polygons], but performs [constant OPERATION_UNION] between the polygons specifically. The second parameter is optional.
+			</description>
+		</method>
+		<method name="new_instance" qualifiers="const">
+			<return type="_PolyBoolean2D">
+			</return>
+			<description>
+				Instantiates a new local [PolyBoolean2D] instance, and [member parameters] can be configured.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="parameters" type="PolyBooleanParameters2D" setter="set_parameters" getter="get_parameters">
+			Parameters to configure the default behavior of operations. Cannot be configured via the global instance, use [method new_instance] first if you need to override the defaults.
+		</member>
+	</members>
+	<constants>
+		<constant name="OPERATION_NONE" value="0" enum="Operation">
+			No-op, but may perform polygons fixup, build hierarchy, depending on the poly_boolean implementation.
+		</constant>
+		<constant name="OPERATION_UNION" value="1" enum="Operation">
+			Merge (combine) polygons.
+		</constant>
+		<constant name="OPERATION_DIFFERENCE" value="2" enum="Operation">
+			Clip (cut) polygons or polylines.
+		</constant>
+		<constant name="OPERATION_INTERSECTION" value="3" enum="Operation">
+			Intersect polygons or polylines.
+		</constant>
+		<constant name="OPERATION_XOR" value="4" enum="Operation">
+			Mutually exclude polygons.
+		</constant>
+	</constants>
+</class>

--- a/doc/PolyBoolean2D.xml
+++ b/doc/PolyBoolean2D.xml
@@ -122,7 +122,7 @@
 			</description>
 		</method>
 		<method name="new_instance" qualifiers="const">
-			<return type="_PolyBoolean2D">
+			<return type="Reference">
 			</return>
 			<description>
 				Instantiates a new local [PolyBoolean2D] instance, and [member parameters] can be configured.

--- a/doc/PolyBooleanParameters2D.xml
+++ b/doc/PolyBooleanParameters2D.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="PolyBooleanParameters2D" inherits="Reference" version="3.2">
 	<brief_description>
-		A set of parameters to configure various polygon and polyline boolean related methods in [GoostGeometry2D].
+		A set of parameters to configure various polygon and polyline boolean related methods in [PolyBoolean2D].
 	</brief_description>
 	<description>
 	</description>

--- a/doc/PolyDecomp2D.xml
+++ b/doc/PolyDecomp2D.xml
@@ -27,7 +27,7 @@
 			<argument index="1" name="type" type="int" enum="PolyDecomp2D.Decomposition">
 			</argument>
 			<description>
-				Partitions polygons into several other convex polygons. The exact algorithm used depends on the type from [enum PolyDecompType].
+				Partitions polygons into several other convex polygons. The exact algorithm used depends on the type from [enum Decomposition].
 				Both outer and inner polygons can be passed to cut holes during decomposition and are distinguished automatically, with potential performance cost.
 				[b]Note:[/b] [constant DECOMP_TRIANGLES_OPT] and [constant DECOMP_TRIANGLES_OPT] do not support partitioning of a polygon with holes.
 			</description>
@@ -42,7 +42,7 @@
 			</description>
 		</method>
 		<method name="new_instance" qualifiers="const">
-			<return type="_PolyDecomp2D">
+			<return type="Reference">
 			</return>
 			<description>
 				Instantiates a new local [PolyDecomp2D] instance, and [member parameters] can be configured.

--- a/doc/PolyDecomp2D.xml
+++ b/doc/PolyDecomp2D.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="PolyDecomp2D" inherits="Reference" version="3.2">
+	<brief_description>
+		Polygon partitioning.
+	</brief_description>
+	<description>
+		A singleton which provides various method for polygon decomposition, partitioning etc.
+		A new local instance must be created manually with [method new_instance] method if you need to override the default [member parameters], else the methods in this class are available globally:
+		[codeblock]
+		var polygons = []
+		# Globally.
+		polygons = PolyDecomp2D.decompose_polygons([boundary, hole])
+		# Locally.
+		var pd = PolyDecomp2D.new_instance()
+		pd.parameters.fill_rule = PolyDecompParameters2D.FILL_RULE_EVEN_ODD
+		polygons = pd.decompose_polygons([boundary, hole])
+		[/codeblock]
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="decompose_polygons" qualifiers="const">
+			<return type="Array">
+			</return>
+			<argument index="0" name="polygons" type="Array">
+			</argument>
+			<argument index="1" name="type" type="int" enum="PolyDecomp2D.Decomposition">
+			</argument>
+			<description>
+				Partitions polygons into several other convex polygons. The exact algorithm used depends on the type from [enum PolyDecompType].
+				Both outer and inner polygons can be passed to cut holes during decomposition and are distinguished automatically, with potential performance cost.
+				[b]Note:[/b] [constant DECOMP_TRIANGLES_OPT] and [constant DECOMP_TRIANGLES_OPT] do not support partitioning of a polygon with holes.
+			</description>
+		</method>
+		<method name="decompose_polygons_into_convex" qualifiers="const">
+			<return type="Array">
+			</return>
+			<argument index="0" name="polygons" type="Array">
+			</argument>
+			<description>
+				Similar to [method decompose_polygons], but partitions polygons with the [constant DECOMP_CONVEX_HM].
+			</description>
+		</method>
+		<method name="new_instance" qualifiers="const">
+			<return type="_PolyDecomp2D">
+			</return>
+			<description>
+				Instantiates a new local [PolyDecomp2D] instance, and [member parameters] can be configured.
+			</description>
+		</method>
+		<method name="triangulate_polygons" qualifiers="const">
+			<return type="Array">
+			</return>
+			<argument index="0" name="polygons" type="Array">
+			</argument>
+			<description>
+				Similar to [method decompose_polygons], but triangulates multiple polygons with the [constant DECOMP_TRIANGLES_MONO].
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="parameters" type="PolyDecompParameters2D" setter="set_parameters" getter="get_parameters">
+			Parameters to configure the default behavior of operations. Cannot be configured via the global instance, use [method new_instance] first if you need to override the defaults.
+		</member>
+	</members>
+	<constants>
+		<constant name="DECOMP_TRIANGLES_EC" value="0" enum="Decomposition">
+			Triangulate a polygon using the ear clipping algorithm. Time/Space complexity: O(n^2)/O(n).
+		</constant>
+		<constant name="DECOMP_TRIANGLES_OPT" value="1" enum="Decomposition">
+			Optimal triangulation in terms of edge length using dynamic programming algorithm. Time/Space complexity: O(n^3)/O(n^2).
+		</constant>
+		<constant name="DECOMP_TRIANGLES_MONO" value="2" enum="Decomposition">
+			Partition the polygon into monotone polygons, then triangulate. Time/Space complexity: O(n*log(n))/O(n).
+		</constant>
+		<constant name="DECOMP_CONVEX_HM" value="3" enum="Decomposition">
+			Convex polygon partitioning using Hertel-Mehlhorn algorithm. Time/Space complexity: O(n^2)/O(n).
+		</constant>
+		<constant name="DECOMP_CONVEX_OPT" value="4" enum="Decomposition">
+			Optimal convex partition using dynamic programming algorithm by Keil and Snoeyink. Time/Space complexity: O(n^3)/O(n^3).
+		</constant>
+	</constants>
+</class>

--- a/doc/PolyDecompParameters2D.xml
+++ b/doc/PolyDecompParameters2D.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="PolyDecompParameters2D" inherits="Reference" version="3.2">
 	<brief_description>
-		A set of parameters to configure various polygon partitioning related methods in [GoostGeometry2D].
+		A set of parameters to configure various polygon partitioning related methods in [PolyDecomp2D].
 	</brief_description>
 	<description>
 	</description>
@@ -12,7 +12,7 @@
 	<members>
 		<member name="fill_rule" type="int" setter="set_fill_rule" getter="get_fill_rule" enum="PolyDecompParameters2D.FillRule" default="1">
 			Filling indicates those regions that are inside a closed path ("filled" with a brush color or pattern in a graphical display) and those regions that are outside.
-			[b]Note:[/b] this is only currently relevant in the [b]clipper10[/b] backend for [constant GoostGeometry2D.DECOMP_TRIANGLES_MONO] algorithm.
+			[b]Note:[/b] this is only currently relevant in the [b]clipper10[/b] backend for [constant PolyDecomp2D.DECOMP_TRIANGLES_MONO] algorithm.
 		</member>
 	</members>
 	<constants>

--- a/doc/PolyNode2D.xml
+++ b/doc/PolyNode2D.xml
@@ -4,7 +4,7 @@
 		Represents a single polygon node in the hierarchy of nested polygons.
 	</brief_description>
 	<description>
-		A data structure which is used to receive solutions from clipping and offsetting operations. It's an alternative to the array-based data structures which also receive these solutions in [GoostGeometry2D]. The class has a major advantage over the [Array] structure by having an ability to properly represent the parent-child relationships of the returned polygons. However, since this is a more complex structure, and since it's more computationally expensive to process, it should only be used when parent-child polygon relationships are needed.
+		A data structure which is used to receive solutions from clipping and offsetting operations. It's an alternative to the array-based data structures which also receive these solutions in [PolyBoolean2D]. The class has a major advantage over the [Array] structure by having an ability to properly represent the parent-child relationships of the returned polygons. However, since this is a more complex structure, and since it's more computationally expensive to process, it should only be used when parent-child polygon relationships are needed.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/PolyOffset2D.xml
+++ b/doc/PolyOffset2D.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="PolyOffset2D" inherits="Reference" version="3.2">
+	<brief_description>
+		Polygon deflating and inflating.
+	</brief_description>
+	<description>
+		A singleton which provides various method for polygon and polylines deflating, inflating, buffering etc.
+		A new local instance must be created manually with [method new_instance] method if you need to override the default [member parameters], else the methods in this class are available globally:
+		[codeblock]
+		var polygons = []
+		# Globally.
+		polygons = PolyOffset2D.deflate_polygons([poly_a, poly_b])
+		# Locally.
+		var po = PolyOffset2D.new_instance()
+		po.parameters.miter_limit = 3.0
+		polygons = po.deflate_polygons([poly_a, poly_b])
+		[/codeblock]
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="deflate_polygons" qualifiers="const">
+			<return type="Array">
+			</return>
+			<argument index="0" name="polygons" type="Array">
+			</argument>
+			<argument index="1" name="delta" type="float">
+			</argument>
+			<description>
+				Deflates an array of [code]polygons[/code] by [code]delta[/code] pixels, growing the polygons outward.
+				Each polygon's vertices will be rounded as determined by [member PolyOffsetParameters2D.join_type].
+			</description>
+		</method>
+		<method name="deflate_polylines" qualifiers="const">
+			<return type="Array">
+			</return>
+			<argument index="0" name="polylines" type="Array">
+			</argument>
+			<argument index="1" name="delta" type="float">
+			</argument>
+			<description>
+				Deflates (grows) [code]polylines[/code] into polygons by [code]delta[/code] pixels.
+				Each polygon's vertices will be rounded as determined by [member PolyOffsetParameters2D.join_type].
+				Each polygon's endpoints will be rounded as determined by [member PolyOffsetParameters2D.end_type], except for the [constant PolyOffsetParameters2D.END_POLYGON] as it's used by polygon offsetting specifically, use [constant PolyOffsetParameters2D.END_JOINED] to grow a polyline like a closed donut instead.
+			</description>
+		</method>
+		<method name="inflate_polygons" qualifiers="const">
+			<return type="Array">
+			</return>
+			<argument index="0" name="polygons" type="Array">
+			</argument>
+			<argument index="1" name="delta" type="float">
+			</argument>
+			<description>
+				Inflates an array of [code]polygons[/code] by [code]delta[/code] pixels, shrinking the polygons inward. Returns an empty array if [code]delta[/code] approximately exceeds the minimum bounding rectangle dimensions of each of the polygons.
+				Each polygon's vertices will be rounded as determined by [member PolyOffsetParameters2D.join_type].
+			</description>
+		</method>
+		<method name="new_instance" qualifiers="const">
+			<return type="_PolyOffset2D">
+			</return>
+			<description>
+				Instantiates a new local [PolyOffset2D] instance, and [member parameters] can be configured.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="parameters" type="PolyOffsetParameters2D" setter="set_parameters" getter="get_parameters">
+			Parameters to configure the default behavior of operations. Cannot be configured via the global instance, use [method new_instance] first if you need to override the defaults.
+		</member>
+	</members>
+	<constants>
+	</constants>
+</class>

--- a/doc/PolyOffset2D.xml
+++ b/doc/PolyOffset2D.xml
@@ -57,7 +57,7 @@
 			</description>
 		</method>
 		<method name="new_instance" qualifiers="const">
-			<return type="_PolyOffset2D">
+			<return type="Reference">
 			</return>
 			<description>
 				Instantiates a new local [PolyOffset2D] instance, and [member parameters] can be configured.

--- a/doc/PolyOffsetParameters2D.xml
+++ b/doc/PolyOffsetParameters2D.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="PolyOffsetParameters2D" inherits="Reference" version="3.2">
 	<brief_description>
-		A set of parameters to configure various polygon and polyline deflating and inflating related methods in [GoostGeometry2D].
+		A set of parameters to configure various polygon and polyline deflating and inflating related methods in [PolyOffset2D].
 	</brief_description>
 	<description>
 	</description>

--- a/doc/Random.xml
+++ b/doc/Random.xml
@@ -13,7 +13,7 @@
 		[/codeblock]
 		The class provides other useful and intuitive methods other than what [RandomNumberGenerator] already provides out of the box.
 		It's not possible to instantiate a new [Random] instance with [code]Random.new()[/code] in GDScript. If you'd like to instantiate a local instance of [Random], use [method new_instance] instead, or [code]ClassDB.instance("Random")[/code], see [method ClassDB.instance].
-		You have to call [method randomize] for local instances manually if you want to have non-reproducible results, else done automatically for the global instance by default.
+		You have to call [method RandomNumberGenerator.randomize] for local instances manually if you want to have non-reproducible results, else done automatically for the global instance by default.
 		For 2D, use [Random2D] class, which inherits all the functionality behind [Random] as well.
 	</description>
 	<tutorials>

--- a/doc/Random2D.xml
+++ b/doc/Random2D.xml
@@ -19,7 +19,7 @@
 			<description>
 				Generates a random point uniformly distributed on the circle's boundary, within the circle's area, or the area confined by inner and outer circle ranges specified with [code]radius_min[/code] and [code]radius_max[/code] parameters.
 				By default, generates points inside unit circle with radius [code]1.0[/code]. If you need random normalized vectors, use [member direction] instead, which is more efficient to compute.
-				If [code]radius_min == 0[/code], generates points inside a unit circle, such that [method Geometry2D.is_point_in_circle] shall return [code]true[/code] given the same radius.
+				If [code]radius_min == 0[/code], generates points inside a unit circle, such that [method Geometry.is_point_in_circle] shall return [code]true[/code] given the same radius.
 				If [code]radius_min != radius_max[/code], generates points within the ring's area, such that the inner area defined by [code]radius_min[/code] remains unaffected.
 				If [code]radius_min == radius_max[/code], generates points exactly [b]on[/b] the circle's boundary, but do note that a point may slightly deviate from the actual circle's boundary due to floating point error accumulation.
 				[codeblock]
@@ -40,7 +40,7 @@
 			</argument>
 			<description>
 				Generates a random point distributed within polygon's area. The distribution may not be completely uniform, but should be good enough in most cases. If [code]point_count == 1[/code], returns a single [Vector2] point. If [code]point_count &gt; 1[/code], returns a [PoolVector2Array] of points, which can be cached for further usage. This improves performance significantly as the polygon must be triangulated first.
-				This works by first decomposing polygons into triangles with [method GoostGeometry2D.decompose_polygons]. For approximately uniform distribution, each triangle is weighted by its area to fetch the needed number of points. Random points are then generated with [method point_in_triangle] uniformly.
+				This works by first decomposing polygons into triangles with [method PolyDecomp2D.decompose_polygons]. For approximately uniform distribution, each triangle is weighted by its area to fetch the needed number of points. Random points are then generated with [method point_in_triangle] uniformly.
 				Polygons may consist of outer and inner polygons (holes), so the [code]polygon[/code] parameter also accepts an [Array] of [PoolVector2Array]s as input.
 				The quality of distribution works better for single polygons with arbitrary number of holes, so it's recommended to use this method on distinct, non-overlapping objects.
 			</description>

--- a/doc/VariantResource.xml
+++ b/doc/VariantResource.xml
@@ -50,7 +50,7 @@
 		</member>
 		<member name="type" type="int" setter="set_type" getter="get_type" default="0">
 			Sets the type of the [Variant], one of the [code]TYPE_*[/code] constants available at [@GlobalScope], such as [constant @GlobalScope.TYPE_INT].
-			Once the type is set, an implicit [Variant] [code]value[/code] property is constructed. The [code]value[/code] property can be changed dynamically anytime, and this emits the [signal changed] signal, which can be connected to other script or engine methods:
+			Once the type is set, an implicit [Variant] [code]value[/code] property is constructed. The [code]value[/code] property can be changed dynamically anytime, and this emits the [signal Resource.changed] signal, which can be connected to other script or engine methods:
 			[codeblock]
 			extends Node2D
 			

--- a/goost.py
+++ b/goost.py
@@ -53,8 +53,11 @@ classes = [
     "ImageIndexed",
     "LinkedList",
     "ListNode",
+    "PolyBoolean2D",
     "PolyBooleanParameters2D",
+    "PolyDecomp2D",
     "PolyDecompParameters2D",
+    "PolyOffset2D",
     "PolyOffsetParameters2D",
     "PolyNode2D",
     "Random",
@@ -65,8 +68,11 @@ classes = [
 ]
 classes_dependencies = {
     # ClassA : Depends on ClassB.
-    "GoostGeometry2D" : "PolyBooleanParameters2D",
-    "GoostGeometry2D" : "PolyDecompParameters2D",
-    "GoostGeometry2D" : "PolyOffsetParameters2D",
-    "GoostGeometry2D" : "PolyNode2D",
+    "PolyBoolean2D" : "PolyBooleanParameters2D",
+    "PolyBoolean2D" : "PolyNode2D",
+    "PolyDecomp2D" : "PolyDecompParameters2D",
+    "PolyOffset2D" : "PolyOffsetParameters2D",
+    "GoostGeometry2D" : "PolyBoolean2D",
+    "GoostGeometry2D" : "PolyDecomp2D",
+    "GoostGeometry2D" : "PolyOffset2D",
 }

--- a/tests/project/goost/core/math/2d/geometry/poly/test_poly_boolean.gd
+++ b/tests/project/goost/core/math/2d/geometry/poly/test_poly_boolean.gd
@@ -39,18 +39,18 @@ func test_exclude_polygons():
 	assert_eq(solution[1].size(), 10)
 
 
-func test_polygons_boolean():
-	solution = PolyBoolean2D.polygons_boolean(PolyBoolean2D.OPERATION_UNION, [poly_a, poly_b, poly_c, poly_d])
+func test_boolean_polygons():
+	solution = PolyBoolean2D.boolean_polygons([poly_a, poly_b], [poly_c, poly_d], PolyBoolean2D.OPERATION_UNION)
 	assert_eq(solution.size(), 1)
 	assert_eq(solution[0].size(), 16)
 
 
-func test_polygons_boolean_tree():
+func test_boolean_polygons_tree():
 	var a = GoostGeometry2D.regular_polygon(4, 150)
 	var b = GoostGeometry2D.regular_polygon(4, 100)
 	var clip = GoostGeometry2D.clip_polygons(a, b)
 	var c = GoostGeometry2D.regular_polygon(4, 50)
-	solution = PolyBoolean2D.polygons_boolean_tree(PolyBoolean2D.OPERATION_UNION, clip, [c])
+	solution = PolyBoolean2D.boolean_polygons_tree(clip, [c], PolyBoolean2D.OPERATION_UNION)
 	var inner = solution.get_child(0).get_child(0).get_child(0).path
 	assert_eq(inner.size(), c.size())
 

--- a/tests/project/goost/core/math/2d/geometry/poly/test_poly_boolean.gd
+++ b/tests/project/goost/core/math/2d/geometry/poly/test_poly_boolean.gd
@@ -1,0 +1,72 @@
+extends "res://addons/gut/test.gd"
+
+const SIZE = 50.0
+
+var base_poly = PoolVector2Array([Vector2(-1, -1), Vector2(1, -1), Vector2(1, 1), Vector2(-1, 1)])
+
+var poly_a = Transform2D(0, Vector2.ONE).scaled(Vector2.ONE * SIZE).xform(base_poly)
+var poly_b = Transform2D(0, Vector2.ONE * SIZE).xform(poly_a)
+var poly_c = Transform2D(0, Vector2.ONE * SIZE).xform(poly_b)
+var poly_d = Transform2D(0, Vector2.ONE * SIZE).xform(poly_c)
+
+var solution = []
+
+
+func test_merge_polygons():
+	solution = PolyBoolean2D.merge_polygons([poly_a, poly_b, poly_c, poly_d])
+	assert_eq(solution.size(), 1)
+	assert_eq(solution[0].size(), 16)
+
+
+func test_clip_polygons():
+	solution = PolyBoolean2D.clip_polygons([poly_a, poly_b], [poly_c, poly_d])
+	assert_eq(solution.size(), 1)
+	assert_eq(solution[0].size(), 10)
+
+
+func test_intersect_polygons():
+	solution = PolyBoolean2D.intersect_polygons([poly_a, poly_c], [poly_b, poly_d])
+	assert_eq(solution.size(), 3)
+	assert_eq(solution[0].size(), 4)
+	assert_eq(solution[1].size(), 4)
+	assert_eq(solution[2].size(), 4)
+
+
+func test_exclude_polygons():
+	solution = PolyBoolean2D.exclude_polygons([poly_a, poly_b], [poly_c, poly_d])
+	assert_eq(solution.size(), 2)
+	assert_eq(solution[0].size(), 10)
+	assert_eq(solution[1].size(), 10)
+
+
+func test_polygons_boolean():
+	solution = PolyBoolean2D.polygons_boolean(PolyBoolean2D.OPERATION_UNION, [poly_a, poly_b, poly_c, poly_d])
+	assert_eq(solution.size(), 1)
+	assert_eq(solution[0].size(), 16)
+
+
+func test_polygons_boolean_tree():
+	var a = GoostGeometry2D.regular_polygon(4, 150)
+	var b = GoostGeometry2D.regular_polygon(4, 100)
+	var clip = GoostGeometry2D.clip_polygons(a, b)
+	var c = GoostGeometry2D.regular_polygon(4, 50)
+	solution = PolyBoolean2D.polygons_boolean_tree(PolyBoolean2D.OPERATION_UNION, clip, [c])
+	var inner = solution.get_child(0).get_child(0).get_child(0).path
+	assert_eq(inner.size(), c.size())
+
+
+func test_clip_polylines_with_polygons():
+	solution = PolyBoolean2D.clip_polylines_with_polygons([poly_a, poly_c], [poly_b, poly_d])
+	assert_eq(solution.size(), 4)
+	assert_eq(solution[0].size(), 2)
+	assert_eq(solution[1].size(), 3)
+	assert_eq(solution[2].size(), 2)
+	assert_eq(solution[3].size(), 3)
+
+
+func test_intersect_polylines_with_polygons():
+	solution = PolyBoolean2D.intersect_polylines_with_polygons([poly_a, poly_c], [poly_b, poly_d])
+	assert_eq(solution.size(), 3)
+	assert_eq(solution[0].size(), 3)
+	assert_eq(solution[1].size(), 2)
+	assert_eq(solution[2].size(), 3)

--- a/tests/project/goost/core/math/2d/geometry/poly/test_poly_boolean.gd
+++ b/tests/project/goost/core/math/2d/geometry/poly/test_poly_boolean.gd
@@ -12,6 +12,16 @@ var poly_d = Transform2D(0, Vector2.ONE * SIZE).xform(poly_c)
 var solution = []
 
 
+func test_create_local_instance():
+	var global = PolyBoolean2D
+	var local = PolyBoolean2D.new_instance()
+	assert_ne(local, PolyBoolean2D)
+	assert_eq(global, PolyBoolean2D)
+	# Should be possible to override in local instance, but not in global.
+#	PolyBoolean2D.parameters.strictly_simple = true
+	local.parameters.strictly_simple = true
+
+
 func test_merge_polygons():
 	solution = PolyBoolean2D.merge_polygons([poly_a, poly_b, poly_c, poly_d])
 	assert_eq(solution.size(), 1)

--- a/tests/project/goost/core/math/2d/geometry/poly/test_poly_decomp.gd
+++ b/tests/project/goost/core/math/2d/geometry/poly/test_poly_decomp.gd
@@ -14,6 +14,16 @@ func before_all():
 	poly_hole.invert()
 
 
+func test_create_local_instance():
+	var global = PolyDecomp2D
+	var local = PolyDecomp2D.new_instance()
+	assert_ne(local, PolyDecomp2D)
+	assert_eq(global, PolyDecomp2D)
+	# Should be possible to override in local instance, but not in global.
+#	PolyDecomp2D.parameters.fill_rule = PolyDecompParameters2D.FILL_RULE_EVEN_ODD
+	local.parameters.fill_rule = PolyDecompParameters2D.FILL_RULE_EVEN_ODD
+
+
 func test_triangulate_polygons():
 	solution = PolyDecomp2D.triangulate_polygons([poly_boundary, poly_hole])
 	assert_eq(solution.size(), 12)

--- a/tests/project/goost/core/math/2d/geometry/poly/test_poly_decomp.gd
+++ b/tests/project/goost/core/math/2d/geometry/poly/test_poly_decomp.gd
@@ -43,7 +43,7 @@ func test_decompose_polygons_into_convex():
 
 
 func test_decompose_polygons_triangles_opt():
-	solution = PolyDecomp2D.decompose_polygons(PolyDecomp2D.DECOMP_TRIANGLES_OPT, [poly_boundary])
+	solution = PolyDecomp2D.decompose_polygons([poly_boundary], PolyDecomp2D.DECOMP_TRIANGLES_OPT)
 	assert_eq(solution.size(), 6)
 	assert_eq(solution[0].size(), 3)
 	assert_eq(solution[1].size(), 3)
@@ -58,7 +58,7 @@ func test_decompose_polygons_triangles_mono():
 		push_error("Skip, internal bug in PolyPartition.Triangulate_MONO...")
 		return true
 
-	solution = PolyDecomp2D.decompose_polygons(PolyDecomp2D.DECOMP_TRIANGLES_MONO, [poly_boundary, poly_hole])
+	solution = PolyDecomp2D.decompose_polygons([poly_boundary, poly_hole], PolyDecomp2D.DECOMP_TRIANGLES_MONO)
 	assert_eq(solution.size(), 12)
 	assert_eq(solution[0].size(), 3)
 	assert_eq(solution[1].size(), 3)
@@ -75,6 +75,6 @@ func test_decompose_polygons_triangles_mono():
 
 
 func test_decompose_polygons_convex_opt():
-	solution = PolyDecomp2D.decompose_polygons(PolyDecomp2D.DECOMP_CONVEX_OPT, [poly_boundary])
+	solution = PolyDecomp2D.decompose_polygons([poly_boundary], PolyDecomp2D.DECOMP_CONVEX_OPT)
 	assert_eq(solution.size(), 1)
 	assert_eq(solution[0].size(), 8)

--- a/tests/project/goost/core/math/2d/geometry/poly/test_poly_decomp.gd
+++ b/tests/project/goost/core/math/2d/geometry/poly/test_poly_decomp.gd
@@ -1,0 +1,80 @@
+extends "res://addons/gut/test.gd"
+
+const SIZE = 50.0
+
+var base_poly = PoolVector2Array([Vector2(-1, -1), Vector2(1, -1), Vector2(1, 1), Vector2(-1, 1)])
+var poly = Transform2D(0, Vector2.ONE * SIZE).xform(base_poly)
+var poly_boundary = GoostGeometry2D.regular_polygon(8, SIZE * 2)
+var poly_hole = GoostGeometry2D.regular_polygon(4, SIZE)
+
+var solution = []
+
+
+func before_all():
+	poly_hole.invert()
+
+
+func test_triangulate_polygons():
+	solution = PolyDecomp2D.triangulate_polygons([poly_boundary, poly_hole])
+	assert_eq(solution.size(), 12)
+	assert_eq(solution[0].size(), 3)
+	assert_eq(solution[1].size(), 3)
+	assert_eq(solution[2].size(), 3)
+	assert_eq(solution[3].size(), 3)
+	assert_eq(solution[4].size(), 3)
+	assert_eq(solution[5].size(), 3)
+	assert_eq(solution[6].size(), 3)
+	assert_eq(solution[7].size(), 3)
+	assert_eq(solution[8].size(), 3)
+	assert_eq(solution[9].size(), 3)
+	assert_eq(solution[10].size(), 3)
+	assert_eq(solution[11].size(), 3)
+
+
+func test_decompose_polygons_into_convex():
+	solution = PolyDecomp2D.decompose_polygons_into_convex([poly_boundary, poly_hole, poly])
+	assert_eq(solution.size(), 6)
+	assert_eq(solution[0].size(), 4)
+	assert_eq(solution[1].size(), 4)
+	assert_eq(solution[2].size(), 4)
+	assert_eq(solution[3].size(), 5)
+	assert_eq(solution[4].size(), 5)
+	assert_eq(solution[5].size(), 4)
+
+
+func test_decompose_polygons_triangles_opt():
+	solution = PolyDecomp2D.decompose_polygons(PolyDecomp2D.DECOMP_TRIANGLES_OPT, [poly_boundary])
+	assert_eq(solution.size(), 6)
+	assert_eq(solution[0].size(), 3)
+	assert_eq(solution[1].size(), 3)
+	assert_eq(solution[2].size(), 3)
+	assert_eq(solution[3].size(), 3)
+	assert_eq(solution[4].size(), 3)
+	assert_eq(solution[5].size(), 3)
+
+
+func test_decompose_polygons_triangles_mono():
+	if ProjectSettings.get_setting("goost/geometry/2d/backends/poly_decomp") == "polypartition":
+		push_error("Skip, internal bug in PolyPartition.Triangulate_MONO...")
+		return true
+
+	solution = PolyDecomp2D.decompose_polygons(PolyDecomp2D.DECOMP_TRIANGLES_MONO, [poly_boundary, poly_hole])
+	assert_eq(solution.size(), 12)
+	assert_eq(solution[0].size(), 3)
+	assert_eq(solution[1].size(), 3)
+	assert_eq(solution[2].size(), 3)
+	assert_eq(solution[3].size(), 3)
+	assert_eq(solution[4].size(), 3)
+	assert_eq(solution[5].size(), 3)
+	assert_eq(solution[6].size(), 3)
+	assert_eq(solution[7].size(), 3)
+	assert_eq(solution[8].size(), 3)
+	assert_eq(solution[9].size(), 3)
+	assert_eq(solution[10].size(), 3)
+	assert_eq(solution[11].size(), 3)
+
+
+func test_decompose_polygons_convex_opt():
+	solution = PolyDecomp2D.decompose_polygons(PolyDecomp2D.DECOMP_CONVEX_OPT, [poly_boundary])
+	assert_eq(solution.size(), 1)
+	assert_eq(solution[0].size(), 8)

--- a/tests/project/goost/core/math/2d/geometry/poly/test_poly_offset.gd
+++ b/tests/project/goost/core/math/2d/geometry/poly/test_poly_offset.gd
@@ -11,6 +11,16 @@ var poly_c = Transform2D(0, Vector2.ONE * SIZE).xform(poly_b)
 var solution = []
 
 
+func test_create_local_instance():
+	var global = PolyOffset2D
+	var local = PolyOffset2D.new_instance()
+	assert_ne(local, PolyOffset2D)
+	assert_eq(global, PolyOffset2D)
+	# Should be possible to override in local instance, but not in global.
+#	PolyOffset2D.parameters.miter_limit = 3.0
+	local.parameters.miter_limit = 3.0
+
+
 func test_inflate_polygons():
 	solution = PolyOffset2D.inflate_polygons([poly_a, poly_c], SIZE / 2.0)
 	assert_eq(solution.size(), 2)
@@ -25,7 +35,8 @@ func test_deflate_polygons():
 
 
 func test_deflate_polylines():
-	solution = PolyOffset2D.deflate_polylines([poly_a, poly_c], SIZE / 2.0)
-	assert_ne(PolyOffset2D.parameters.end_type, PolyOffsetParameters2D.END_POLYGON)
+	var polyofs = PolyOffset2D.new_instance()
+	solution = polyofs.deflate_polylines([poly_a, poly_c], SIZE / 2.0)
+	assert_ne(polyofs.parameters.end_type, PolyOffsetParameters2D.END_POLYGON)
 	assert_eq(solution.size(), 1) # Successfully merged together.
 	assert_eq(solution[0].size(), 17)

--- a/tests/project/goost/core/math/2d/geometry/poly/test_poly_offset.gd
+++ b/tests/project/goost/core/math/2d/geometry/poly/test_poly_offset.gd
@@ -1,0 +1,31 @@
+extends "res://addons/gut/test.gd"
+
+const SIZE = 50.0
+
+var base_poly = PoolVector2Array([Vector2(-1, -1), Vector2(1, -1), Vector2(1, 1), Vector2(-1, 1)])
+
+var poly_a = Transform2D(0, Vector2.ONE).scaled(Vector2.ONE * SIZE).xform(base_poly)
+var poly_b = Transform2D(0, Vector2.ONE * SIZE).xform(poly_a)
+var poly_c = Transform2D(0, Vector2.ONE * SIZE).xform(poly_b)
+
+var solution = []
+
+
+func test_inflate_polygons():
+	solution = PolyOffset2D.inflate_polygons([poly_a, poly_c], SIZE / 2.0)
+	assert_eq(solution.size(), 2)
+	assert_eq(solution[0].size(), 4)
+	assert_eq(solution[1].size(), 4)
+
+
+func test_deflate_polygons():
+	solution = PolyOffset2D.deflate_polygons([poly_a, poly_c], SIZE / 2.0)
+	assert_eq(solution.size(), 1) # Successfully merged together.
+	assert_eq(solution[0].size(), 14)
+
+
+func test_deflate_polylines():
+	solution = PolyOffset2D.deflate_polylines([poly_a, poly_c], SIZE / 2.0)
+	assert_ne(PolyOffset2D.parameters.end_type, PolyOffsetParameters2D.END_POLYGON)
+	assert_eq(solution.size(), 1) # Successfully merged together.
+	assert_eq(solution[0].size(), 17)

--- a/tests/project/goost/core/math/2d/geometry/test_geometry_2d.gd
+++ b/tests/project/goost/core/math/2d/geometry/test_geometry_2d.gd
@@ -4,21 +4,12 @@ var testbed
 
 const SIZE = 50.0
 
-var base_poly = PoolVector2Array([Vector2(-1, -1), Vector2(1, -1), Vector2(1, 1), Vector2(-1, 1)])
-
-var poly_a = Transform2D(0, Vector2.ONE).scaled(Vector2.ONE * SIZE).xform(base_poly)
+var poly_base = PoolVector2Array([Vector2(-1, -1), Vector2(1, -1), Vector2(1, 1), Vector2(-1, 1)])
+var poly_a = Transform2D(0, Vector2.ONE).scaled(Vector2.ONE * SIZE).xform(poly_base)
 var poly_b = Transform2D(0, Vector2.ONE * SIZE).xform(poly_a)
-var poly_c = Transform2D(0, Vector2.ONE * SIZE).xform(poly_b)
-var poly_d = Transform2D(0, Vector2.ONE * SIZE).xform(poly_c)
-
 var poly_boundary = GoostGeometry2D.regular_polygon(8, SIZE * 2)
-var poly_hole = GoostGeometry2D.regular_polygon(4, SIZE)
 
 var solution = []
-
-
-func before_all():
-	poly_hole.invert()
 
 
 func setup():
@@ -61,49 +52,6 @@ func test_exclude_polygons():
 	assert_eq(solution[1].size(), 6)
 
 
-func test_merge_multiple_polygons():
-	solution = GoostGeometry2D.merge_multiple_polygons([poly_a, poly_b, poly_c, poly_d])
-	assert_eq(solution.size(), 1)
-	assert_eq(solution[0].size(), 16)
-
-
-func test_clip_multiple_polygons():
-	solution = GoostGeometry2D.clip_multiple_polygons([poly_a, poly_b], [poly_c, poly_d])
-	assert_eq(solution.size(), 1)
-	assert_eq(solution[0].size(), 10)
-
-
-func test_intersect_multiple_polygons():
-	solution = GoostGeometry2D.intersect_multiple_polygons([poly_a, poly_c], [poly_b, poly_d])
-	assert_eq(solution.size(), 3)
-	assert_eq(solution[0].size(), 4)
-	assert_eq(solution[1].size(), 4)
-	assert_eq(solution[2].size(), 4)
-
-
-func test_exclude_multiple_polygons():
-	solution = GoostGeometry2D.exclude_multiple_polygons([poly_a, poly_b], [poly_c, poly_d])
-	assert_eq(solution.size(), 2)
-	assert_eq(solution[0].size(), 10)
-	assert_eq(solution[1].size(), 10)
-
-
-func test_polygons_boolean():
-	solution = GoostGeometry2D.polygons_boolean(GoostGeometry2D.OPERATION_UNION, [poly_a, poly_b, poly_c, poly_d])
-	assert_eq(solution.size(), 1)
-	assert_eq(solution[0].size(), 16)
-
-
-func test_polygons_boolean_tree():
-	var a = GoostGeometry2D.regular_polygon(4, 150)
-	var b = GoostGeometry2D.regular_polygon(4, 100)
-	var clip = GoostGeometry2D.clip_polygons(a, b)
-	var c = GoostGeometry2D.regular_polygon(4, 50)
-	solution = GoostGeometry2D.polygons_boolean_tree(GoostGeometry2D.OPERATION_UNION, clip, [c])
-	var inner = solution.get_child(0).get_child(0).get_child(0).path
-	assert_eq(inner.size(), c.size())
-
-
 func test_clip_polyline_with_polygon():
 	solution = GoostGeometry2D.clip_polyline_with_polygon(poly_a, poly_b)
 	assert_eq(solution.size(), 2)
@@ -115,23 +63,6 @@ func test_intersect_polyline_with_polygon():
 	solution = GoostGeometry2D.intersect_polyline_with_polygon(poly_a, poly_b)
 	assert_eq(solution.size(), 1)
 	assert_eq(solution[0].size(), 3)
-
-
-func test_clip_multiple_polylines_with_polygons():
-	solution = GoostGeometry2D.clip_multiple_polylines_with_polygons([poly_a, poly_c], [poly_b, poly_d])
-	assert_eq(solution.size(), 4)
-	assert_eq(solution[0].size(), 2)
-	assert_eq(solution[1].size(), 3)
-	assert_eq(solution[2].size(), 2)
-	assert_eq(solution[3].size(), 3)
-
-
-func test_intersect_multiple_polylines_with_polygons():
-	solution = GoostGeometry2D.intersect_multiple_polylines_with_polygons([poly_a, poly_c], [poly_b, poly_d])
-	assert_eq(solution.size(), 3)
-	assert_eq(solution[0].size(), 3)
-	assert_eq(solution[1].size(), 2)
-	assert_eq(solution[2].size(), 3)
 
 
 func test_inflate_polygon():
@@ -146,47 +77,10 @@ func test_deflate_polygon():
 	assert_eq(solution[0].size(), 8)
 
 
-func test_inflate_multiple_polygons():
-	solution = GoostGeometry2D.inflate_multiple_polygons([poly_a, poly_c], SIZE / 2.0)
-	assert_eq(solution.size(), 2)
-	assert_eq(solution[0].size(), 4)
-	assert_eq(solution[1].size(), 4)
-
-
-func test_deflate_multiple_polygons():
-	solution = GoostGeometry2D.deflate_multiple_polygons([poly_a, poly_c], SIZE / 2.0)
-	assert_eq(solution.size(), 1) # Successfully merged together.
-	assert_eq(solution[0].size(), 14)
-
-
 func test_deflate_polyline():
 	solution = GoostGeometry2D.deflate_polyline(poly_a, SIZE / 2.0)
 	assert_eq(solution.size(), 1)
 	assert_eq(solution[0].size(), 10)
-
-
-func test_deflate_multiple_polylines():
-	solution = GoostGeometry2D.deflate_multiple_polylines([poly_a, poly_c], SIZE / 2.0)
-	assert_eq(solution.size(), 1) # Successfully merged together.
-	assert_eq(solution[0].size(), 17)
-
-
-func test_offset_polygon():
-	var params = PolyOffsetParameters2D.new()
-	params.join_type = PolyOffsetParameters2D.JOIN_ROUND
-	params.end_type = PolyOffsetParameters2D.END_ROUND
-	solution = GoostGeometry2D.offset_polygon(poly_a, SIZE / 2.0, params)
-	assert_eq(solution.size(), 1)
-	assert_eq(solution[0].size(), 28)
-
-
-func test_offset_multiple_polygons():
-	var params = PolyOffsetParameters2D.new()
-	params.join_type = PolyOffsetParameters2D.JOIN_ROUND
-	params.end_type = PolyOffsetParameters2D.END_ROUND
-	solution = GoostGeometry2D.offset_multiple_polygons([poly_a, poly_c], SIZE / 2.0, params)
-	assert_eq(solution.size(), 1)
-	assert_eq(solution[0].size(), 44)
 
 
 func test_triangulate_polygon():
@@ -200,75 +94,9 @@ func test_triangulate_polygon():
 	assert_eq(solution[5].size(), 3)
 
 
-func test_triangulate_multiple_polygons():
-	solution = GoostGeometry2D.triangulate_multiple_polygons([poly_boundary, poly_hole])
-	assert_eq(solution.size(), 12)
-	assert_eq(solution[0].size(), 3)
-	assert_eq(solution[1].size(), 3)
-	assert_eq(solution[2].size(), 3)
-	assert_eq(solution[3].size(), 3)
-	assert_eq(solution[4].size(), 3)
-	assert_eq(solution[5].size(), 3)
-	assert_eq(solution[6].size(), 3)
-	assert_eq(solution[7].size(), 3)
-	assert_eq(solution[8].size(), 3)
-	assert_eq(solution[9].size(), 3)
-	assert_eq(solution[10].size(), 3)
-	assert_eq(solution[11].size(), 3)
-
-
-func test_decompose_polygon_into_convex():
-	solution = GoostGeometry2D.decompose_polygon_into_convex(poly_boundary)
+func test_decompose_polygon():
+	solution = GoostGeometry2D.decompose_polygon(poly_boundary)
 	assert_eq(solution.size(), 1)
-
-
-func test_decompose_multiple_polygons_into_convex():
-	solution = GoostGeometry2D.decompose_multiple_polygons_into_convex([poly_boundary, poly_hole, poly_c])
-	assert_eq(solution.size(), 6)
-	assert_eq(solution[0].size(), 4)
-	assert_eq(solution[1].size(), 4)
-	assert_eq(solution[2].size(), 4)
-	assert_eq(solution[3].size(), 5)
-	assert_eq(solution[4].size(), 5)
-	assert_eq(solution[5].size(), 4)
-
-
-func test_decompose_polygons_triangles_opt():
-	solution = GoostGeometry2D.decompose_polygons(GoostGeometry2D.DECOMP_TRIANGLES_OPT, [poly_boundary])
-	assert_eq(solution.size(), 6)
-	assert_eq(solution[0].size(), 3)
-	assert_eq(solution[1].size(), 3)
-	assert_eq(solution[2].size(), 3)
-	assert_eq(solution[3].size(), 3)
-	assert_eq(solution[4].size(), 3)
-	assert_eq(solution[5].size(), 3)
-
-
-func test_decompose_polygons_triangles_mono():
-	if ProjectSettings.get_setting("goost/geometry/2d/backends/poly_decomp") == "polypartition":
-		push_error("Skip, internal bug in PolyPartition.Triangulate_MONO...")
-		return true
-
-	solution = GoostGeometry2D.decompose_polygons(GoostGeometry2D.DECOMP_TRIANGLES_MONO, [poly_boundary, poly_hole])
-	assert_eq(solution.size(), 12)
-	assert_eq(solution[0].size(), 3)
-	assert_eq(solution[1].size(), 3)
-	assert_eq(solution[2].size(), 3)
-	assert_eq(solution[3].size(), 3)
-	assert_eq(solution[4].size(), 3)
-	assert_eq(solution[5].size(), 3)
-	assert_eq(solution[6].size(), 3)
-	assert_eq(solution[7].size(), 3)
-	assert_eq(solution[8].size(), 3)
-	assert_eq(solution[9].size(), 3)
-	assert_eq(solution[10].size(), 3)
-	assert_eq(solution[11].size(), 3)
-
-
-func test_decompose_polygons_convex_opt():
-	solution = GoostGeometry2D.decompose_polygons(GoostGeometry2D.DECOMP_CONVEX_OPT, [poly_boundary])
-	assert_eq(solution.size(), 1)
-	assert_eq(solution[0].size(), 8)
 
 
 func test_polygon_centroid():


### PR DESCRIPTION
Introduces `PolyBoolean2D`, `PolyOffset2D`, `PolyDecomp2D` singletons, which were previously internal instances of `GoostGeometry2D`.

`GoostGeometry2D` only operates on single polygons now, removed various too verbose `*_multiple` variants, which are moved to singletons above (without `*_multiple` suffix), removed parameter arguments. This cleans up the API quite a lot.

`offset_polygon` methods are removed in favor of existing `deflate/inflate_polygon` methods. This was previously confusing to some users: godotengine/godot-proposals#777.

Poly parameter classes are made part of newly added singletons as properties. Poly singletons can be instantiated locally.

Reordered poly boolean and decomposition parameters for respective types for consistency, to ensure the first parameters accept polygons at all times. Also renamed methods and decomposition type enum.

Classes such as `PolyBoolean2D` can be used globally, but the default parameters cannot be configured for those. If you do need to configure parameters, create a local instance of the same class with a newly added `new_instance()` method. This is done to prevent programming mistakes relating to singletons usage, so that parameters from local operations cannot affect the result of other operations throughout a project.

In most cases, it's not necessary to instantiate parameter classes, since this is done per class now.

This heavily breaks compatibility, but for the greater good. All the functionality is still there, though. Only minimal compatibility changes were made to underlying backend implementations.
