### PR TITLE
Implement class dependency system

### DIFF
--- a/SCsub
+++ b/SCsub
@@ -3,8 +3,6 @@
 import os
 import goost
 
-import methods
-
 Import("env")
 env_goost = env.Clone()
 
@@ -18,6 +16,19 @@ for name in goost.get_components():
     opt = "goost_%s_enabled" % (name)
     if env_goost[opt]:
         env_goost.Prepend(CPPDEFINES=[opt.upper()])
+
+# Generate header with classes enabled.
+with open("classes_enabled.gen.h", "w") as f:
+    f.write("static const int _goost_classes_enabled_count = %s;\n" % len(goost.classes_enabled))
+    f.write("static const char* _goost_classes_enabled[_goost_classes_enabled_count] = {\n")
+    for c in goost.classes_enabled:
+        f.write('\t"%s",\n' % c)
+    f.write("};\n")
+    for c in goost.classes_enabled:
+        m = "GOOST_CLASS_" + c.upper() + "_ENABLED"
+        f.write("#ifndef %s\n" % m)
+        f.write("#define %s\n" % m)
+        f.write("#endif\n")
 
 env_goost.Prepend(CPPDEFINES={"SCALE_FACTOR" : env["goost_scale_factor"]})
 

--- a/config.py
+++ b/config.py
@@ -8,6 +8,18 @@ def can_build(env, platform):
 def configure(env):
     from SCons.Script import Variables, BoolVariable, Help, Exit
 
+    # Check dependencies.
+    dependencies_satisfied = True
+    for c in goost.classes_enabled:
+        resolved = goost.resolve_dependency(goost.classes[c])
+        for cr in resolved:
+            if cr not in goost.classes_enabled:
+                dependencies_satisfied = False
+                print("Goost: Cannot disable `%s` class, because `%s` class depends on it." % (cr, c))
+
+    if not dependencies_satisfied:
+        Exit(255)
+
     opts = Variables()
     for name in goost.get_components():
         opts.Add(BoolVariable("goost_%s_enabled" % (name), "Build %s component." % (name), True))
@@ -41,8 +53,7 @@ def configure(env):
 
 
 def get_doc_classes():
-    # No error if a particular class is missing anyway, so return all classes.
-    return goost.classes
+    return goost.classes.keys()
 
 
 def get_doc_path():

--- a/core/image/register_image_types.cpp
+++ b/core/image/register_image_types.cpp
@@ -1,4 +1,6 @@
 #include "register_image_types.h"
+#include "goost/register_types.h"
+#include "goost/classes_enabled.gen.h"
 
 #include "core/engine.h"
 
