### PR TITLE
Do not compile sources associated with disabled Goost classes

### DIFF
--- a/SCsub
+++ b/SCsub
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 
 import os
+import glob
+import re
+
+from compat import isbasestring
 import goost
 
 Import("env")
@@ -19,15 +23,14 @@ for name in goost.get_components():
 
 # Generate header with classes enabled.
 with open("classes_enabled.gen.h", "w") as f:
-    f.write("static const int _goost_classes_enabled_count = %s;\n" % len(goost.classes_enabled))
-    f.write("static const char* _goost_classes_enabled[_goost_classes_enabled_count] = {\n")
     for c in goost.classes_enabled:
-        f.write('\t"%s",\n' % c)
-    f.write("};\n")
-    for c in goost.classes_enabled:
-        m = "GOOST_CLASS_" + c.upper() + "_ENABLED"
-        f.write("#ifndef %s\n" % m)
-        f.write("#define %s\n" % m)
+        f.write("#define GOOST_%s\n" % c)
+    for c in goost.classes:
+        f.write("#ifdef GOOST_%s\n" % c)
+        f.write("#define GOOST_REGISTER_%s \\\n" % c)
+        f.write("\tClassDB::register_class<%s>();\n" % c)
+        f.write("#else\n")
+        f.write("#define GOOST_REGISTER_%s\n" % c)
         f.write("#endif\n")
 
 env_goost.Prepend(CPPDEFINES={"SCALE_FACTOR" : env["goost_scale_factor"]})
@@ -44,8 +47,67 @@ subdirs = [
     "scene",
     "editor",
     "thirdparty",
-    # "modules", # Cannot build directly, use `custom_modules` option explicitly.
+    # "modules", # Built automatically if `custom_modules_recursive=yes` (default).
 ]
-SConscript(dirs=subdirs, name="SCsub", exports="env_goost")
 
+# Inject our own version of `add_source_files` (found in methods.py in Godot).
+# This is needed to filter out the sources of disabled classes without
+# modifying each and every SCSub file, making it work everywhere in Goost.
+godot_add_source_files = env_goost.__class__.add_source_files
+
+def goost_add_source_files(self, sources, files, warn_duplicates=True):
+    # Convert string to list of absolute paths (including expanding wildcard)
+    if isbasestring(files):
+        # Keep SCons project-absolute path as they are (no wildcard support)
+        if files.startswith("#"):
+            if "*" in files:
+                print("ERROR: Wildcards can't be expanded in SCons project-absolute path: '{}'".format(files))
+                return
+            files = [files]
+        else:
+            dir_path = self.Dir(".").abspath
+            files = sorted(glob.glob(dir_path + "/" + files))
+    # Flatten.
+    _files = []
+    for path in files:
+        if isinstance(path, list):
+            for p in path:
+                _files.append(p.abspath)
+        elif isinstance(path, str):
+            _files.append(path)
+        else:
+            _files.append(path.abspath)
+    files = _files
+
+    def to_snake_case(pascal):
+        # https://stackoverflow.com/a/33516645/
+        return re.sub(r'([A-Z]*)([A-Z][a-z]+)', lambda x: (x.group(1) + '_' if x.group(1) else '') + x.group(2) + '_', pascal).rstrip('_').lower()
+
+    # Add each path as compiled Object following environment (self) configuration
+    for path in files:
+        # Skip compiling sources of disabled Goost classes.
+        skip = False
+        for c in goost.classes_disabled:
+            n = "%s.cpp" % to_snake_case(c)
+            if re.search(n, path):
+                skip = True
+                break
+        if skip:
+            continue
+        obj = self.Object(path)
+        if obj in sources:
+            if warn_duplicates:
+                print('WARNING: Object "{}" already included in environment sources.'.format(obj))
+            else:
+                continue
+        sources.append(obj)
+
+# Inject now!
+env_goost.__class__.add_source_files = goost_add_source_files
+
+# Add sources.
+SConscript(dirs=subdirs, name="SCsub", exports="env_goost")
 env_goost.add_source_files(env.modules_sources, "*.cpp")
+
+# Restore the method back (not sure if needed, but good for consistency).
+env_goost.__class__.add_source_files = godot_add_source_files

