### PR TITLE
Add `Grid2D` structure to hold `Variant` values in 2D

### DIFF
--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -4,6 +4,7 @@
 
 #include "image/register_image_types.h"
 #include "math/register_math_types.h"
+#include "types/grid_2d.h"
 #include "types/list.h"
 #include "types/variant_resource.h"
 
@@ -24,6 +25,7 @@ static void _variant_resource_preview_init() {
 #endif
 
 void register_core_types() {
+	ClassDB::register_class<Grid2D>();
 	ClassDB::register_class<ListNode>();
 	ClassDB::register_class<LinkedList>();
 

--- a/core/types/grid_2d.cpp
+++ b/core/types/grid_2d.cpp
@@ -1,0 +1,159 @@
+#include "grid_2d.h"
+
+void Grid2D::create(int p_width, int p_height) {
+	clear();
+	resize(p_width, p_height);
+}
+
+void Grid2D::create_from_data(int p_width, int p_height, Array p_data) {
+	ERR_FAIL_COND_MSG(p_data.empty(), "Array is empty.");
+	ERR_FAIL_COND_MSG(p_data.size() != p_width * p_height, "Element count mismatch in the Array to create a Grid2D.");
+
+	create(p_width, p_height);
+
+	Variant *dest = data.ptrw();
+	for (int i = 0; i < p_data.size(); ++i) {
+		dest[i] = p_data[i];
+	}
+}
+
+void Grid2D::resize(int p_new_width, int p_new_height) {
+	ERR_FAIL_COND(p_new_width <= 0);
+	ERR_FAIL_COND(p_new_height <= 0);
+
+	if (p_new_width == width && p_new_height == height) {
+		return;
+	}
+	Error err = data.resize(p_new_width * p_new_height);
+	if (err != OK) {
+		return;
+	}
+	width = p_new_width;
+	height = p_new_height;
+}
+
+void Grid2D::set_element(int p_x, int p_y, const Variant &p_value) {
+#ifdef DEBUG_ENABLED
+	ERR_FAIL_COND(p_x < 0);
+	ERR_FAIL_COND(p_y < 0);
+	ERR_FAIL_COND(p_x > width);
+	ERR_FAIL_COND(p_y > height);
+#endif
+	uint32_t ofs = p_y * width + p_x;
+	return data.write[ofs] = p_value;
+}
+
+Variant Grid2D::get_element(int p_x, int p_y) {
+#ifdef DEBUG_ENABLED
+	ERR_FAIL_COND_V(p_x < 0, Variant());
+	ERR_FAIL_COND_V(p_y < 0, Variant());
+	ERR_FAIL_COND_V(p_x > width, Variant());
+	ERR_FAIL_COND_V(p_y > height, Variant());
+#endif
+	uint32_t ofs = p_y * width + p_x;
+	return data[ofs];
+}
+
+void Grid2D::set_cell(const Vector2 &p_pos, const Variant &p_value) {
+	set_element(p_pos.x, p_pos.y, p_value);
+}
+
+Variant Grid2D::get_cell(const Vector2 &p_pos) {
+	return get_element(p_pos.x, p_pos.y);
+}
+
+void Grid2D::fill(const Variant &p_value) {
+	int idx = 0;
+	const int count = width * height;
+	Variant *dest = data.ptrw();
+	while (idx < count) {
+		dest[idx++] = p_value;
+	}
+}
+
+Variant Grid2D::_iter_init(const Array &p_iter) {
+	_iter_current = 0;
+	return _iter_current < width * height;
+}
+
+Variant Grid2D::_iter_next(const Array &p_iter) {
+	_iter_current++;
+	return _iter_current < width * height;
+}
+
+Variant Grid2D::_iter_get(const Variant &p_iter) {
+	return data[_iter_current];
+}
+
+void Grid2D::_set_data(const Dictionary &p_data) {
+	ERR_FAIL_COND(!p_data.has("width"));
+	ERR_FAIL_COND(!p_data.has("height"));
+	ERR_FAIL_COND(!p_data.has("data"));
+
+	int w = p_data["width"];
+	int h = p_data["height"];
+	Array arr = p_data["data"];
+
+	create_from_data(w, h, arr);
+}
+
+Dictionary Grid2D::_get_data() const {
+	Dictionary ret;
+	ret["width"] = width;
+	ret["height"] = height;
+	Array arr;
+	for (int i = 0; i < data.size(); ++i) {
+		arr.push_back(data[i]);
+	}
+	ret["data"] = arr;
+	return ret;
+}
+
+String Grid2D::to_string() {
+	if (is_empty()) {
+		return "[]";
+	}
+	String str;
+	for (int y = 0; y < height; ++y) {
+		str += "[";
+		for (int x = 0; x < width; ++x) {
+			uint32_t ofs = y * width + x;
+			str += String(data[ofs]);
+			if (x != width - 1) {
+				str += ", ";
+			} else {
+				str += "]";
+			}
+		}
+		str += "\n";
+	}
+	return str;
+}
+
+void Grid2D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("create", "width", "height"), &Grid2D::create);
+	ClassDB::bind_method(D_METHOD("create_from_data", "width", "height", "data"), &Grid2D::create_from_data);
+	ClassDB::bind_method(D_METHOD("resize", "new_width", "new_height"), &Grid2D::resize);
+
+	ClassDB::bind_method(D_METHOD("set_element", "x", "y", "value"), &Grid2D::set_element);
+	ClassDB::bind_method(D_METHOD("get_element", "x", "y"), &Grid2D::get_element);
+	ClassDB::bind_method(D_METHOD("set_cell", "position", "value"), &Grid2D::set_cell);
+	ClassDB::bind_method(D_METHOD("get_cell", "position"), &Grid2D::get_cell);
+
+	ClassDB::bind_method(D_METHOD("fill", "with_value"), &Grid2D::fill);
+
+	ClassDB::bind_method(D_METHOD("get_width"), &Grid2D::get_width);
+	ClassDB::bind_method(D_METHOD("get_height"), &Grid2D::get_height);
+	ClassDB::bind_method(D_METHOD("get_size"), &Grid2D::get_size);
+
+	ClassDB::bind_method(D_METHOD("is_empty"), &Grid2D::is_empty);
+	ClassDB::bind_method(D_METHOD("clear"), &Grid2D::clear);
+	
+	ClassDB::bind_method(D_METHOD("_iter_init"), &Grid2D::_iter_init);
+	ClassDB::bind_method(D_METHOD("_iter_get"), &Grid2D::_iter_get);
+	ClassDB::bind_method(D_METHOD("_iter_next"), &Grid2D::_iter_next);
+	
+	ClassDB::bind_method(D_METHOD("_set_data", "data"), &Grid2D::_set_data);
+	ClassDB::bind_method(D_METHOD("_get_data"), &Grid2D::_get_data);
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "_set_data", "_get_data");
+}

