### PR TITLE
Add `invoke` method

### DIFF
--- a/core/goost_engine.cpp
+++ b/core/goost_engine.cpp
@@ -47,35 +47,69 @@ Variant GoostEngine::_defer_call_unique_bind(const Variant **p_args, int p_argco
 	return Variant();
 }
 
-void GoostEngine::_invoke(Object *p_obj, StringName p_method, real_t p_sec, bool p_pause_mode, bool p_deferred) {
+void GoostEngine::_invoke(Object *p_obj, StringName p_method, real_t p_sec, real_t p_rate, bool p_pause_mode, bool p_deferred) {
 	ERR_FAIL_NULL_MSG(p_obj, "Invalid object");
 
 	SceneTree *tree = Object::cast_to<SceneTree>(OS::get_singleton()->get_main_loop());
 	ERR_FAIL_NULL_MSG(tree, "The `invoke()` method requires a SceneTree to work.");
 
 	Ref<SceneTreeTimer> timer = tree->create_timer(p_sec, p_pause_mode);
+
+	Ref<InvokeState> state;
+	state.instance();
+	state->instance_id = p_obj->get_instance_id();
+	state->method = p_method;
+	state->timer = timer;
+	state->active = true;
+	state->repeat_rate = p_rate;
+
 	timer->connect("timeout", this, "_on_invoke_timeout",
-			varray(p_obj->get_instance_id(), p_method), p_deferred ? CONNECT_DEFERRED : 0);
+			varray(state, p_pause_mode, p_deferred), p_deferred ? CONNECT_DEFERRED : 0);
+
+	invokes.push_back(state);
 }
 