@@ -16,11 +18,12 @@ static Ref<ResourceSaverIndexedPNG> resource_saver_indexed_png;
 namespace goost {
 
 void register_image_types() {
+#ifdef GOOST_CLASS_GOOSTIMAGE_ENABLED
 	_goost_image = memnew(_GoostImage);
-
 	ClassDB::register_class<_GoostImage>();
 	Engine::get_singleton()->add_singleton(Engine::Singleton("GoostImage", _GoostImage::get_singleton()));
-
+#endif
+#ifdef GOOST_CLASS_IMAGEINDEXED_ENABLED
 	ClassDB::register_class<ImageIndexed>();
 
 	image_loader_indexed_png = memnew(ImageLoaderIndexedPNG);
@@ -28,17 +31,22 @@ void register_image_types() {
 
 	resource_saver_indexed_png.instance();
 	ResourceSaver::add_resource_format_saver(resource_saver_indexed_png);
+#endif
 
-	ClassDB::register_class<ImageBlender>();
+	GOOST_REGISTER_CLASS(ImageBlender);
 }
 
 void unregister_image_types() {
+#ifdef GOOST_CLASS_GOOSTIMAGE_ENABLED
 	memdelete(_goost_image);
+#endif
+#ifdef GOOST_CLASS_IMAGEINDEXED_ENABLED
 	if (image_loader_indexed_png) {
 		memdelete(image_loader_indexed_png);
 	}
 	ResourceSaver::remove_resource_format_saver(resource_saver_indexed_png);
 	resource_saver_indexed_png.unref();
+#endif
 }
 
 } // namespace goost

--- a/core/math/register_math_types.cpp
+++ b/core/math/register_math_types.cpp
@@ -1,4 +1,6 @@
 #include "register_math_types.h"
+#include "goost/register_types.h"
+#include "goost/classes_enabled.gen.h"
 
 #include "core/engine.h"
 
@@ -23,59 +25,75 @@ static Ref<_PolyDecomp2D> _poly_decomp_2d;
 namespace goost {
 
 void register_math_types() {
+#ifdef GOOST_CLASS_RANDOM_ENABLED
 	_random.instance();
 	ClassDB::register_class<Random>();
 	Object *random = Object::cast_to<Object>(Random::get_singleton());
 	Engine::get_singleton()->add_singleton(Engine::Singleton("Random", random));
-
+#endif
+#ifdef GOOST_CLASS_RANDOM2D_ENABLED
 	_random_2d.instance();
 	ClassDB::register_class<Random2D>();
 	Object *random_2d = Object::cast_to<Object>(Random2D::get_singleton());
 	Engine::get_singleton()->add_singleton(Engine::Singleton("Random2D", random_2d));
-
-	// GoostGeometry2D
+#endif
+#ifdef GOOST_CLASS_GOOSTGEOMETRY2D_ENABLED
 	_goost_geometry_2d = memnew(_GoostGeometry2D);
 	ClassDB::register_class<_GoostGeometry2D>();
 	Engine::get_singleton()->add_singleton(Engine::Singleton("GoostGeometry2D", _GoostGeometry2D::get_singleton()));
-	
+#endif
+	// Can still be used in C++ alone.
 	PolyBackends2D::initialize();
 
-	// PolyBoolean2D
+#ifdef GOOST_CLASS_POLYBOOLEAN2D_ENABLED
 	_poly_boolean_2d.instance();
 	ClassDB::register_class<_PolyBoolean2D>();
 	Object *poly_boolean_2d = Object::cast_to<Object>(_PolyBoolean2D::get_singleton());
 	Engine::get_singleton()->add_singleton(Engine::Singleton("PolyBoolean2D", poly_boolean_2d));
+#endif
+	GOOST_REGISTER_CLASS(PolyBooleanParameters2D);
+	GOOST_REGISTER_CLASS(PolyNode2D);
 
-	ClassDB::register_class<PolyBooleanParameters2D>();
-	ClassDB::register_class<PolyNode2D>();
-
-	// PolyOffset2D
+#ifdef GOOST_CLASS_POLYOFFSET2D_ENABLED
 	_poly_offset_2d.instance();
 	ClassDB::register_class<_PolyOffset2D>();
 	Object *poly_offset_2d = Object::cast_to<Object>(_PolyOffset2D::get_singleton());
 	Engine::get_singleton()->add_singleton(Engine::Singleton("PolyOffset2D", poly_offset_2d));
+#endif
+	GOOST_REGISTER_CLASS(PolyOffsetParameters2D);
 
-	ClassDB::register_class<PolyOffsetParameters2D>();
-
-	// PolyOffset2D
+#ifdef GOOST_CLASS_POLYDECOMP2D_ENABLED
 	_poly_decomp_2d.instance();
 	ClassDB::register_class<_PolyDecomp2D>();
 	Object *poly_decomp_2d = Object::cast_to<Object>(_PolyDecomp2D::get_singleton());
 	Engine::get_singleton()->add_singleton(Engine::Singleton("PolyDecomp2D", poly_decomp_2d));
-
-	ClassDB::register_class<PolyDecompParameters2D>();
+#endif
+	GOOST_REGISTER_CLASS(PolyDecompParameters2D);
 }
 
 void unregister_math_types() {
+#ifdef GOOST_CLASS_RANDOM_ENABLED
 	_random.unref();
+#endif
+#ifdef GOOST_CLASS_RANDOM2D_ENABLED
 	_random_2d.unref();
+#endif
 
+#ifdef GOOST_CLASS_GOOSTGEOMETRY2D_ENABLED
 	memdelete(_goost_geometry_2d);
+#endif
+
 	PolyBackends2D::finalize();
 
+#ifdef GOOST_CLASS_POLYBOOLEAN2D_ENABLED
 	_poly_boolean_2d.unref();
+#endif
+#ifdef GOOST_CLASS_POLYOFFSET2D_ENABLED
 	_poly_offset_2d.unref();
+#endif
+#ifdef GOOST_CLASS_POLYDECOMP2D_ENABLED
 	_poly_decomp_2d.unref();
+#endif
 }
 
 } // namespace goost

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -1,13 +1,16 @@
 #include "register_core_types.h"
+#include "goost/register_types.h"
+#include "goost/classes_enabled.gen.h"
 
 #include "core/engine.h"
 #include "scene/main/scene_tree.h"
 
+#include "image/register_image_types.h"
+#include "math/register_math_types.h"
+
 #include "goost_engine.h"
 #include "invoke_state.h"
 
-#include "image/register_image_types.h"
-#include "math/register_math_types.h"
 #include "types/grid_2d.h"
 #include "types/list.h"
 #include "types/variant_resource.h"
@@ -19,26 +22,29 @@
 #endif
 
 namespace goost {
-	
+
 static GoostEngine *_goost = nullptr;
-#ifdef TOOLS_ENABLED
+
+#if defined(TOOLS_ENABLED) && defined(GOOST_CLASS_VARIANTRESOURCE_ENABLED)
 static void _variant_resource_preview_init();
 #endif
 
 void register_core_types() {
+#ifdef GOOST_CLASS_GOOSTENGINE_ENABLED
 	_goost = memnew(GoostEngine);
 	ClassDB::register_class<GoostEngine>();
 	Engine::get_singleton()->add_singleton(
 			Engine::Singleton("GoostEngine", GoostEngine::get_singleton()));
 	SceneTree::add_idle_callback(&GoostEngine::flush_calls);
-	ClassDB::register_class<InvokeState>();
+#endif
+	GOOST_REGISTER_CLASS(InvokeState);
 
-	ClassDB::register_class<Grid2D>();
-	ClassDB::register_class<ListNode>();
-	ClassDB::register_class<LinkedList>();
+	GOOST_REGISTER_CLASS(Grid2D);
+	GOOST_REGISTER_CLASS(ListNode);
+	GOOST_REGISTER_CLASS(LinkedList);
 
-	ClassDB::register_class<VariantResource>();
-#ifdef TOOLS_ENABLED
+	GOOST_REGISTER_CLASS(VariantResource);
+#if defined(TOOLS_ENABLED) && defined(GOOST_CLASS_VARIANTRESOURCE_ENABLED)
 	EditorNode::add_init_callback(_variant_resource_preview_init);
 #endif
 
@@ -51,7 +57,7 @@ void register_core_types() {
 }
 
 void unregister_core_types() {
-	if (_goost) { 
+	if (_goost) {
 		memdelete(_goost);
 	}
 #ifdef GOOST_IMAGE_ENABLED
@@ -62,7 +68,7 @@ void unregister_core_types() {
 #endif
 }
 
-#ifdef TOOLS_ENABLED
+#if defined(TOOLS_ENABLED) && defined(GOOST_CLASS_VARIANTRESOURCE_ENABLED)
 void _variant_resource_preview_init() {
 	Ref<VariantResourcePreviewGenerator> variant_resource_preview;
 	variant_resource_preview.instance();

--- a/register_types.h
+++ b/register_types.h
@@ -1,2 +1,22 @@
 void register_goost_types();
 void unregister_goost_types();
+
+// Register a class only if enabled.
+//
+// Use this macro over `ClassDB::register_class` in Goost,
+// unless the process of registering the class involes more complex steps
+// such as instantiating a singleton of the class, or adding editor plugins.
+// If that's the case, you'll have to check whether coresponding
+// `GOOST_CLASS_*_ENABLED` macros are defined manually in code which are
+// generated in "classes_enabled.gen.h" file included above.
+//
+#ifndef GOOST_REGISTER_CLASS
+#define GOOST_REGISTER_CLASS(m_name)                         \
+	for (int i = 0; i < _goost_classes_enabled_count; ++i) { \
+		String name = _goost_classes_enabled[i];             \
+		if (name == #m_name) {                               \
+			ClassDB::register_class<m_name>();               \
+			break;                                           \
+		}                                                    \
+	}
+#endif

--- a/scene/physics/register_physics_types.cpp
+++ b/scene/physics/register_physics_types.cpp
@@ -1,12 +1,13 @@
-#include "core/object.h"
+#include "register_physics_types.h"
+#include "goost/register_types.h"
+#include "goost/classes_enabled.gen.h"
 
 #include "2d/shape_cast_2d.h"
-#include "register_physics_types.h"
 
 namespace goost {
 
 void register_physics_types() {
-	ClassDB::register_class<ShapeCast2D>();
+	GOOST_REGISTER_CLASS(ShapeCast2D);
 }
 
 void unregister_physics_types() {

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -1,7 +1,8 @@
-#include "core/object.h"
+#include "register_scene_types.h"
+#include "goost/register_types.h"
+#include "goost/classes_enabled.gen.h"
 
 #include "physics/register_physics_types.h"
-#include "register_scene_types.h"
 
 #include "2d/editor/poly_node_2d_editor_plugin.h"
 #include "2d/editor/visual_shape_2d_editor_plugin.h"
@@ -16,19 +17,21 @@ namespace goost {
 void register_scene_types() {
 #ifdef GOOST_CORE_ENABLED
 	// Depend on `PolyNode2D`.
-	ClassDB::register_class<PolyCircle2D>();
-	ClassDB::register_class<PolyRectangle2D>();
-	ClassDB::register_class<PolyShape2D>();
-	ClassDB::register_class<PolyCollisionShape2D>();
+	GOOST_REGISTER_CLASS(PolyCircle2D);
+	GOOST_REGISTER_CLASS(PolyRectangle2D);
+	GOOST_REGISTER_CLASS(PolyShape2D);
+	GOOST_REGISTER_CLASS(PolyCollisionShape2D);
 #endif
-	ClassDB::register_class<VisualShape2D>();
-	ClassDB::register_class<GradientTexture2D>();
+	GOOST_REGISTER_CLASS(VisualShape2D);
+	GOOST_REGISTER_CLASS(GradientTexture2D);
 
 #if defined(TOOLS_ENABLED) && defined(GOOST_EDITOR_ENABLED)
-#ifdef GOOST_CORE_ENABLED
-	EditorPlugins::add_by_type<PolyNode2DEditorPlugin>(); // Depends on `PolyNode2D`.
+#if defined(GOOST_CORE_ENABLED) && defined(GOOST_CLASS_POLYNODE2D_ENABLED)
+	EditorPlugins::add_by_type<PolyNode2DEditorPlugin>();
 #endif
+#if defined(GOOST_CLASS_VISUALSHAPE2D_ENABLED)
 	EditorPlugins::add_by_type<VisualShape2DEditorPlugin>();
+#endif
 #endif
 #ifdef GOOST_PHYSICS_ENABLED
 	register_physics_types();


### PR DESCRIPTION
Solves part of #49.

Declares a list of dependencies, so that it's not possible to compile the engine if a particular class is disabled if it's a dependency of other class.

Classes should be registered via new `GOOST_REGISTER_CLASS` macro now, unless there are valid reasons to use `ClassDB::register_class` alone.

Individual classes can be currently disabled via `custom.py::goost_classes_disabled` list, which can be created at the root of the Goost source. For instance:
```python
# custom.py

goost_classes_disabled = [
    "LinkedList",
    "ListNode",
    "VariantResource",
    "VisualShape2D",
]
```

Note that currently this mostly affects run-time behavior. Classes may still be compiled, but this patch makes it easier to further optimize binaries for size in the future.

For instance, here's what happens if you try to disable `ListNode` alone:

![image](https://user-images.githubusercontent.com/17108460/107700940-dc459380-6cc0-11eb-8c97-6f3006e3056c.png)