--- a/core/types/grid_2d.h
+++ b/core/types/grid_2d.h
@@ -1,0 +1,51 @@
+#ifndef GOOST_GRID_2D_H
+#define GOOST_GRID_2D_H
+
+#include "core/resource.h"
+#include "core/variant.h"
+
+class Grid2D : public Resource {
+	GDCLASS(Grid2D, Resource);
+
+protected:
+	static void _bind_methods();
+
+private:
+	Vector<Variant> data;
+	int width = 0;
+	int height = 0;
+
+protected:
+	// Custom iterator for scripting.
+	int _iter_current = 0;
+	Variant _iter_init(const Array &p_iter);
+	Variant _iter_next(const Array &p_iter);
+	Variant _iter_get(const Variant &p_iter);
+
+	// Storage.
+	void _set_data(const Dictionary &p_data);
+	Dictionary _get_data() const;
+
+public:
+	void create(int p_width, int p_height);
+	void create_from_data(int p_width, int p_height, Array p_data);
+	void resize(int p_new_width, int p_new_height);
+
+	_FORCE_INLINE_ void set_element(int p_x, int p_y, const Variant &p_value);
+	_FORCE_INLINE_ Variant get_element(int p_x, int p_y);
+	void set_cell(const Vector2 &p_pos, const Variant &p_value);
+	Variant get_cell(const Vector2 &p_pos);
+
+	void fill(const Variant &p_value);
+
+	int get_width() const { return width; }
+	int get_height() const { return height; }
+	Vector2 get_size() const { return Vector2(width, height); }
+
+	bool is_empty() const { return width == 0 && height == 0; }
+	void clear() { data.clear(); width = height = 0; }
+
+	virtual String to_string();
+};
+
+#endif // GOOST_GRID_2D_H