--- a/core/image/register_image_types.cpp
+++ b/core/image/register_image_types.cpp
@@ -18,12 +18,12 @@ static Ref<ResourceSaverIndexedPNG> resource_saver_indexed_png;
 namespace goost {
 
 void register_image_types() {
-#ifdef GOOST_CLASS_GOOSTIMAGE_ENABLED
+#ifdef GOOST_GoostImage
 	_goost_image = memnew(_GoostImage);
 	ClassDB::register_class<_GoostImage>();
 	Engine::get_singleton()->add_singleton(Engine::Singleton("GoostImage", _GoostImage::get_singleton()));
 #endif
-#ifdef GOOST_CLASS_IMAGEINDEXED_ENABLED
+#ifdef GOOST_ImageIndexed
 	ClassDB::register_class<ImageIndexed>();
 
 	image_loader_indexed_png = memnew(ImageLoaderIndexedPNG);
@@ -33,14 +33,14 @@ void register_image_types() {
 	ResourceSaver::add_resource_format_saver(resource_saver_indexed_png);
 #endif
 
-	GOOST_REGISTER_CLASS(ImageBlender);
+	GOOST_REGISTER_ImageBlender;
 }
 
 void unregister_image_types() {
-#ifdef GOOST_CLASS_GOOSTIMAGE_ENABLED
+#ifdef GOOST_GoostImage
 	memdelete(_goost_image);
 #endif
-#ifdef GOOST_CLASS_IMAGEINDEXED_ENABLED
+#ifdef GOOST_ImageIndexed
 	if (image_loader_indexed_png) {
 		memdelete(image_loader_indexed_png);
 	}

--- a/core/math/register_math_types.cpp
+++ b/core/math/register_math_types.cpp
@@ -25,19 +25,19 @@ static Ref<_PolyDecomp2D> _poly_decomp_2d;
 namespace goost {
 
 void register_math_types() {
-#ifdef GOOST_CLASS_RANDOM_ENABLED
+#ifdef GOOST_Random
 	_random.instance();
 	ClassDB::register_class<Random>();
 	Object *random = Object::cast_to<Object>(Random::get_singleton());
 	Engine::get_singleton()->add_singleton(Engine::Singleton("Random", random));
 #endif
-#ifdef GOOST_CLASS_RANDOM2D_ENABLED
+#ifdef GOOST_Random2D
 	_random_2d.instance();
 	ClassDB::register_class<Random2D>();
 	Object *random_2d = Object::cast_to<Object>(Random2D::get_singleton());
 	Engine::get_singleton()->add_singleton(Engine::Singleton("Random2D", random_2d));
 #endif
-#ifdef GOOST_CLASS_GOOSTGEOMETRY2D_ENABLED
+#ifdef GOOST_GoostGeometry2D
 	_goost_geometry_2d = memnew(_GoostGeometry2D);
 	ClassDB::register_class<_GoostGeometry2D>();
 	Engine::get_singleton()->add_singleton(Engine::Singleton("GoostGeometry2D", _GoostGeometry2D::get_singleton()));
@@ -45,53 +45,53 @@ void register_math_types() {
 	// Can still be used in C++ alone.
 	PolyBackends2D::initialize();
 
-#ifdef GOOST_CLASS_POLYBOOLEAN2D_ENABLED
+#ifdef GOOST_PolyBoolean2D
 	_poly_boolean_2d.instance();
 	ClassDB::register_class<_PolyBoolean2D>();
 	Object *poly_boolean_2d = Object::cast_to<Object>(_PolyBoolean2D::get_singleton());
 	Engine::get_singleton()->add_singleton(Engine::Singleton("PolyBoolean2D", poly_boolean_2d));
 #endif
-	GOOST_REGISTER_CLASS(PolyBooleanParameters2D);
-	GOOST_REGISTER_CLASS(PolyNode2D);
+	GOOST_REGISTER_PolyBooleanParameters2D;
+	GOOST_REGISTER_PolyNode2D;
 
-#ifdef GOOST_CLASS_POLYOFFSET2D_ENABLED
+#ifdef GOOST_PolyOffset2D
 	_poly_offset_2d.instance();
 	ClassDB::register_class<_PolyOffset2D>();
 	Object *poly_offset_2d = Object::cast_to<Object>(_PolyOffset2D::get_singleton());
 	Engine::get_singleton()->add_singleton(Engine::Singleton("PolyOffset2D", poly_offset_2d));
 #endif
-	GOOST_REGISTER_CLASS(PolyOffsetParameters2D);
+	GOOST_REGISTER_PolyOffsetParameters2D;
 
-#ifdef GOOST_CLASS_POLYDECOMP2D_ENABLED
+#ifdef GOOST_PolyDecomp2D
 	_poly_decomp_2d.instance();
 	ClassDB::register_class<_PolyDecomp2D>();
 	Object *poly_decomp_2d = Object::cast_to<Object>(_PolyDecomp2D::get_singleton());
 	Engine::get_singleton()->add_singleton(Engine::Singleton("PolyDecomp2D", poly_decomp_2d));
 #endif
-	GOOST_REGISTER_CLASS(PolyDecompParameters2D);
+	GOOST_REGISTER_PolyDecompParameters2D;
 }
 
 void unregister_math_types() {
-#ifdef GOOST_CLASS_RANDOM_ENABLED
+#ifdef GOOST_Random
 	_random.unref();
 #endif
-#ifdef GOOST_CLASS_RANDOM2D_ENABLED
+#ifdef GOOST_Random2D
 	_random_2d.unref();
 #endif
 
-#ifdef GOOST_CLASS_GOOSTGEOMETRY2D_ENABLED
+#ifdef GOOST_GoostGeometry2D
 	memdelete(_goost_geometry_2d);
 #endif
 
 	PolyBackends2D::finalize();
 
-#ifdef GOOST_CLASS_POLYBOOLEAN2D_ENABLED
+#ifdef GOOST_PolyBoolean2D
 	_poly_boolean_2d.unref();
 #endif
-#ifdef GOOST_CLASS_POLYOFFSET2D_ENABLED
+#ifdef GOOST_PolyOffset2D
 	_poly_offset_2d.unref();
 #endif
-#ifdef GOOST_CLASS_POLYDECOMP2D_ENABLED
+#ifdef GOOST_PolyDecomp2D
 	_poly_decomp_2d.unref();
 #endif
 }

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -1,6 +1,6 @@
 #include "register_core_types.h"
-#include "goost/register_types.h"
 #include "goost/classes_enabled.gen.h"
+#include "goost/register_types.h"
 
 #include "core/engine.h"
 #include "scene/main/scene_tree.h"
@@ -25,26 +25,26 @@ namespace goost {
 
 static GoostEngine *_goost = nullptr;
 
-#if defined(TOOLS_ENABLED) && defined(GOOST_CLASS_VARIANTRESOURCE_ENABLED)
+#if defined(TOOLS_ENABLED) && defined(GOOST_VariantResource)
 static void _variant_resource_preview_init();
 #endif
 
 void register_core_types() {
-#ifdef GOOST_CLASS_GOOSTENGINE_ENABLED
+#ifdef GOOST_GoostEngine
 	_goost = memnew(GoostEngine);
 	ClassDB::register_class<GoostEngine>();
 	Engine::get_singleton()->add_singleton(
 			Engine::Singleton("GoostEngine", GoostEngine::get_singleton()));
 	SceneTree::add_idle_callback(&GoostEngine::flush_calls);
 #endif
-	GOOST_REGISTER_CLASS(InvokeState);
+	GOOST_REGISTER_InvokeState;
 
-	GOOST_REGISTER_CLASS(Grid2D);
-	GOOST_REGISTER_CLASS(ListNode);
-	GOOST_REGISTER_CLASS(LinkedList);
+	GOOST_REGISTER_Grid2D;
+	GOOST_REGISTER_ListNode;
+	GOOST_REGISTER_LinkedList;
 
-	GOOST_REGISTER_CLASS(VariantResource);
-#if defined(TOOLS_ENABLED) && defined(GOOST_CLASS_VARIANTRESOURCE_ENABLED)
+	GOOST_REGISTER_VariantResource;
+#if defined(TOOLS_ENABLED) && defined(GOOST_VariantResource)
 	EditorNode::add_init_callback(_variant_resource_preview_init);
 #endif
 
@@ -68,7 +68,7 @@ void unregister_core_types() {
 #endif
 }
 
-#if defined(TOOLS_ENABLED) && defined(GOOST_CLASS_VARIANTRESOURCE_ENABLED)
+#if defined(TOOLS_ENABLED) && defined(GOOST_VariantResource)
 void _variant_resource_preview_init() {
 	Ref<VariantResourcePreviewGenerator> variant_resource_preview;
 	variant_resource_preview.instance();

--- a/core/types/editor/variant_resource_preview.cpp
+++ b/core/types/editor/variant_resource_preview.cpp
@@ -29,6 +29,7 @@ Ref<Texture> VariantResourcePreviewGenerator::generate(const Ref<Resource> &p_fr
             image.instance();
             // The icon is stretched in grid mode so it's possible to speed up
             // generation in those cases, but won't work in tree mode (default).
+            // Therefore, we must still use `p_size` for the preview...
             image->create(p_size.x, p_size.y, false, Image::FORMAT_RGBA8);
             image->fill(color);
             Ref<ImageTexture> img_tex;

--- a/register_types.h
+++ b/register_types.h
@@ -1,22 +1,2 @@
 void register_goost_types();
 void unregister_goost_types();
-
-// Register a class only if enabled.
-//
-// Use this macro over `ClassDB::register_class` in Goost,
-// unless the process of registering the class involes more complex steps
-// such as instantiating a singleton of the class, or adding editor plugins.
-// If that's the case, you'll have to check whether coresponding
-// `GOOST_CLASS_*_ENABLED` macros are defined manually in code which are
-// generated in "classes_enabled.gen.h" file included above.
-//
-#ifndef GOOST_REGISTER_CLASS
-#define GOOST_REGISTER_CLASS(m_name)                         \
-	for (int i = 0; i < _goost_classes_enabled_count; ++i) { \
-		String name = _goost_classes_enabled[i];             \
-		if (name == #m_name) {                               \
-			ClassDB::register_class<m_name>();               \
-			break;                                           \
-		}                                                    \
-	}
-#endif

--- a/scene/physics/register_physics_types.cpp
+++ b/scene/physics/register_physics_types.cpp
@@ -7,7 +7,7 @@
 namespace goost {
 
 void register_physics_types() {
-	GOOST_REGISTER_CLASS(ShapeCast2D);
+	GOOST_REGISTER_ShapeCast2D;
 }
 
 void unregister_physics_types() {

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -15,21 +15,20 @@
 namespace goost {
 
 void register_scene_types() {
-#ifdef GOOST_CORE_ENABLED
-	// Depend on `PolyNode2D`.
-	GOOST_REGISTER_CLASS(PolyCircle2D);
-	GOOST_REGISTER_CLASS(PolyRectangle2D);
-	GOOST_REGISTER_CLASS(PolyShape2D);
-	GOOST_REGISTER_CLASS(PolyCollisionShape2D);
+#if defined(GOOST_CORE_ENABLED) && defined(GOOST_PolyNode2D)
+	GOOST_REGISTER_PolyCircle2D;
+	GOOST_REGISTER_PolyRectangle2D;
+	GOOST_REGISTER_PolyShape2D;
+	GOOST_REGISTER_PolyCollisionShape2D;
 #endif
-	GOOST_REGISTER_CLASS(VisualShape2D);
-	GOOST_REGISTER_CLASS(GradientTexture2D);
+	GOOST_REGISTER_VisualShape2D;
+	GOOST_REGISTER_GradientTexture2D;
 
 #if defined(TOOLS_ENABLED) && defined(GOOST_EDITOR_ENABLED)
-#if defined(GOOST_CORE_ENABLED) && defined(GOOST_CLASS_POLYNODE2D_ENABLED)
+#if defined(GOOST_CORE_ENABLED) && defined(GOOST_PolyNode2D)
 	EditorPlugins::add_by_type<PolyNode2DEditorPlugin>();
 #endif
-#if defined(GOOST_CLASS_VISUALSHAPE2D_ENABLED)
+#if defined(GOOST_VisualShape2D)
 	EditorPlugins::add_by_type<VisualShape2DEditorPlugin>();
 #endif
 #endif


### PR DESCRIPTION
With #54, solves #49.

Allows to optimize the resulting binary for size while compiling the engine, so it's not only about run-time behavior now.

Some hacks are removed, but some added. Using injection mechanism in `add_source_files` to override the default behavior so that we can filter out Goost-specific classes compiled in the module, without having to modify the rest of `SCSub`, making it highly compatible with Godot development.

This kind of approach is important if we'd like some features in Goost to be upstreamed to Godot without much hassle in the future.

Some sources need to be renamed to match the `snake_case` version of class names, as the mechanism relies on `PascalCase` to `snake_case` string conversion.

That said, I think this PR pretty much makes the dependency system in Goost more or less feature-complete. It means that more classes can be added in Goost without fearing the bloat, because each and every class can be possibly disabled now in Goost.

If there are link/compilation errors that you stumble upon while disabling classes (and those are not coming from dependency errors), then feel free to open a bug report.

Should also write some documentation for this... But not 100% sure about the best API/implementation yet.