-void GoostEngine::invoke(Object *p_obj, StringName p_method, real_t p_sec, bool p_pause_mode) {
-	_invoke(p_obj, p_method, p_sec, p_pause_mode, false);
+void GoostEngine::invoke(Object *p_obj, StringName p_method, real_t p_sec, real_t p_rate, bool p_pause_mode) {
+	_invoke(p_obj, p_method, p_sec, p_rate, p_pause_mode, false);
 }
 
-void GoostEngine::invoke_deferred(Object *p_obj, StringName p_method, real_t p_sec, bool p_pause_mode) {
-	_invoke(p_obj, p_method, p_sec, p_pause_mode, true);
+void GoostEngine::invoke_deferred(Object *p_obj, StringName p_method, real_t p_sec, real_t p_rate, bool p_pause_mode) {
+	_invoke(p_obj, p_method, p_sec, p_rate, p_pause_mode, true);
 }
 
-void GoostEngine::_on_invoke_timeout(ObjectID p_id, StringName p_method) {
-	Object *obj = ObjectDB::get_instance(p_id);
-	if (!obj) {
-		return; // Might be gone by this time.
+void GoostEngine::_on_invoke_timeout(Ref<InvokeState> p_state, bool p_pause_mode, bool p_deferred) {
+	ERR_FAIL_COND(p_state.is_null());
+
+	Object *obj = ObjectDB::get_instance(p_state->instance_id);
+	if (obj && p_state->is_active()) {
+		Variant::CallError ce;
+		obj->call(p_state->method, nullptr, 0, ce);
+		if (ce.error != Variant::CallError::CALL_OK) {
+			ERR_PRINT("Error invoking method: " + Variant::get_call_error_text(obj, p_state->method, nullptr, 0, ce) + ".");
+		}
+		if (p_state->is_repeating()) {
+			SceneTree *tree = Object::cast_to<SceneTree>(OS::get_singleton()->get_main_loop());
+			Ref<SceneTreeTimer> timer = tree->create_timer(p_state->repeat_rate, p_pause_mode);
+			p_state->timer = timer;
+			timer->connect("timeout", this, "_on_invoke_timeout",
+					varray(p_state, p_pause_mode, p_deferred), p_deferred ? CONNECT_DEFERRED : 0);
+			p_state->emit_signal("step");
+		} else {
+			p_state->active = false;
+			p_state->emit_signal("completed");
+		}
 	}
-	Variant::CallError ce;
-	obj->call(p_method, nullptr, 0, ce);
-	if (ce.error != Variant::CallError::CALL_OK) {
-		ERR_PRINT("Error invoking method: " + Variant::get_call_error_text(obj, p_method, nullptr, 0, ce) + ".");
+	if (!p_state->is_active()) {
+		invokes.erase(p_state);
 	}
+}
+
+Array GoostEngine::get_invokes() const {
+	Array ret;
+	for (int i = 0; i < invokes.size(); ++i) {
+		ret.push_back(invokes[i]);
+	}
+	return ret;
 }
 
 void GoostEngine::flush_calls() {
@@ -91,7 +125,8 @@ void GoostEngine::_bind_methods() {
 		mi.arguments.push_back(PropertyInfo(Variant::STRING, "method"));
 		ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "defer_call_unique", &GoostEngine::_defer_call_unique_bind, mi, varray(), false);
 	}
-	ClassDB::bind_method(D_METHOD("invoke", "object", "method", "delay_seconds", "pause_mode_process"), &GoostEngine::invoke, DEFVAL(true));
-	ClassDB::bind_method(D_METHOD("invoke_deferred", "object", "method", "delay_seconds", "pause_mode_process"), &GoostEngine::invoke_deferred, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("invoke", "object", "method", "delay_seconds", "repeat_rate_seconds", "pause_mode_process"), &GoostEngine::invoke, DEFVAL(-1.0), DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("invoke_deferred", "object", "method", "delay_seconds", "repeat_rate_seconds", "pause_mode_process"), &GoostEngine::invoke_deferred, DEFVAL(-1.0), DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("get_invokes"), &GoostEngine::get_invokes);
 	ClassDB::bind_method(D_METHOD("_on_invoke_timeout"), &GoostEngine::_on_invoke_timeout);
 }

--- a/core/goost_engine.cpp
+++ b/core/goost_engine.cpp
@@ -1,7 +1,7 @@
 #include "goost_engine.h"
 
-#include "core/engine.h"
 #include "core/color_names.inc"
+#include "core/os/os.h"
 
 GoostEngine *GoostEngine::singleton = nullptr;
 
@@ -47,6 +47,37 @@ Variant GoostEngine::_defer_call_unique_bind(const Variant **p_args, int p_argco
 	return Variant();
 }
 
+void GoostEngine::_invoke(Object *p_obj, StringName p_method, real_t p_sec, bool p_pause_mode, bool p_deferred) {
+	ERR_FAIL_NULL_MSG(p_obj, "Invalid object");
+
+	SceneTree *tree = Object::cast_to<SceneTree>(OS::get_singleton()->get_main_loop());
+	ERR_FAIL_NULL_MSG(tree, "The `invoke()` method requires a SceneTree to work.");
+
+	Ref<SceneTreeTimer> timer = tree->create_timer(p_sec, p_pause_mode);
+	timer->connect("timeout", this, "_on_invoke_timeout",
+			varray(p_obj->get_instance_id(), p_method), p_deferred ? CONNECT_DEFERRED : 0);
+}
+
+void GoostEngine::invoke(Object *p_obj, StringName p_method, real_t p_sec, bool p_pause_mode) {
+	_invoke(p_obj, p_method, p_sec, p_pause_mode, false);
+}
+
+void GoostEngine::invoke_deferred(Object *p_obj, StringName p_method, real_t p_sec, bool p_pause_mode) {
+	_invoke(p_obj, p_method, p_sec, p_pause_mode, true);
+}
+
+void GoostEngine::_on_invoke_timeout(ObjectID p_id, StringName p_method) {
+	Object *obj = ObjectDB::get_instance(p_id);
+	if (!obj) {
+		return; // Might be gone by this time.
+	}
+	Variant::CallError ce;
+	obj->call(p_method, nullptr, 0, ce);
+	if (ce.error != Variant::CallError::CALL_OK) {
+		ERR_PRINT("Error invoking method: " + Variant::get_call_error_text(obj, p_method, nullptr, 0, ce) + ".");
+	}
+}
+
 void GoostEngine::flush_calls() {
 	singleton->deferred_calls.flush();
 }
@@ -60,4 +91,7 @@ void GoostEngine::_bind_methods() {
 		mi.arguments.push_back(PropertyInfo(Variant::STRING, "method"));
 		ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "defer_call_unique", &GoostEngine::_defer_call_unique_bind, mi, varray(), false);
 	}
+	ClassDB::bind_method(D_METHOD("invoke", "object", "method", "delay_seconds", "pause_mode_process"), &GoostEngine::invoke, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("invoke_deferred", "object", "method", "delay_seconds", "pause_mode_process"), &GoostEngine::invoke_deferred, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("_on_invoke_timeout"), &GoostEngine::_on_invoke_timeout);
 }

--- a/core/goost_engine.h
+++ b/core/goost_engine.h
@@ -1,9 +1,11 @@
 #ifndef GOOST_ENGINE_H
 #define GOOST_ENGINE_H
 
-#include "scene/main/scene_tree.h"
 #include "core/object.h"
+#include "scene/main/scene_tree.h"
+
 #include "func_buffer.h"
+#include "invoke_state.h"
 
 class GoostEngine : public Object {
 	GDCLASS(GoostEngine, Object);
@@ -11,14 +13,15 @@ class GoostEngine : public Object {
 private:
 	static GoostEngine *singleton;
 	FuncBuffer deferred_calls;
+	Vector<Ref<InvokeState>> invokes;
 
 protected:
 	static void _bind_methods();
 
 	Variant _defer_call_unique_bind(const Variant **p_args, int p_argcount, Variant::CallError &r_error);
 
-	void _invoke(Object *p_obj, StringName p_method, real_t p_delay_seconds, bool p_pause_mode_process, bool p_deferred);
-	void _on_invoke_timeout(ObjectID p_id, StringName p_method);
+	void _invoke(Object *p_obj, StringName p_method, real_t p_delay_seconds, real_t p_repeat_rate, bool p_pause_mode_process, bool p_deferred);
+	void _on_invoke_timeout(Ref<InvokeState> p_state, bool p_pause_mode, bool p_deferred);
 
 public:
 	static GoostEngine *get_singleton() { return singleton; }
@@ -27,8 +30,9 @@ public:
 
 	void defer_call_unique(Object *p_obj, StringName p_method, VARIANT_ARG_LIST);
 
-	void invoke(Object *p_obj, StringName p_method, real_t p_delay_seconds, bool p_pause_mode_process = true);
-	void invoke_deferred(Object *p_obj, StringName p_method, real_t p_delay_seconds, bool p_pause_mode_process = true);
+	void invoke(Object *p_obj, StringName p_method, real_t p_delay_seconds, real_t p_repeat_rate, bool p_pause_mode_process = true);
+	void invoke_deferred(Object *p_obj, StringName p_method, real_t p_delay_seconds, real_t p_repeat_rate, bool p_pause_mode_process = true);
+	Array get_invokes() const;
 
 	static void flush_calls();
 

--- a/core/goost_engine.h
+++ b/core/goost_engine.h
@@ -20,7 +20,7 @@ protected:
 
 	Variant _defer_call_unique_bind(const Variant **p_args, int p_argcount, Variant::CallError &r_error);
 
-	void _invoke(Object *p_obj, StringName p_method, real_t p_delay_seconds, real_t p_repeat_rate, bool p_pause_mode_process, bool p_deferred);
+	Ref<InvokeState> _invoke(Object *p_obj, StringName p_method, real_t p_delay, real_t p_repeat_rate, bool p_pause_mode_process, bool p_deferred);
 	void _on_invoke_timeout(Ref<InvokeState> p_state, bool p_pause_mode, bool p_deferred);
 
 public:
@@ -30,8 +30,8 @@ public:
 
 	void defer_call_unique(Object *p_obj, StringName p_method, VARIANT_ARG_LIST);
 
-	void invoke(Object *p_obj, StringName p_method, real_t p_delay_seconds, real_t p_repeat_rate, bool p_pause_mode_process = true);
-	void invoke_deferred(Object *p_obj, StringName p_method, real_t p_delay_seconds, real_t p_repeat_rate, bool p_pause_mode_process = true);
+	Ref<InvokeState> invoke(Object *p_obj, StringName p_method, real_t p_delay, real_t p_repeat_rate, bool p_pause_mode_process = true);
+	Ref<InvokeState> invoke_deferred(Object *p_obj, StringName p_method, real_t p_delay, real_t p_repeat_rate, bool p_pause_mode_process = true);
 	Array get_invokes() const;
 
 	static void flush_calls();

--- a/core/goost_engine.h
+++ b/core/goost_engine.h
@@ -1,6 +1,7 @@
 #ifndef GOOST_ENGINE_H
 #define GOOST_ENGINE_H
 
+#include "scene/main/scene_tree.h"
 #include "core/object.h"
 #include "func_buffer.h"
 
@@ -14,13 +15,20 @@ private:
 protected:
 	static void _bind_methods();
 
+	Variant _defer_call_unique_bind(const Variant **p_args, int p_argcount, Variant::CallError &r_error);
+
+	void _invoke(Object *p_obj, StringName p_method, real_t p_delay_seconds, bool p_pause_mode_process, bool p_deferred);
+	void _on_invoke_timeout(ObjectID p_id, StringName p_method);
+
 public:
 	static GoostEngine *get_singleton() { return singleton; }
 
 	Dictionary get_color_constants() const;
 
 	void defer_call_unique(Object *p_obj, StringName p_method, VARIANT_ARG_LIST);
-	Variant _defer_call_unique_bind(const Variant **p_args, int p_argcount, Variant::CallError &r_error);
+
+	void invoke(Object *p_obj, StringName p_method, real_t p_delay_seconds, bool p_pause_mode_process = true);
+	void invoke_deferred(Object *p_obj, StringName p_method, real_t p_delay_seconds, bool p_pause_mode_process = true);
 
 	static void flush_calls();
 

--- a/core/invoke_state.cpp
+++ b/core/invoke_state.cpp
@@ -1,0 +1,17 @@
+#include "invoke_state.h"
+#include "scene/scene_string_names.h"
+
+void InvokeState::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_target_id"), &InvokeState::get_target_id);
+	ClassDB::bind_method(D_METHOD("get_target"), &InvokeState::get_target);
+	ClassDB::bind_method(D_METHOD("get_target_method"), &InvokeState::get_target_method);
+
+	ClassDB::bind_method(D_METHOD("cancel"), &InvokeState::cancel);
+	ClassDB::bind_method(D_METHOD("is_active"), &InvokeState::is_active);
+	ClassDB::bind_method(D_METHOD("is_repeating"), &InvokeState::is_repeating);
+
+	ClassDB::bind_method(D_METHOD("get_time_left"), &InvokeState::get_time_left);
+	
+	ADD_SIGNAL(MethodInfo("completed"));
+	ADD_SIGNAL(MethodInfo("step"));
+}

--- a/core/invoke_state.cpp
+++ b/core/invoke_state.cpp
@@ -2,7 +2,6 @@
 #include "scene/scene_string_names.h"
 
 void InvokeState::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("get_target_id"), &InvokeState::get_target_id);
 	ClassDB::bind_method(D_METHOD("get_target"), &InvokeState::get_target);
 	ClassDB::bind_method(D_METHOD("get_target_method"), &InvokeState::get_target_method);
 
@@ -12,6 +11,11 @@ void InvokeState::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_time_left"), &InvokeState::get_time_left);
 	
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "target"), "", "get_target");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "method"), "", "get_target_method");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "time_left"), "", "get_time_left");
+
+	ADD_SIGNAL(MethodInfo("pre_call"));
+	ADD_SIGNAL(MethodInfo("post_call"));
 	ADD_SIGNAL(MethodInfo("completed"));
