### PR TITLE
Target Godot `3.x` development branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ There are separate branches which are targeted for specific Godot Engine's major
 version.
 
 Regarding latest extension development version, switch to
-* [`gd3`](https://github.com/goostengine/goost/tree/gd3) branch for Godot 3.2+
+* [`gd3`](https://github.com/goostengine/goost/tree/gd3) branch for Godot 3.x
 * [`gd4`](https://github.com/goostengine/goost/tree/gd4) branch for Godot 4.x (does not exist yet).
 
 Similarly, you may use any of the stable branches with a similar branch

--- a/SConstruct
+++ b/SConstruct
@@ -32,7 +32,7 @@ module_name = os.path.basename(Dir(".").abspath)
 print("Configuring %s module ..." % module_name.capitalize())
 
 # Environment variables (can override default build options).
-godot_version = os.getenv("GODOT_VERSION", "3.2") # A branch, commit, tag etc.
+godot_version = os.getenv("GODOT_VERSION", "3.x") # A branch, commit, tag etc.
 
 # Find a path to Godot source to build with this module.
 godot_dir = Dir("godot")
@@ -70,7 +70,7 @@ Help(opts.GenerateHelpText(env), append=True)
 help_msg = """
 {module} environment variables:
 
-GODOT_VERSION: such as 3.2, 3.2.4-stable, master, commit hash etc.
+GODOT_VERSION: such as 3.x, 3.3-stable, master, commit hash etc.
     Current: {version}
 GODOT_SOURCE_PATH: a directory path to the existing Godot source code.
     Current: {path}


### PR DESCRIPTION
See godotengine/godot#47057.

The `gd3` branch in Goost maps to `3.x` development branch in Godot now.