--- a/doc/Grid2D.xml
+++ b/doc/Grid2D.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="Grid2D" inherits="Resource" version="3.2">
+	<brief_description>
+		A two-dimensional data container.
+	</brief_description>
+	<description>
+		A data structure which holds an arbitrary number of elements in a grid. Each cell represents a single element which stores any [Variant] compatible datatype. Can act as a helper class for other pixel-based classes such as [Image], [BitMap], [TileMap] etc.
+		The grid is initialized with [method create] method:
+		[codeblock]
+		var grid = Grid2D.new()
+		grid.create(3, 4)
+		grid.set_element(2, 3, "Goost")
+		print(grid.get_element(2, 3)) # Prints: "Goost".
+		[/codeblock]
+		Traversing all elements can be done just like two-dimensional array (or image):
+		[codeblock]
+		for y in grid.get_height():
+		    for x in grid.get_width():
+		        print(grid.get_element(x, y))
+		[/codeblock]
+		Alternatively, all elements can be traversed using a simplified syntax:
+		[codeblock]
+		for element in grid:
+		    print(element)
+		[/codeblock]
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="clear">
+			<return type="void">
+			</return>
+			<description>
+				Clears all elements in this grid.
+			</description>
+		</method>
+		<method name="create">
+			<return type="void">
+			</return>
+			<argument index="0" name="width" type="int">
+			</argument>
+			<argument index="1" name="height" type="int">
+			</argument>
+			<description>
+				Initializes the grid by allocating new data to hold [code]width * height[/code] elements. By default, all elements of the grid are initialized to [code]null[/code] values.
+				[b]Note:[/b] this clears all existing elements from the grid before creation.
+			</description>
+		</method>
+		<method name="create_from_data">
+			<return type="void">
+			</return>
+			<argument index="0" name="width" type="int">
+			</argument>
+			<argument index="1" name="height" type="int">
+			</argument>
+			<argument index="2" name="data" type="Array">
+			</argument>
+			<description>
+				Initializes the grid from a continuos 1D array of data. The number of elements in [code]data[/code] must be equal to [code]width * height[/code].
+			</description>
+		</method>
+		<method name="fill">
+			<return type="void">
+			</return>
+			<argument index="0" name="with_value" type="Variant">
+			</argument>
+			<description>
+				Fills all elements in the grid with a specified value.
+			</description>
+		</method>
+		<method name="get_cell">
+			<return type="Variant">
+			</return>
+			<argument index="0" name="position" type="Vector2">
+			</argument>
+			<description>
+				Similar to [method get_element], but accepts [Vector2] as coordinates.
+			</description>
+		</method>
+		<method name="get_element">
+			<return type="Variant">
+			</return>
+			<argument index="0" name="x" type="int">
+			</argument>
+			<argument index="1" name="y" type="int">
+			</argument>
+			<description>
+				Returns an element at specified coordinates.
+			</description>
+		</method>
+		<method name="get_height" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns the total number of rows.
+			</description>
+		</method>
+		<method name="get_size" qualifiers="const">
+			<return type="Vector2">
+			</return>
+			<description>
+				Returns the grid dimensions as [Vector2] (width and height).
+			</description>
+		</method>
+		<method name="get_width" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns the total number of elements per row.
+			</description>
+		</method>
+		<method name="is_empty" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+				Returns whether the grid is empty (does not contain data).
+			</description>
+		</method>
+		<method name="resize">
+			<return type="void">
+			</return>
+			<argument index="0" name="new_width" type="int">
+			</argument>
+			<argument index="1" name="new_height" type="int">
+			</argument>
+			<description>
+				Resizes the grid to have a different number of elements. Resizing an existing grid to a smaller size rearranges the elements to fit new width and height without preserving original positions ([b]To-do:[/b] implement cropping method for this). Resizing an existing grid to a larger size initializes new elements to [code]null[/code].
+			</description>
+		</method>
+		<method name="set_cell">
+			<return type="void">
+			</return>
+			<argument index="0" name="position" type="Vector2">
+			</argument>
+			<argument index="1" name="value" type="Variant">
+			</argument>
+			<description>
+				Similar to [method set_element], but accepts [Vector2] as coordinates.
+			</description>
+		</method>
+		<method name="set_element">
+			<return type="void">
+			</return>
+			<argument index="0" name="x" type="int">
+			</argument>
+			<argument index="1" name="y" type="int">
+			</argument>
+			<argument index="2" name="value" type="Variant">
+			</argument>
+			<description>
+				Sets any value to element at specified coordinates.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="data" type="Dictionary" setter="_set_data" getter="_get_data" default="{&quot;data&quot;: [  ],&quot;height&quot;: 0,&quot;width&quot;: 0}">
+			The data which represents this grid. Used for storage.
+		</member>
+	</members>
+	<constants>
+	</constants>
+</class>

--- a/editor/icons/icon_grid_2d.svg
+++ b/editor/icons/icon_grid_2d.svg
@@ -1,0 +1,1 @@
+<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m1 1v14h14v-14zm2 2h2v2h-2zm4 0h2v2h-2zm4 0h2v2h-2zm-8 4h2v2h-2zm4 0h2v2h-2zm4 0h2v2h-2zm-8 4h2v2h-2zm4 0h2v2h-2zm4 0h2v2h-2z" fill="#e0e0e0"/></svg>

