### PR TITLE
Refactor class registration

### DIFF
--- a/SCsub
+++ b/SCsub
@@ -32,14 +32,15 @@ with open("classes_enabled.gen.h", "w") as f:
         f.write("template <> void register_class<%s>();\n" % c)
     f.write("}\n")
 
-with open("classes_enabled.gen.cpp", "w") as f:
-    f.write("#include \"register_types.h\"\n")
-    f.write("#include \"classes_enabled.gen.h\"\n")
-    f.write("\n")
-    f.write("namespace goost {\n")
-    for c in goost.classes_disabled:
-        f.write("template <> void register_class<%s>() {}\n" % c)
-    f.write("}\n")
+if len(goost.classes_disabled) > 0:
+    with open("classes_enabled.gen.cpp", "w") as f:
+        f.write("#include \"register_types.h\"\n")
+        f.write("#include \"classes_enabled.gen.h\"\n")
+        f.write("\n")
+        f.write("namespace goost {\n")
+        for c in goost.classes_disabled:
+            f.write("template <> void register_class<%s>() {}\n" % c)
+        f.write("}\n")
 
 env_goost.Prepend(CPPDEFINES={"SCALE_FACTOR" : env["goost_scale_factor"]})
 

--- a/SCsub
+++ b/SCsub
@@ -23,15 +23,23 @@ for name in goost.get_components():
 
 # Generate header with classes enabled.
 with open("classes_enabled.gen.h", "w") as f:
+    f.write("#pragma once\n")
     for c in goost.classes_enabled:
         f.write("#define GOOST_%s\n" % c)
-    for c in goost.classes:
-        f.write("#ifdef GOOST_%s\n" % c)
-        f.write("#define GOOST_REGISTER_%s \\\n" % c)
-        f.write("\tClassDB::register_class<%s>();\n" % c)
-        f.write("#else\n")
-        f.write("#define GOOST_REGISTER_%s\n" % c)
-        f.write("#endif\n")
+    f.write("\n")
+    f.write("namespace goost {\n")
+    for c in goost.classes_disabled:
+        f.write("template <> void register_class<%s>();\n" % c)
+    f.write("}\n")
+
+with open("classes_enabled.gen.cpp", "w") as f:
+    f.write("#include \"register_types.h\"\n")
+    f.write("#include \"classes_enabled.gen.h\"\n")
+    f.write("\n")
+    f.write("namespace goost {\n")
+    for c in goost.classes_disabled:
+        f.write("template <> void register_class<%s>() {}\n" % c)
+    f.write("}\n")
 
 env_goost.Prepend(CPPDEFINES={"SCALE_FACTOR" : env["goost_scale_factor"]})
 

--- a/core/image/register_image_types.cpp
+++ b/core/image/register_image_types.cpp
@@ -6,10 +6,6 @@
 
 #include "drivers/png/image_loader_indexed_png.h"
 #include "drivers/png/resource_saver_indexed_png.h"
-#include "goost_image.h"
-#include "goost_image_bind.h"
-#include "image_blender.h"
-#include "image_indexed.h"
 
 static _GoostImage *_goost_image = nullptr;
 static ImageLoaderIndexedPNG *image_loader_indexed_png;