-	ADD_SIGNAL(MethodInfo("step"));
 }

--- a/core/invoke_state.h
+++ b/core/invoke_state.h
@@ -1,0 +1,34 @@
+#ifndef INVOKE_STATE_H
+#define INVOKE_STATE_H
+
+#include "core/reference.h"
+#include "scene/main/scene_tree.h"
+
+class InvokeState : public Reference {
+	GDCLASS(InvokeState, Reference);
+
+	friend class GoostEngine;
+
+	ObjectID instance_id = 0;
+	StringName method;
+	Ref<SceneTreeTimer> timer;
+
+	bool active = false;
+	real_t repeat_rate = 0.0;
+
+protected:
+	static void _bind_methods();
+
+public:
+	ObjectID get_target_id() const { return instance_id; }
+	Object * get_target() const { return ObjectDB::get_instance(instance_id); }
+	StringName get_target_method() const { return method; }
+
+	void cancel() { active = false; }
+	bool is_active() { return active; } // No setter, only possible to cancel the state.
+	bool is_repeating() { return repeat_rate >= 0.0; }
+
+	real_t get_time_left() { return timer->get_time_left(); }
+};
+
+#endif // INVOKE_STATE_H

--- a/core/invoke_state.h
+++ b/core/invoke_state.h
@@ -11,7 +11,7 @@ class InvokeState : public Reference {
 
 	ObjectID instance_id = 0;
 	StringName method;
-	Ref<SceneTreeTimer> timer;
+	Ref<SceneTreeTimer> timer; // Needed to fetch `time_left`.
 
 	bool active = false;
 	real_t repeat_rate = 0.0;
@@ -20,15 +20,14 @@ protected:
 	static void _bind_methods();
 
 public:
-	ObjectID get_target_id() const { return instance_id; }
-	Object * get_target() const { return ObjectDB::get_instance(instance_id); }
+	Object *get_target() const { return ObjectDB::get_instance(instance_id); }
 	StringName get_target_method() const { return method; }
 
 	void cancel() { active = false; }
 	bool is_active() { return active; } // No setter, only possible to cancel the state.
 	bool is_repeating() { return repeat_rate >= 0.0; }
 
-	real_t get_time_left() { return timer->get_time_left(); }
+	real_t get_time_left() { return active ? timer->get_time_left() : 0; }
 };
 
 #endif // INVOKE_STATE_H

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -1,13 +1,16 @@
 #include "register_core_types.h"
 
 #include "core/engine.h"