--- a/goost.py
+++ b/goost.py
@@ -50,6 +50,7 @@ classes = [
     "GoostGeometry2D",
     "GoostImage",
     "GradientTexture2D",
+    "Grid2D",
     "ImageBlender",
     "ImageIndexed",
     "LinkedList",

--- a/tests/project/goost/core/types/test_grid_2d.gd
+++ b/tests/project/goost/core/types/test_grid_2d.gd
@@ -1,0 +1,118 @@
+extends "res://addons/gut/test.gd"
+
+func test_create_clear():
+	var grid = Grid2D.new()
+	assert_true(grid.is_empty())
+
+	grid.create(512, 1024)
+	assert_false(grid.is_empty())
+
+	assert_eq(grid.get_width(), 512)
+	assert_eq(grid.get_height(), 1024)
+
+	grid.clear()
+	assert_true(grid.is_empty())
+
+
+func test_create_from_data():
+	var grid = Grid2D.new()
+	grid.create_from_data(2, 3, [0, 1, 2, 3, 4, 5])
+	gut.p(grid)
+
+	assert_eq(grid.get_element(0, 0), 0)
+	assert_eq(grid.get_element(1, 0), 1)
+	assert_eq(grid.get_element(0, 1), 2)
+	assert_eq(grid.get_element(1, 1), 3)
+	assert_eq(grid.get_element(0, 2), 4)
+	assert_eq(grid.get_element(1, 2), 5)
+
+
+func test_data():
+	var grid = Grid2D.new()
+	var arr = [0, 1, 2, 3, 4, 5]
+	var data = {"width": 2, "height": 3, "data": arr}
+	grid.data = data
+
+	assert_eq(grid.get_element(0, 0), 0)
+	assert_eq(grid.get_element(1, 0), 1)
+	assert_eq(grid.get_element(0, 1), 2)
+	assert_eq(grid.get_element(1, 1), 3)
+	assert_eq(grid.get_element(0, 2), 4)
+	assert_eq(grid.get_element(1, 2), 5)
+
+	var d = grid.data
+
+	assert_eq(d.width, 2)
+	assert_eq(d.height, 3)
+
+	var darr = d.data
+	for i in 6:
+		assert_eq(darr[i], arr[i])
+
+
+func test_resize():
+	var grid = Grid2D.new()
+	grid.create(4, 4)
+
+	var n = 0
+	for y in grid.get_height():
+		for x in grid.get_width():
+			grid.set_element(x, y, n)
+			n += 1
+
+	assert_eq(grid.get_element(0, 0), 0)
+	assert_eq(grid.get_element(1, 0), 1)
+	assert_eq(grid.get_element(0, 1), 4)
+	assert_eq(grid.get_element(1, 1), 5)
+
+	grid.resize(2, 2)
+
+	var msg = "This should just resize the data, and does not crop the grid."
+	assert_eq(grid.get_element(0, 0), 0, msg)
+	assert_eq(grid.get_element(1, 0), 1, msg)
+	assert_eq(grid.get_element(0, 1), 2, msg)
+	assert_eq(grid.get_element(1, 1), 3, msg)
+
+
+func test_element_cell_pixel():
+	var grid = Grid2D.new()
+	grid.create(4, 4)
+	assert_null(grid.get_element(0, 0))
+
+	grid.set_element(0, 0, "Goost")
+	assert_not_null(grid.get_element(0, 0))
+	assert_eq(grid.get_element(0, 0), "Goost")
+
+	assert_eq(grid.get_cell(Vector2(3, 3)), null)
+
+	grid.set_cell(Vector2(0, 0), null)
+	assert_null(grid.get_element(0, 0))
+
+
+func test_custom_iterator():
+	var grid = Grid2D.new()
+	grid.create(4, 4)
+
+	var n = 0
+	for y in grid.get_height():
+		for x in grid.get_width():
+			grid.set_element(x, y, n)
+			n += 1
+	gut.p(grid)
+
+	n = 0
+	for element in grid:
+		assert_eq(element, n)
+		n += 1
+
+
+func test_fill():
+	var grid = Grid2D.new()
+	grid.fill("Goost") # Should not crash filling empty grid.
+
+	grid.create(4, 4)
+	grid.fill("Goost")
+
+	for y in grid.get_height():
+		for x in grid.get_width():
+			assert_eq(grid.get_element(x, y), "Goost")


### PR DESCRIPTION
Currently implements essential modification and storage functionality.

Helps the underlying use case behind godotengine/godot#28631 (namely https://github.com/godotengine/godot/issues/28631#issuecomment-489058746).
Helps #14 (can hold `float` values), but doesn't provide per-element operations.

`Grid3D` can also be implemented (feel free to contribute).

