### PR TITLE
Add `has_cell` and `get_cell_or_null` to `Grid2D`

### DIFF
--- a/core/types/grid_2d.cpp
+++ b/core/types/grid_2d.cpp
@@ -62,6 +62,17 @@ Variant Grid2D::get_cell(const Vector2 &p_pos) {
 	return get_element(p_pos.x, p_pos.y);
 }
 
+Variant Grid2D::get_cell_or_null(const Vector2 &p_pos) {
+	if (!has_cell(p_pos)) {
+		return Variant();
+	}
+	return get_element(p_pos.x, p_pos.y);
+}
+
+bool Grid2D::has_cell(const Vector2 &p_pos) {
+	return p_pos.x >= 0 && p_pos.y >= 0 && p_pos.x < width && p_pos.y < height;
+}
+
 void Grid2D::fill(const Variant &p_value) {
 	int idx = 0;
 	const int count = width * height;
@@ -69,6 +80,12 @@ void Grid2D::fill(const Variant &p_value) {
 	while (idx < count) {
 		dest[idx++] = p_value;
 	}
+}
+
+void Grid2D::clear() {
+	data.clear();
+	width = 0;
+	height = 0;
 }
 
 Variant Grid2D::_iter_init(const Array &p_iter) {
@@ -137,8 +154,11 @@ void Grid2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_element", "x", "y", "value"), &Grid2D::set_element);
 	ClassDB::bind_method(D_METHOD("get_element", "x", "y"), &Grid2D::get_element);
+
 	ClassDB::bind_method(D_METHOD("set_cell", "position", "value"), &Grid2D::set_cell);
 	ClassDB::bind_method(D_METHOD("get_cell", "position"), &Grid2D::get_cell);
+	ClassDB::bind_method(D_METHOD("get_cell_or_null", "position"), &Grid2D::get_cell_or_null);
+	ClassDB::bind_method(D_METHOD("has_cell", "position"), &Grid2D::has_cell);
 
 	ClassDB::bind_method(D_METHOD("fill", "with_value"), &Grid2D::fill);
 
@@ -148,11 +168,11 @@ void Grid2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("is_empty"), &Grid2D::is_empty);
 	ClassDB::bind_method(D_METHOD("clear"), &Grid2D::clear);
-	
+
 	ClassDB::bind_method(D_METHOD("_iter_init"), &Grid2D::_iter_init);
 	ClassDB::bind_method(D_METHOD("_iter_get"), &Grid2D::_iter_get);
 	ClassDB::bind_method(D_METHOD("_iter_next"), &Grid2D::_iter_next);
-	
+
 	ClassDB::bind_method(D_METHOD("_set_data", "data"), &Grid2D::_set_data);
 	ClassDB::bind_method(D_METHOD("_get_data"), &Grid2D::_get_data);
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "_set_data", "_get_data");

--- a/core/types/grid_2d.h
+++ b/core/types/grid_2d.h
@@ -33,8 +33,11 @@ public:
 
 	_FORCE_INLINE_ void set_element(int p_x, int p_y, const Variant &p_value);
 	_FORCE_INLINE_ Variant get_element(int p_x, int p_y);
+
 	void set_cell(const Vector2 &p_pos, const Variant &p_value);
 	Variant get_cell(const Vector2 &p_pos);
+	Variant get_cell_or_null(const Vector2 &p_pos);
+	bool has_cell(const Vector2 &p_pos);
 
 	void fill(const Variant &p_value);
 
@@ -43,7 +46,7 @@ public:
 	Vector2 get_size() const { return Vector2(width, height); }
 
 	bool is_empty() const { return width == 0 && height == 0; }
-	void clear() { data.clear(); width = height = 0; }
+	void clear();
 
 	virtual String to_string();
 };

--- a/doc/Grid2D.xml
+++ b/doc/Grid2D.xml
@@ -77,6 +77,15 @@
 				Similar to [method get_element], but accepts [Vector2] as coordinates.
 			</description>
 		</method>
+		<method name="get_cell_or_null">
+			<return type="Variant">
+			</return>
+			<argument index="0" name="position" type="Vector2">
+			</argument>
+			<description>
+				Returns cell's value if the grid contains an element at specified position, otherwise returns [code]null[/code]. See also [method has_cell].
+			</description>
+		</method>
 		<method name="get_element">
 			<return type="Variant">
 			</return>
@@ -107,6 +116,15 @@
 			</return>
 			<description>
 				Returns the total number of elements per row.
+			</description>
+		</method>
+		<method name="has_cell">
+			<return type="bool">
+			</return>
+			<argument index="0" name="position" type="Vector2">
+			</argument>
+			<description>
+				Returns [code]true[/code] if the grid contains an element at specified position. Returns [code]false[/code] if the position lies outside the grid dimensions. See also [method get_cell_or_null].
 			</description>
 		</method>
 		<method name="is_empty" qualifiers="const">

--- a/tests/project/goost/core/types/test_grid_2d.gd
+++ b/tests/project/goost/core/types/test_grid_2d.gd
@@ -74,7 +74,7 @@ func test_resize():
 	assert_eq(grid.get_element(1, 1), 3, msg)
 
 
-func test_element_cell_pixel():
+func test_element_cell():
 	var grid = Grid2D.new()
 	grid.create(4, 4)
 	assert_null(grid.get_element(0, 0))
@@ -87,6 +87,22 @@ func test_element_cell_pixel():
 
 	grid.set_cell(Vector2(0, 0), null)
 	assert_null(grid.get_element(0, 0))
+
+	assert_true(grid.has_cell(Vector2(0, 0)))
+	assert_true(grid.has_cell(Vector2(3, 0)))
+	assert_true(grid.has_cell(Vector2(0, 3)))
+	assert_true(grid.has_cell(Vector2(3, 3)))
+	assert_false(grid.has_cell(Vector2(0, -1)))
+	assert_false(grid.has_cell(Vector2(4, 3)))
+
+	assert_null(grid.get_cell_or_null(Vector2(-1, -1)))
+	assert_null(grid.get_cell_or_null(Vector2(3, 4)))
+	assert_null(grid.get_cell_or_null(Vector2(4, 3)))
+
+	grid.set_cell(Vector2(0, 0), "Goost")
+
+	assert_not_null(grid.get_cell_or_null(Vector2(0, 0)))
+	assert_eq(grid.get_cell_or_null(Vector2(0, 0)), "Goost")
 
 
 func test_custom_iterator():


### PR DESCRIPTION
Useful for grid cardinal/diagonal lookups, and various other algorithms which may require preventing going outside of the grid's dimensions.