### PR TITLE
Rename `OPERATION_*` boolean constants to `OP_*`

### DIFF
--- a/core/math/2d/geometry/poly/boolean/clipper10/poly_boolean_clipper10.cpp
+++ b/core/math/2d/geometry/poly/boolean/clipper10/poly_boolean_clipper10.cpp
@@ -70,19 +70,19 @@ clipperlib::Clipper PolyBoolean2DClipper10::configure(Operation p_op, const Ref<
 	using namespace clipperlib;
 
 	switch (p_op) {
-		case OPERATION_NONE:
+		case OP_NONE:
 			clip_type = ctNone;
 			break;
-		case OPERATION_UNION:
+		case OP_UNION:
 			clip_type = ctUnion;
 			break;
-		case OPERATION_DIFFERENCE:
+		case OP_DIFFERENCE:
 			clip_type = ctDifference;
 			break;
-		case OPERATION_INTERSECTION:
+		case OP_INTERSECTION:
 			clip_type = ctIntersection;
 			break;
-		case OPERATION_XOR:
+		case OP_XOR:
 			clip_type = ctXor;
 			break;
 	}

--- a/core/math/2d/geometry/poly/boolean/clipper6/poly_boolean_clipper6.cpp
+++ b/core/math/2d/geometry/poly/boolean/clipper6/poly_boolean_clipper6.cpp
@@ -75,20 +75,20 @@ ClipperLib::Clipper PolyBoolean2DClipper6::configure(Operation p_op, const Ref<P
 	using namespace ClipperLib;
 
 	switch (p_op) {
-		case OPERATION_NONE: {
+		case OP_NONE: {
 			clip_type = ctUnion;
-			WARN_PRINT_ONCE("OPERATION_NONE is not available in clipper6 backend, fallback to OPERATION_UNION.");
+			WARN_PRINT_ONCE("OP_NONE is not available in clipper6 backend, fallback to OP_UNION.");
 		} break;
-		case OPERATION_UNION:
+		case OP_UNION:
 			clip_type = ctUnion;
 			break;
-		case OPERATION_DIFFERENCE:
+		case OP_DIFFERENCE:
 			clip_type = ctDifference;
 			break;
-		case OPERATION_INTERSECTION:
+		case OP_INTERSECTION:
 			clip_type = ctIntersection;
 			break;
-		case OPERATION_XOR:
+		case OP_XOR:
 			clip_type = ctXor;
 			break;
 	}

--- a/core/math/2d/geometry/poly/boolean/poly_boolean.cpp
+++ b/core/math/2d/geometry/poly/boolean/poly_boolean.cpp
@@ -15,25 +15,25 @@ void PolyBoolean2DBackend::set_parameters(const Ref<PolyBooleanParameters2D> &p_
 Vector<Vector<Point2>> PolyBoolean2D::merge_polygons(const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b, const Ref<PolyBooleanParameters2D> &p_parameters) {
 	backend->set_parameters(p_parameters);
 	backend->get_parameters()->subject_open = false;
-	return backend->boolean_polypaths(p_polygons_a, p_polygons_b, PolyBoolean2DBackend::OPERATION_UNION);
+	return backend->boolean_polypaths(p_polygons_a, p_polygons_b, PolyBoolean2DBackend::OP_UNION);
 }
 
 Vector<Vector<Point2>> PolyBoolean2D::clip_polygons(const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b, const Ref<PolyBooleanParameters2D> &p_parameters) {
 	backend->set_parameters(p_parameters);
 	backend->get_parameters()->subject_open = false;
-	return backend->boolean_polypaths(p_polygons_a, p_polygons_b, PolyBoolean2DBackend::OPERATION_DIFFERENCE);
+	return backend->boolean_polypaths(p_polygons_a, p_polygons_b, PolyBoolean2DBackend::OP_DIFFERENCE);
 }
 
 Vector<Vector<Point2>> PolyBoolean2D::intersect_polygons(const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b, const Ref<PolyBooleanParameters2D> &p_parameters) {
 	backend->set_parameters(p_parameters);
 	backend->get_parameters()->subject_open = false;
-	return backend->boolean_polypaths(p_polygons_a, p_polygons_b, PolyBoolean2DBackend::OPERATION_INTERSECTION);
+	return backend->boolean_polypaths(p_polygons_a, p_polygons_b, PolyBoolean2DBackend::OP_INTERSECTION);
 }
 
 Vector<Vector<Point2>> PolyBoolean2D::exclude_polygons(const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b, const Ref<PolyBooleanParameters2D> &p_parameters) {
 	backend->set_parameters(p_parameters);
 	backend->get_parameters()->subject_open = false;
-	return backend->boolean_polypaths(p_polygons_a, p_polygons_b, PolyBoolean2DBackend::OPERATION_XOR);
+	return backend->boolean_polypaths(p_polygons_a, p_polygons_b, PolyBoolean2DBackend::OP_XOR);
 }
 
 Vector<Vector<Point2>> PolyBoolean2D::boolean_polygons(const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b, Operation p_op, const Ref<PolyBooleanParameters2D> &p_parameters) {
@@ -51,13 +51,13 @@ Ref<PolyNode2D> PolyBoolean2D::boolean_polygons_tree(const Vector<Vector<Point2>
 Vector<Vector<Point2>> PolyBoolean2D::clip_polylines_with_polygons(const Vector<Vector<Point2>> &p_polylines, const Vector<Vector<Point2>> &p_polygons, const Ref<PolyBooleanParameters2D> &p_parameters) {
 	backend->set_parameters(p_parameters);
 	backend->get_parameters()->subject_open = true;
-	return backend->boolean_polypaths(p_polylines, p_polygons, PolyBoolean2DBackend::OPERATION_DIFFERENCE);
+	return backend->boolean_polypaths(p_polylines, p_polygons, PolyBoolean2DBackend::OP_DIFFERENCE);
 }
 
 Vector<Vector<Point2>> PolyBoolean2D::intersect_polylines_with_polygons(const Vector<Vector<Point2>> &p_polylines, const Vector<Vector<Point2>> &p_polygons, const Ref<PolyBooleanParameters2D> &p_parameters) {
 	backend->set_parameters(p_parameters);
 	backend->get_parameters()->subject_open = true;
-	return backend->boolean_polypaths(p_polylines, p_polygons, PolyBoolean2DBackend::OPERATION_INTERSECTION);
+	return backend->boolean_polypaths(p_polylines, p_polygons, PolyBoolean2DBackend::OP_INTERSECTION);
 }
 
 // BIND
@@ -240,11 +240,11 @@ void _PolyBoolean2D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "parameters"), "set_parameters", "get_parameters");
 
-	BIND_ENUM_CONSTANT(OPERATION_NONE);
-	BIND_ENUM_CONSTANT(OPERATION_UNION);
-	BIND_ENUM_CONSTANT(OPERATION_DIFFERENCE);
-	BIND_ENUM_CONSTANT(OPERATION_INTERSECTION);
-	BIND_ENUM_CONSTANT(OPERATION_XOR);
+	BIND_ENUM_CONSTANT(OP_NONE);
+	BIND_ENUM_CONSTANT(OP_UNION);
+	BIND_ENUM_CONSTANT(OP_DIFFERENCE);
+	BIND_ENUM_CONSTANT(OP_INTERSECTION);
+	BIND_ENUM_CONSTANT(OP_XOR);
 }
 
 void PolyBooleanParameters2D::_bind_methods() {

--- a/core/math/2d/geometry/poly/boolean/poly_boolean.h
+++ b/core/math/2d/geometry/poly/boolean/poly_boolean.h
@@ -13,11 +13,11 @@ public:
 	virtual Ref<PolyBooleanParameters2D> get_parameters() { return parameters; }
 
 	enum Operation {
-		OPERATION_NONE,
-		OPERATION_UNION,
-		OPERATION_DIFFERENCE,
-		OPERATION_INTERSECTION,
-		OPERATION_XOR,
+		OP_NONE,
+		OP_UNION,
+		OP_DIFFERENCE,
+		OP_INTERSECTION,
+		OP_XOR,
 	};
 	virtual Vector<Vector<Point2>> boolean_polypaths(const Vector<Vector<Point2>> &p_polypaths_A, const Vector<Vector<Point2>> &p_polypaths_B, Operation p_op) = 0;
 	virtual Ref<PolyNode2D> boolean_polypaths_tree(const Vector<Vector<Point2>> &p_polypaths_A, const Vector<Vector<Point2>> &p_polypaths_B, Operation p_op) = 0;
@@ -36,11 +36,11 @@ protected:
 class PolyBoolean2D {
 public:
 	enum Operation {
-		OPERATION_NONE,
-		OPERATION_UNION,
-		OPERATION_DIFFERENCE,
-		OPERATION_INTERSECTION,
-		OPERATION_XOR,
+		OP_NONE,
+		OP_UNION,
+		OP_DIFFERENCE,
+		OP_INTERSECTION,
+		OP_XOR,
 	};
 	static Vector<Vector<Point2>> merge_polygons(const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b = Vector<Vector<Point2>>(), const Ref<PolyBooleanParameters2D> &p_parameters = Ref<PolyBooleanParameters2D>());
 	static Vector<Vector<Point2>> clip_polygons(const Vector<Vector<Point2>> &p_polygons_a, const Vector<Vector<Point2>> &p_polygons_b, const Ref<PolyBooleanParameters2D> &p_parameters = Ref<PolyBooleanParameters2D>());
@@ -80,11 +80,11 @@ public:
 	Ref<PolyBooleanParameters2D> get_parameters() const;
 
 	enum Operation {
-		OPERATION_NONE,
-		OPERATION_UNION,
-		OPERATION_DIFFERENCE,
-		OPERATION_INTERSECTION,
-		OPERATION_XOR,
+		OP_NONE,
+		OP_UNION,
+		OP_DIFFERENCE,
+		OP_INTERSECTION,
+		OP_XOR,
 	};
 	Array merge_polygons(Array p_polygons_a, Array p_polygons_b) const;
 	Array clip_polygons(Array p_polygons_a, Array p_polygons_b) const;

--- a/doc/GoostGeometry2D.xml
+++ b/doc/GoostGeometry2D.xml
@@ -31,7 +31,7 @@
 			<argument index="1" name="polygon_b" type="PoolVector2Array">
 			</argument>
 			<description>
-				Performs [constant PolyBoolean2D.OPERATION_DIFFERENCE] between individual polygons.
+				Performs [constant PolyBoolean2D.OP_DIFFERENCE] between individual polygons.
 			</description>
 		</method>
 		<method name="clip_polyline_with_polygon" qualifiers="const">
@@ -42,7 +42,7 @@
 			<argument index="1" name="polygon" type="PoolVector2Array">
 			</argument>
 			<description>
-				Clips a single [code]polyline[/code] against a single [code]polygon[/code] and returns an array of clipped polylines. This performs [constant PolyBoolean2D.OPERATION_DIFFERENCE] between the polyline and the polygon. Returns an empty array if the [code]polygon[/code] completely encloses [code]polyline[/code]. This operation can be thought of as cutting a line with a closed shape.
+				Clips a single [code]polyline[/code] against a single [code]polygon[/code] and returns an array of clipped polylines. This performs [constant PolyBoolean2D.OP_DIFFERENCE] between the polyline and the polygon. Returns an empty array if the [code]polygon[/code] completely encloses [code]polyline[/code]. This operation can be thought of as cutting a line with a closed shape.
 			</description>
 		</method>
 		<method name="decompose_polygon" qualifiers="const">
@@ -84,7 +84,7 @@
 			<argument index="1" name="polygon_b" type="PoolVector2Array">
 			</argument>
 			<description>
-				Performs [constant PolyBoolean2D.OPERATION_XOR] between individual polygons.
+				Performs [constant PolyBoolean2D.OP_XOR] between individual polygons.
 			</description>
 		</method>
 		<method name="inflate_polygon" qualifiers="const">
@@ -106,7 +106,7 @@
 			<argument index="1" name="polygon_b" type="PoolVector2Array">
 			</argument>
 			<description>
-				Performs [constant PolyBoolean2D.OPERATION_INTERSECTION] between individual polygons.
+				Performs [constant PolyBoolean2D.OP_INTERSECTION] between individual polygons.
 			</description>
 		</method>
 		<method name="intersect_polyline_with_polygon" qualifiers="const">
@@ -117,7 +117,7 @@
 			<argument index="1" name="polygon" type="PoolVector2Array">
 			</argument>
 			<description>
-				Intersects polyline with polygon and returns an array of intersected polylines. This performs [constant PolyBoolean2D.OPERATION_INTERSECTION] between the polyline and the polygon. This operation can be thought of as chopping a line with a closed shape.
+				Intersects polyline with polygon and returns an array of intersected polylines. This performs [constant PolyBoolean2D.OP_INTERSECTION] between the polyline and the polygon. This operation can be thought of as chopping a line with a closed shape.
 			</description>
 		</method>
 		<method name="merge_polygons" qualifiers="const">
@@ -128,7 +128,7 @@
 			<argument index="1" name="polygon_b" type="PoolVector2Array">
 			</argument>
 			<description>
-				Performs [constant PolyBoolean2D.OPERATION_UNION] between individual polygons. If you need to merge multiple polygons, use [method PolyBoolean2D.merge_polygons] instead.
+				Performs [constant PolyBoolean2D.OP_UNION] between individual polygons. If you need to merge multiple polygons, use [method PolyBoolean2D.merge_polygons] instead.
 			</description>
 		</method>
 		<method name="point_in_polygon" qualifiers="const">

--- a/doc/PolyBoolean2D.xml
+++ b/doc/PolyBoolean2D.xml
@@ -31,14 +31,14 @@
 			<description>
 				Performs a boolean operation between an array of polygons, with the [code]polygons_a[/code] acting as the [i]subject[/i] of the operation. Returns an array of resulting polygons with vertices in either clockwise or counterclockwise order, which determines whether a polygon is an outer polygon (boundary) or an inner polygon (hole). The orientation of returned polygons can be checked with [method Geometry.is_polygon_clockwise]. If you need to retain the hierarchy of nested outer and inner polygons, use [method boolean_polygons_tree] instead.
 				[b]Operations:[/b]
-				[constant OPERATION_UNION]:
+				[constant OP_UNION]:
 				Merges polygons into one if they overlap in any way. Passing [code]polygons_b[/code] is optional in this case, but you can specify a different [member PolyBooleanParameters2D.clip_fill_rule] for these polygons, producing different results.
 				This operation can also be used to convert arbitrary polygons into strictly simple ones (no self-intersections).
-				[constant OPERATION_DIFFERENCE]:
+				[constant OP_DIFFERENCE]:
 				Clips polygons, the [i]subject[/i] remains intact if neither polygons overlap. Returns an empty array if [code]polygons_b[/code] completely covers [code]polygons_a[/code]. If [code]polygons_b[/code] are enclosed by [code]polygons_a[/code], returns an array of boundary and hole polygons.
-				[constant OPERATION_INTERSECTION]:
+				[constant OP_INTERSECTION]:
 				Intersects polygons, effectively returning the common area shared by these polygons. Returns an empty array if no intersection occurs.
-				[constant OPERATION_XOR]:
+				[constant OP_XOR]:
 				Mutually excludes common area defined by the intersection of the polygons. In other words, returns all but common area between the polygons.
 			</description>
 		</method>
@@ -63,7 +63,7 @@
 			<argument index="1" name="polygons_b" type="Array">
 			</argument>
 			<description>
-				Similar to [method boolean_polygons], but performs [constant OPERATION_DIFFERENCE] between the polygons specifically.
+				Similar to [method boolean_polygons], but performs [constant OP_DIFFERENCE] between the polygons specifically.
 			</description>
 		</method>
 		<method name="clip_polylines_with_polygons" qualifiers="const">
@@ -74,7 +74,7 @@
 			<argument index="1" name="polygons" type="Array">
 			</argument>
 			<description>
-				Clips multiple polylines against polygons and returns an array of clipped polylines. This performs [constant OPERATION_DIFFERENCE] between the polylines and the polygons. Returns an empty array if polygons completely enclose polylines.
+				Clips multiple polylines against polygons and returns an array of clipped polylines. This performs [constant OP_DIFFERENCE] between the polylines and the polygons. Returns an empty array if polygons completely enclose polylines.
 			</description>
 		</method>
 		<method name="exclude_polygons" qualifiers="const">
@@ -85,7 +85,7 @@
 			<argument index="1" name="polygons_b" type="Array">
 			</argument>
 			<description>
-				Similar to [method boolean_polygons], but performs [constant OPERATION_XOR] between the polygons specifically.
+				Similar to [method boolean_polygons], but performs [constant OP_XOR] between the polygons specifically.
 			</description>
 		</method>
 		<method name="intersect_polygons" qualifiers="const">
@@ -96,7 +96,7 @@
 			<argument index="1" name="polygons_b" type="Array">
 			</argument>
 			<description>
-				Similar to [method boolean_polygons], but performs [constant OPERATION_INTERSECTION] between the polygons specifically.
+				Similar to [method boolean_polygons], but performs [constant OP_INTERSECTION] between the polygons specifically.
 			</description>
 		</method>
 		<method name="intersect_polylines_with_polygons" qualifiers="const">
@@ -107,7 +107,7 @@
 			<argument index="1" name="polygons" type="Array">
 			</argument>
 			<description>
-				Intersects multiple polylines with polygons and returns an array of intersected polylines. This performs [constant OPERATION_INTERSECTION] between the polylines and the polygons.
+				Intersects multiple polylines with polygons and returns an array of intersected polylines. This performs [constant OP_INTERSECTION] between the polylines and the polygons.
 			</description>
 		</method>
 		<method name="merge_polygons" qualifiers="const">
@@ -118,7 +118,7 @@
 			<argument index="1" name="polygons_b" type="Array" default="null">
 			</argument>
 			<description>
-				Similar to [method boolean_polygons], but performs [constant OPERATION_UNION] between the polygons specifically. The second parameter is optional.
+				Similar to [method boolean_polygons], but performs [constant OP_UNION] between the polygons specifically. The second parameter is optional.
 			</description>
 		</method>
 		<method name="new_instance" qualifiers="const">
@@ -135,19 +135,19 @@
 		</member>
 	</members>
 	<constants>
-		<constant name="OPERATION_NONE" value="0" enum="Operation">
+		<constant name="OP_NONE" value="0" enum="Operation">
 			No-op, but may perform polygons fixup, build hierarchy, depending on the poly_boolean implementation.
 		</constant>
-		<constant name="OPERATION_UNION" value="1" enum="Operation">
+		<constant name="OP_UNION" value="1" enum="Operation">
 			Merge (combine) polygons.
 		</constant>
-		<constant name="OPERATION_DIFFERENCE" value="2" enum="Operation">
+		<constant name="OP_DIFFERENCE" value="2" enum="Operation">
 			Clip (cut) polygons or polylines.
 		</constant>
-		<constant name="OPERATION_INTERSECTION" value="3" enum="Operation">
+		<constant name="OP_INTERSECTION" value="3" enum="Operation">
 			Intersect polygons or polylines.
 		</constant>
-		<constant name="OPERATION_XOR" value="4" enum="Operation">
+		<constant name="OP_XOR" value="4" enum="Operation">
 			Mutually exclude polygons.
 		</constant>
 	</constants>

--- a/tests/project/goost/core/math/2d/geometry/poly/test_poly_boolean.gd
+++ b/tests/project/goost/core/math/2d/geometry/poly/test_poly_boolean.gd
@@ -50,7 +50,7 @@ func test_exclude_polygons():
 
 
 func test_boolean_polygons():
-	solution = PolyBoolean2D.boolean_polygons([poly_a, poly_b], [poly_c, poly_d], PolyBoolean2D.OPERATION_UNION)
+	solution = PolyBoolean2D.boolean_polygons([poly_a, poly_b], [poly_c, poly_d], PolyBoolean2D.OP_UNION)
 	assert_eq(solution.size(), 1)
 	assert_eq(solution[0].size(), 16)
 
@@ -60,7 +60,7 @@ func test_boolean_polygons_tree():
 	var b = GoostGeometry2D.regular_polygon(4, 100)
 	var clip = GoostGeometry2D.clip_polygons(a, b)
 	var c = GoostGeometry2D.regular_polygon(4, 50)
-	solution = PolyBoolean2D.boolean_polygons_tree(clip, [c], PolyBoolean2D.OPERATION_UNION)
+	solution = PolyBoolean2D.boolean_polygons_tree(clip, [c], PolyBoolean2D.OP_UNION)
 	var inner = solution.get_child(0).get_child(0).get_child(0).path
 	assert_eq(inner.size(), c.size())
 


### PR DESCRIPTION
Follow-up to #37.

For consistency with global scope `OP_*` constants, and other similar constants throughout the engine. This also reduces verbosity quite a bit. Also somewhat consistent with `DECOMP_*` constants for polygon decomposition (which are already short).