+#include "scene/main/scene_tree.h"
+
+#include "goost_engine.h"
+#include "invoke_state.h"
 
 #include "image/register_image_types.h"
 #include "math/register_math_types.h"
 #include "types/grid_2d.h"
 #include "types/list.h"
 #include "types/variant_resource.h"
-#include "invoke_state.h"
 
 #ifdef TOOLS_ENABLED
 #include "editor/editor_node.h"
@@ -16,16 +19,20 @@
 #endif
 
 namespace goost {
-
+	
+static GoostEngine *_goost = nullptr;
 #ifdef TOOLS_ENABLED
-static void _variant_resource_preview_init() {
-	Ref<VariantResourcePreviewGenerator> variant_resource_preview;
-	variant_resource_preview.instance();
-	EditorResourcePreview::get_singleton()->add_preview_generator(variant_resource_preview);
-}
+static void _variant_resource_preview_init();
 #endif
 
 void register_core_types() {
+	_goost = memnew(GoostEngine);
+	ClassDB::register_class<GoostEngine>();
+	Engine::get_singleton()->add_singleton(
+			Engine::Singleton("GoostEngine", GoostEngine::get_singleton()));
+	SceneTree::add_idle_callback(&GoostEngine::flush_calls);
+	ClassDB::register_class<InvokeState>();
+
 	ClassDB::register_class<Grid2D>();
 	ClassDB::register_class<ListNode>();
 	ClassDB::register_class<LinkedList>();
@@ -34,7 +41,6 @@ void register_core_types() {
 #ifdef TOOLS_ENABLED
 	EditorNode::add_init_callback(_variant_resource_preview_init);
 #endif
-	ClassDB::register_class<InvokeState>();
 
 #ifdef GOOST_IMAGE_ENABLED
 	register_image_types();
@@ -45,6 +51,9 @@ void register_core_types() {
 }
 
 void unregister_core_types() {
+	if (_goost) { 
+		memdelete(_goost);
+	}
 #ifdef GOOST_IMAGE_ENABLED
 	unregister_image_types();
 #endif
@@ -52,5 +61,13 @@ void unregister_core_types() {
 	unregister_math_types();
 #endif
 }
+
+#ifdef TOOLS_ENABLED
+void _variant_resource_preview_init() {
+	Ref<VariantResourcePreviewGenerator> variant_resource_preview;
+	variant_resource_preview.instance();
+	EditorResourcePreview::get_singleton()->add_preview_generator(variant_resource_preview);
+}
+#endif
 
 } // namespace goost

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -7,6 +7,7 @@
 #include "types/grid_2d.h"
 #include "types/list.h"
 #include "types/variant_resource.h"
+#include "invoke_state.h"
 
 #ifdef TOOLS_ENABLED
 #include "editor/editor_node.h"
@@ -33,6 +34,7 @@ void register_core_types() {
 #ifdef TOOLS_ENABLED
 	EditorNode::add_init_callback(_variant_resource_preview_init);
 #endif
+	ClassDB::register_class<InvokeState>();
 
 #ifdef GOOST_IMAGE_ENABLED
 	register_image_types();

--- a/doc/GoostEngine.xml
+++ b/doc/GoostEngine.xml
@@ -36,35 +36,52 @@
 				[/codeblock]
 			</description>
 		</method>
+		<method name="get_invokes" qualifiers="const">
+			<return type="Array">
+			</return>
+			<description>
+				Returns an [Array] of active [InvokeState] objects which can be used to track pending method invocations. If any reference to repeating [InvokeState] is lost, then all such invocations can be cancelled the following way:
+				[codeblock]
+				for state in GoostEngine.get_invokes():
+				    if state.is_repeating():
+				        state.cancel()
+				[/codeblock]
+			</description>
+		</method>
 		<method name="invoke">
-			<return type="void">
+			<return type="InvokeState">
 			</return>
 			<argument index="0" name="object" type="Object">
 			</argument>
 			<argument index="1" name="method" type="String">
 			</argument>
-			<argument index="2" name="delay_seconds" type="float">
+			<argument index="2" name="delay" type="float">
 			</argument>
-			<argument index="3" name="pause_mode_process" type="bool" default="true">
+			<argument index="3" name="repeat_rate" type="float" default="-1.0">
+			</argument>
+			<argument index="4" name="pause_mode_process" type="bool" default="true">
 			</argument>
 			<description>
-				Schedules a [code]method[/code] on the [code]object[/code] to be called [code]delay_seconds[/code] later. If [code]pause_mode_process[/code] is set to [code]false[/code], pausing the [SceneTree] will also postpone the function from being called until the [SceneTree] pause state is resumed. If the object is freed during the wait period, the invocation is cancelled.
-				[b]Note:[/b] manual cancellation is not supported.
+				Schedules a [code]method[/code] on the [code]object[/code] to be called [code]delay[/code] seconds later.
+				If [code]repeat_rate &gt;= 0.0[/code], then the method is invoked repeatedly every [code]repeat_rate[/code] seconds until it's cancelled manually using [method InvokeState.cancel]. If the object is freed during the wait period, the invocation is cancelled automatically.
+				If [code]pause_mode_process[/code] is set to [code]false[/code], pausing the [SceneTree] will also postpone the function from being called until the [SceneTree] pause state is resumed.
 			</description>
 		</method>
 		<method name="invoke_deferred">
-			<return type="void">
+			<return type="InvokeState">
 			</return>
 			<argument index="0" name="object" type="Object">
 			</argument>
 			<argument index="1" name="method" type="String">
 			</argument>
-			<argument index="2" name="delay_seconds" type="float">
+			<argument index="2" name="delay" type="float">
 			</argument>
-			<argument index="3" name="pause_mode_process" type="bool" default="true">
+			<argument index="3" name="repeat_rate" type="float" default="-1.0">
+			</argument>
+			<argument index="4" name="pause_mode_process" type="bool" default="true">
 			</argument>
 			<description>
-				Same as [method invoke], but calls the [code]method[/code] on idle time when the time arrives.
+				Same as [method invoke], but calls the [code]method[/code] on idle time when the time arrives. This means that the method may not always be invoked exactly after [code]delay[/code] seconds.
 			</description>
 		</method>
 	</methods>

--- a/doc/GoostEngine.xml
+++ b/doc/GoostEngine.xml
@@ -36,6 +36,37 @@
 				[/codeblock]
 			</description>
 		</method>
+		<method name="invoke">
+			<return type="void">
+			</return>
+			<argument index="0" name="object" type="Object">
+			</argument>
+			<argument index="1" name="method" type="String">
+			</argument>
+			<argument index="2" name="delay_seconds" type="float">
+			</argument>
+			<argument index="3" name="pause_mode_process" type="bool" default="true">
+			</argument>
+			<description>
+				Schedules a [code]method[/code] on the [code]object[/code] to be called [code]delay_seconds[/code] later. If [code]pause_mode_process[/code] is set to [code]false[/code], pausing the [SceneTree] will also postpone the function from being called until the [SceneTree] pause state is resumed. If the object is freed during the wait period, the invocation is cancelled.
+				[b]Note:[/b] manual cancellation is not supported.
+			</description>
+		</method>
+		<method name="invoke_deferred">
+			<return type="void">
+			</return>
+			<argument index="0" name="object" type="Object">
+			</argument>
+			<argument index="1" name="method" type="String">
+			</argument>
+			<argument index="2" name="delay_seconds" type="float">
+			</argument>
+			<argument index="3" name="pause_mode_process" type="bool" default="true">
+			</argument>
+			<description>
+				Same as [method invoke], but calls the [code]method[/code] on idle time when the time arrives.
+			</description>
+		</method>
 	</methods>
 	<constants>
 	</constants>

--- a/doc/InvokeState.xml
+++ b/doc/InvokeState.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="InvokeState" inherits="Reference" version="3.2">
+	<brief_description>
+		The function invocation state.
+	</brief_description>
+	<description>
+		This class is used by [method GoostEngine.invoke] to manage pending invocations.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="cancel">
+			<return type="void">
+			</return>
+			<description>
+				Cancels the invocation, preventing the target [member method] from being called.
+			</description>
+		</method>
+		<method name="is_active">
+			<return type="bool">
+			</return>
+			<description>
+				Tells whether this state is currently processed. If the state is cancelled with [method cancel], then this will return [code]false[/code].
+			</description>
+		</method>
+		<method name="is_repeating">
+			<return type="bool">
+			</return>
+			<description>
+				Tells whether the [member method] invocation is repeated every [code]repeat_rate[/code] seconds as requested by [method GoostEngine.invoke].
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="method" type="String" setter="" getter="get_target_method" default="&quot;&quot;">
+			The method name which is going to be invoked in the [member target] object (read-only).
+		</member>
+		<member name="target" type="Object" setter="" getter="get_target">
+			The target [Object] where the [member method] is going to be invoked (read-only).
+		</member>
+		<member name="time_left" type="float" setter="" getter="get_time_left" default="0.0">
+			The total time left before the target method is called (read-only).
+		</member>
+	</members>
+	<signals>
+		<signal name="completed">
+			<description>
+				Emitted when the [member method] is successfully called without errors. This signal is not emitted if the invocation is configured as repeating, see [method is_repeating].
+			</description>
+		</signal>
+		<signal name="post_call">
+			<description>
+				Emitted after the [member method] is called.
+			</description>
+		</signal>
+		<signal name="pre_call">
+			<description>
+				Emitted when the [member method] is about to be called.
+			</description>
+		</signal>
+	</signals>
+	<constants>
+	</constants>
+</class>

--- a/goost.py
+++ b/goost.py
@@ -54,6 +54,7 @@ classes = [
     "Grid2D",
     "ImageBlender",
     "ImageIndexed",
+    "InvokeState",
     "LinkedList",
     "ListNode",
     "PolyBoolean2D",
@@ -74,6 +75,7 @@ classes = [
     "VisualShape2D",
 ]
 # ClassA : Depends on ClassB.
+# "GoostEngine" : "InvokeState"
 # "PolyBoolean2D" : "PolyBooleanParameters2D"
 # "PolyBoolean2D" : "PolyNode2D"
 # "PolyDecomp2D" : "PolyDecompParameters2D"

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -1,25 +1,13 @@
 #include "register_types.h"
 
 #include "core/engine.h"
-#include "core/goost_engine.h"
-#include "scene/main/scene_tree.h"
 
 #include "core/register_core_types.h"
 #include "scene/register_scene_types.h"
 #include "editor/register_editor_types.h"
 
-#ifdef GOOST_CORE_ENABLED
-static GoostEngine *_goost = nullptr;
-#endif
-
 void register_goost_types() {
 #ifdef GOOST_CORE_ENABLED
-	_goost = memnew(GoostEngine);
-	ClassDB::register_class<GoostEngine>();
-	Engine::get_singleton()->add_singleton(
-			Engine::Singleton("GoostEngine", GoostEngine::get_singleton()));
-	SceneTree::add_idle_callback(&GoostEngine::flush_calls);
-
 	goost::register_core_types();
 #endif
 #ifdef GOOST_SCENE_ENABLED
@@ -32,9 +20,6 @@ void register_goost_types() {
 
 void unregister_goost_types() {
 #ifdef GOOST_CORE_ENABLED
-	if (_goost) { 
-		memdelete(_goost);
-	}
 	goost::unregister_core_types();
 #endif
 #ifdef GOOST_SCENE_ENABLED


### PR DESCRIPTION
Kind of closes godotengine/godot-proposals#44.

One of the benefits of using this over `get_tree().create_timer(time).connect("timeout", object, "target")` is that this ensures function is not ever called on freed objects, and of course it's much shorter to write (and more readable):

```gdscript
GoostEngine.invoke(launcher, "shoot", 1) # Launch projectile 1 second later.
var shooting: InvokeState = GoostEngine.invoke(launcher, "shoot", 0, 1) # Launch projectile immediately every 1 second.
# ...
shooting.cancel() # No longer shoot projectiles.
```