@@ -20,11 +16,11 @@ namespace goost {
 void register_image_types() {
 #ifdef GOOST_GoostImage
 	_goost_image = memnew(_GoostImage);
-	ClassDB::register_class<_GoostImage>();
+	goost::register_class<_GoostImage>();
 	Engine::get_singleton()->add_singleton(Engine::Singleton("GoostImage", _GoostImage::get_singleton()));
 #endif
 #ifdef GOOST_ImageIndexed
-	ClassDB::register_class<ImageIndexed>();
+	goost::register_class<ImageIndexed>();
 
 	image_loader_indexed_png = memnew(ImageLoaderIndexedPNG);
 	ImageLoader::add_image_format_loader(image_loader_indexed_png);
@@ -32,8 +28,7 @@ void register_image_types() {
 	resource_saver_indexed_png.instance();
 	ResourceSaver::add_resource_format_saver(resource_saver_indexed_png);
 #endif
-
-	GOOST_REGISTER_ImageBlender;
+	goost::register_class<ImageBlender>();
 }
 
 void unregister_image_types() {

--- a/core/math/2d/geometry/poly/boolean/clipper10/poly_boolean_clipper10.h
+++ b/core/math/2d/geometry/poly/boolean/clipper10/poly_boolean_clipper10.h
@@ -6,8 +6,8 @@
 
 class PolyBoolean2DClipper10 : public PolyBoolean2DBackend {
 public:
-	virtual Vector<Vector<Point2>> boolean_polypaths(const Vector<Vector<Point2>> &p_polypaths_a, const Vector<Vector<Point2>> &p_polypaths_b, Operation p_op) override;
-	virtual void boolean_polypaths_tree(const Vector<Vector<Point2>> &p_polypaths_a, const Vector<Vector<Point2>> &p_polypaths_b, Operation p_op, PolyNode2D *r_root) override;
+	virtual Vector<Vector<Point2>> boolean_polypaths(const Vector<Vector<Point2>> &p_polypaths_a, const Vector<Vector<Point2>> &p_polypaths_b, Operation p_op);
+	virtual void boolean_polypaths_tree(const Vector<Vector<Point2>> &p_polypaths_a, const Vector<Vector<Point2>> &p_polypaths_b, Operation p_op, PolyNode2D *r_root);
 
 private:
 	clipperlib::Clipper configure(Operation p_op, const Ref<PolyBooleanParameters2D> &p_params);

--- a/core/math/2d/geometry/poly/boolean/clipper6/poly_boolean_clipper6.h
+++ b/core/math/2d/geometry/poly/boolean/clipper6/poly_boolean_clipper6.h
@@ -6,8 +6,8 @@
 
 class PolyBoolean2DClipper6 : public PolyBoolean2DBackend {
 public:
-	virtual Vector<Vector<Point2>> boolean_polypaths(const Vector<Vector<Point2>> &p_polypaths_a, const Vector<Vector<Point2>> &p_polypaths_b, Operation p_op) override;
-	virtual void boolean_polypaths_tree(const Vector<Vector<Point2>> &p_polypaths_a, const Vector<Vector<Point2>> &p_polypaths_b, Operation p_op, PolyNode2D *r_root) override;
+	virtual Vector<Vector<Point2>> boolean_polypaths(const Vector<Vector<Point2>> &p_polypaths_a, const Vector<Vector<Point2>> &p_polypaths_b, Operation p_op);
+	virtual void boolean_polypaths_tree(const Vector<Vector<Point2>> &p_polypaths_a, const Vector<Vector<Point2>> &p_polypaths_b, Operation p_op, PolyNode2D *r_root);
 
 private:
 	ClipperLib::Clipper configure(Operation p_op, const Ref<PolyBooleanParameters2D> &p_params);

--- a/core/math/2d/geometry/poly/decomp/clipper10/poly_decomp_clipper10.h
+++ b/core/math/2d/geometry/poly/decomp/clipper10/poly_decomp_clipper10.h
@@ -6,7 +6,7 @@
 
 class PolyDecomp2DClipper10 : public PolyDecomp2DPolyPartition {
 public:
-	virtual Vector<Vector<Point2>> triangulate_mono(const Vector<Vector<Point2>> &p_polygons) override;
+	virtual Vector<Vector<Point2>> triangulate_mono(const Vector<Vector<Point2>> &p_polygons);
 
 private:
 	clipperlib::ClipperTri configure(const Ref<PolyDecompParameters2D> &p_params);

--- a/core/math/2d/geometry/poly/decomp/polypartition/poly_decomp_polypartition.h
+++ b/core/math/2d/geometry/poly/decomp/polypartition/poly_decomp_polypartition.h
@@ -8,11 +8,11 @@ class PolyDecompParameters2D;
 
 class PolyDecomp2DPolyPartition : public PolyDecomp2DBackend {
 public:
-	virtual Vector<Vector<Point2>> triangulate_ec(const Vector<Vector<Point2>> &p_polygons) override;
-	virtual Vector<Vector<Point2>> triangulate_opt(const Vector<Vector<Point2>> &p_polygons) override;
-	virtual Vector<Vector<Point2>> triangulate_mono(const Vector<Vector<Point2>> &p_polygons) override;
-	virtual Vector<Vector<Point2>> decompose_convex_hm(const Vector<Vector<Point2>> &p_polygons) override;
-	virtual Vector<Vector<Point2>> decompose_convex_opt(const Vector<Vector<Point2>> &p_polygons) override;
+	virtual Vector<Vector<Point2>> triangulate_ec(const Vector<Vector<Point2>> &p_polygons);
+	virtual Vector<Vector<Point2>> triangulate_opt(const Vector<Vector<Point2>> &p_polygons);
+	virtual Vector<Vector<Point2>> triangulate_mono(const Vector<Vector<Point2>> &p_polygons);
+	virtual Vector<Vector<Point2>> decompose_convex_hm(const Vector<Vector<Point2>> &p_polygons);
+	virtual Vector<Vector<Point2>> decompose_convex_opt(const Vector<Vector<Point2>> &p_polygons);
 };
 
 #endif // GOOST_GEOMETRY_POLY_DECOMP_POLYPARTITION_H

--- a/core/math/2d/geometry/poly/offset/clipper10/poly_offset_clipper10.h
+++ b/core/math/2d/geometry/poly/offset/clipper10/poly_offset_clipper10.h
@@ -6,7 +6,7 @@
 
 class PolyOffset2DClipper10 : public PolyOffset2DBackend {
 public:
-	virtual Vector<Vector<Point2>> offset_polypaths(const Vector<Vector<Point2>> &p_polypaths, real_t p_delta) override;
+	virtual Vector<Vector<Point2>> offset_polypaths(const Vector<Vector<Point2>> &p_polypaths, real_t p_delta);
 
 private:
 	clipperlib::ClipperOffset configure(const Ref<PolyOffsetParameters2D> &p_parameters);

--- a/core/math/2d/geometry/poly/offset/clipper6/poly_offset_clipper6.h
+++ b/core/math/2d/geometry/poly/offset/clipper6/poly_offset_clipper6.h
@@ -6,7 +6,7 @@
 
 class PolyOffset2DClipper6 : public PolyOffset2DBackend {
 public:
-	virtual Vector<Vector<Point2>> offset_polypaths(const Vector<Vector<Point2>> &p_polypaths, real_t p_delta) override;
+	virtual Vector<Vector<Point2>> offset_polypaths(const Vector<Vector<Point2>> &p_polypaths, real_t p_delta);
 
 private:
 	ClipperLib::ClipperOffset configure(const Ref<PolyOffsetParameters2D> &p_parameters);

--- a/core/math/2d/random_2d.h
+++ b/core/math/2d/random_2d.h
@@ -14,7 +14,7 @@ protected:
 
 public:
 	static Random2D *get_singleton() { return singleton; }
-	virtual Ref<Random> new_instance() const override { return memnew(Random2D); }
+	virtual Ref<Random> new_instance() const { return memnew(Random2D); }
 
 	real_t get_rotation();
 	Vector2 get_direction(); // Unit vector.

--- a/core/math/register_math_types.cpp
+++ b/core/math/register_math_types.cpp
@@ -2,18 +2,6 @@
 #include "goost/register_types.h"
 #include "goost/classes_enabled.gen.h"
 
-#include "core/engine.h"
-
-#include "2d/random_2d.h"
-#include "random.h"
-
-#include "2d/geometry/goost_geometry_2d.h"
-#include "2d/geometry/goost_geometry_2d_bind.h"
-#include "2d/geometry/poly/boolean/poly_boolean.h"
-#include "2d/geometry/poly/decomp/poly_decomp.h"
-#include "2d/geometry/poly/offset/poly_offset.h"
-#include "2d/geometry/poly/poly_backends.h"
-
 static Ref<Random> _random;
 static Ref<Random2D> _random_2d;
 
@@ -27,48 +15,48 @@ namespace goost {
 void register_math_types() {
 #ifdef GOOST_Random
 	_random.instance();
-	ClassDB::register_class<Random>();
+	goost::register_class<Random>();
 	Object *random = Object::cast_to<Object>(Random::get_singleton());
 	Engine::get_singleton()->add_singleton(Engine::Singleton("Random", random));
 #endif
 #ifdef GOOST_Random2D
 	_random_2d.instance();
-	ClassDB::register_class<Random2D>();
+	goost::register_class<Random2D>();
 	Object *random_2d = Object::cast_to<Object>(Random2D::get_singleton());
 	Engine::get_singleton()->add_singleton(Engine::Singleton("Random2D", random_2d));
 #endif
 #ifdef GOOST_GoostGeometry2D
 	_goost_geometry_2d = memnew(_GoostGeometry2D);
-	ClassDB::register_class<_GoostGeometry2D>();
+	goost::register_class<_GoostGeometry2D>();
 	Engine::get_singleton()->add_singleton(Engine::Singleton("GoostGeometry2D", _GoostGeometry2D::get_singleton()));
 #endif
-	// Can still be used in C++ alone.
+#ifdef GOOST_PolyNode2D
 	PolyBackends2D::initialize();
-
+#endif
 #ifdef GOOST_PolyBoolean2D
 	_poly_boolean_2d.instance();
-	ClassDB::register_class<_PolyBoolean2D>();
+	goost::register_class<_PolyBoolean2D>();
 	Object *poly_boolean_2d = Object::cast_to<Object>(_PolyBoolean2D::get_singleton());
 	Engine::get_singleton()->add_singleton(Engine::Singleton("PolyBoolean2D", poly_boolean_2d));
 #endif
-	GOOST_REGISTER_PolyBooleanParameters2D;
-	GOOST_REGISTER_PolyNode2D;
+	goost::register_class<PolyBooleanParameters2D>();
+	goost::register_class<PolyNode2D>();
 
 #ifdef GOOST_PolyOffset2D
 	_poly_offset_2d.instance();
-	ClassDB::register_class<_PolyOffset2D>();
+	goost::register_class<_PolyOffset2D>();
 	Object *poly_offset_2d = Object::cast_to<Object>(_PolyOffset2D::get_singleton());
 	Engine::get_singleton()->add_singleton(Engine::Singleton("PolyOffset2D", poly_offset_2d));
 #endif
-	GOOST_REGISTER_PolyOffsetParameters2D;
+	goost::register_class<PolyOffsetParameters2D>();
 
 #ifdef GOOST_PolyDecomp2D
 	_poly_decomp_2d.instance();
-	ClassDB::register_class<_PolyDecomp2D>();
+	goost::register_class<_PolyDecomp2D>();
 	Object *poly_decomp_2d = Object::cast_to<Object>(_PolyDecomp2D::get_singleton());
 	Engine::get_singleton()->add_singleton(Engine::Singleton("PolyDecomp2D", poly_decomp_2d));
 #endif
-	GOOST_REGISTER_PolyDecompParameters2D;
+	goost::register_class<PolyDecompParameters2D>();
 }
 
 void unregister_math_types() {
@@ -82,9 +70,9 @@ void unregister_math_types() {
 #ifdef GOOST_GoostGeometry2D
 	memdelete(_goost_geometry_2d);
 #endif
-
+#ifdef GOOST_PolyNode2D
 	PolyBackends2D::finalize();
-
+#endif
 #ifdef GOOST_PolyBoolean2D
 	_poly_boolean_2d.unref();
 #endif

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -1,19 +1,12 @@
 #include "register_core_types.h"
-#include "goost/classes_enabled.gen.h"
 #include "goost/register_types.h"
+#include "goost/classes_enabled.gen.h"
 
 #include "core/engine.h"
 #include "scene/main/scene_tree.h"
 
 #include "image/register_image_types.h"
 #include "math/register_math_types.h"
-
-#include "goost_engine.h"
-#include "invoke_state.h"
-
-#include "types/grid_2d.h"
-#include "types/linked_list.h"
-#include "types/variant_resource.h"
 
 #ifdef TOOLS_ENABLED
 #include "editor/editor_node.h"
@@ -32,18 +25,18 @@ static void _variant_resource_preview_init();
 void register_core_types() {
 #ifdef GOOST_GoostEngine
 	_goost = memnew(GoostEngine);
-	ClassDB::register_class<GoostEngine>();
+	goost::register_class<GoostEngine>();
 	Engine::get_singleton()->add_singleton(
 			Engine::Singleton("GoostEngine", GoostEngine::get_singleton()));
 	SceneTree::add_idle_callback(&GoostEngine::flush_calls);
 #endif
-	GOOST_REGISTER_InvokeState;
+	goost::register_class<InvokeState>();
 
-	GOOST_REGISTER_Grid2D;
-	GOOST_REGISTER_ListNode;
-	GOOST_REGISTER_LinkedList;
+	goost::register_class<Grid2D>();
+	goost::register_class<ListNode>();
+	goost::register_class<LinkedList>();
 
-	GOOST_REGISTER_VariantResource;
+	goost::register_class<VariantResource>();
 #if defined(TOOLS_ENABLED) && defined(GOOST_VariantResource)
 	EditorNode::add_init_callback(_variant_resource_preview_init);
 #endif

--- a/register_types.h
+++ b/register_types.h
@@ -1,2 +1,38 @@
+#include "core/engine.h"
+
+#include "scene/2d/editor/poly_node_2d_editor_plugin.h"
+#include "scene/2d/editor/visual_shape_2d_editor_plugin.h"
+#include "scene/2d/poly_collision_shape_2d.h"
+#include "scene/2d/poly_generators_2d.h"
+#include "scene/2d/poly_shape_2d.h"
+#include "scene/2d/visual_shape_2d.h"
+#include "scene/physics/2d/shape_cast_2d.h"
+#include "scene/resources/gradient_texture_2d.h"
+
+#include "core/goost_engine.h"
+#include "core/image/goost_image.h"
+#include "core/image/goost_image_bind.h"
+#include "core/image/image_blender.h"
+#include "core/image/image_indexed.h"
+#include "core/invoke_state.h"
+#include "core/math/2d/geometry/goost_geometry_2d.h"
+#include "core/math/2d/geometry/goost_geometry_2d_bind.h"
+#include "core/math/2d/geometry/poly/boolean/poly_boolean.h"
+#include "core/math/2d/geometry/poly/decomp/poly_decomp.h"
+#include "core/math/2d/geometry/poly/offset/poly_offset.h"
+#include "core/math/2d/geometry/poly/poly_backends.h"
+#include "core/math/2d/random_2d.h"
+#include "core/math/random.h"
+#include "core/types/grid_2d.h"
+#include "core/types/linked_list.h"
+#include "core/types/variant_resource.h"
+
 void register_goost_types();
 void unregister_goost_types();
+
+namespace goost {
+template <typename T>
+void register_class() {
+	ClassDB::register_class<T>();
+}
+} // namespace goost

--- a/register_types.h
+++ b/register_types.h
@@ -1,3 +1,6 @@
+#ifndef GOOST_REGISTER_TYPES
+#define GOOST_REGISTER_TYPES
+
 #include "core/engine.h"
 
 #include "scene/2d/editor/poly_node_2d_editor_plugin.h"
@@ -36,3 +39,5 @@ void register_class() {
 	ClassDB::register_class<T>();
 }
 } // namespace goost
+
+#endif // GOOST_REGISTER_TYPES

--- a/scene/2d/editor/poly_node_2d_editor_plugin.h
+++ b/scene/2d/editor/poly_node_2d_editor_plugin.h
@@ -21,13 +21,13 @@ protected:
 
 	static PolyNode2DEditor* singleton;
 
-	virtual void _set_node(Node *p_node) override;
-	virtual Node2D *_get_node() const override;
+	virtual void _set_node(Node *p_node);
+	virtual Node2D *_get_node() const;
 
-	virtual bool _is_line() const override;
-	virtual Variant _get_polygon(int p_idx) const override;
-	virtual void _set_polygon(int p_idx, const Variant &p_polygon) const override;
-	virtual void _action_set_polygon(int p_idx, const Variant &p_previous, const Variant &p_polygon) override;
+	virtual bool _is_line() const;
+	virtual Variant _get_polygon(int p_idx) const;
+	virtual void _set_polygon(int p_idx, const Variant &p_polygon) const;
+	virtual void _action_set_polygon(int p_idx, const Variant &p_previous, const Variant &p_polygon);
 
 public:
 	static PolyNode2DEditor* get_singleton() { return singleton; }

--- a/scene/physics/register_physics_types.cpp
+++ b/scene/physics/register_physics_types.cpp
@@ -2,12 +2,10 @@
 #include "goost/register_types.h"
 #include "goost/classes_enabled.gen.h"
 
-#include "2d/shape_cast_2d.h"
-
 namespace goost {
 
 void register_physics_types() {
-	GOOST_REGISTER_ShapeCast2D;
+	goost::register_class<ShapeCast2D>();
 }
 
 void unregister_physics_types() {

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -1,28 +1,19 @@
 #include "register_scene_types.h"
 #include "goost/register_types.h"
-#include "goost/classes_enabled.gen.h"
-
 #include "physics/register_physics_types.h"
-
-#include "2d/editor/poly_node_2d_editor_plugin.h"
-#include "2d/editor/visual_shape_2d_editor_plugin.h"
-#include "2d/poly_collision_shape_2d.h"
-#include "2d/poly_generators_2d.h"
-#include "2d/poly_shape_2d.h"
-#include "2d/visual_shape_2d.h"
-#include "resources/gradient_texture_2d.h"
+#include "goost/classes_enabled.gen.h"
 
 namespace goost {
 
 void register_scene_types() {
 #if defined(GOOST_CORE_ENABLED) && defined(GOOST_PolyNode2D)
-	GOOST_REGISTER_PolyCircle2D;
-	GOOST_REGISTER_PolyRectangle2D;
-	GOOST_REGISTER_PolyShape2D;
-	GOOST_REGISTER_PolyCollisionShape2D;
+	goost::register_class<PolyCircle2D>();
+	goost::register_class<PolyRectangle2D>();
+	goost::register_class<PolyShape2D>();
+	goost::register_class<PolyCollisionShape2D>();
 #endif
-	GOOST_REGISTER_VisualShape2D;
-	GOOST_REGISTER_GradientTexture2D;
+	goost::register_class<VisualShape2D>();
+	goost::register_class<GradientTexture2D>();
 
 #if defined(TOOLS_ENABLED) && defined(GOOST_EDITOR_ENABLED)
 #if defined(GOOST_CORE_ENABLED) && defined(GOOST_PolyNode2D)

--- a/scene/resources/gradient_texture_2d.h
+++ b/scene/resources/gradient_texture_2d.h
@@ -44,9 +44,9 @@ public:
 	Ref<Gradient> get_gradient() const { return gradient; }
 
 	void set_width(int p_width);
-	virtual int get_width() const override { return width; }
+	virtual int get_width() const { return width; }
 	void set_height(int p_height);
-	virtual int get_height() const override { return height; };
+	virtual int get_height() const { return height; };
 
 	void set_fill(Fill p_fill);
 	Fill get_fill() const { return fill; }
@@ -61,9 +61,9 @@ public:
 	virtual void set_flags(uint32_t p_flags) {}
 	virtual uint32_t get_flags() const { return FLAG_FILTER; }
 
-	virtual RID get_rid() const override { return texture; }
-	virtual bool has_alpha() const override { return true; }
-	virtual Ref<Image> get_data() const override;
+	virtual RID get_rid() const { return texture; }
+	virtual bool has_alpha() const { return true; }
+	virtual Ref<Image> get_data() const;
 
 	GradientTexture2D();
 	virtual ~GradientTexture2D();


### PR DESCRIPTION
- Use templates over macros (can be specialized);
- Move includes to top-level `register_types.h`.