### PR TITLE
Resolve crashes relating to custom iterators

### DIFF
--- a/core/types/grid_2d.cpp
+++ b/core/types/grid_2d.cpp
@@ -99,6 +99,11 @@ Variant Grid2D::_iter_next(const Array &p_iter) {
 }
 
 Variant Grid2D::_iter_get(const Variant &p_iter) {
+#ifdef DEBUG_ENABLED
+	ERR_FAIL_COND_V(p_iter.get_type() != Variant::INT, Variant());
+	int size = p_iter;
+	ERR_FAIL_INDEX_V(size, data.size(), Variant());
+#endif
 	return data[_iter_current];
 }
 

--- a/core/types/linked_list.cpp
+++ b/core/types/linked_list.cpp
@@ -380,11 +380,17 @@ Variant LinkedList::_iter_init(const Array &p_iter) {
 }
 
 Variant LinkedList::_iter_next(const Array &p_iter) {
+#ifdef DEBUG_ENABLED
+	ERR_FAIL_NULL_V(_iter_current, Variant());
+#endif
 	_iter_current = _iter_current->get_next();
 	return _iter_current != nullptr;
 }
 
 Variant LinkedList::_iter_get(const Variant &p_iter) {
+#ifdef DEBUG_ENABLED
+	ERR_FAIL_NULL_V(_iter_current, Variant());
+#endif
 	return _iter_current->get_value();
 }
 


### PR DESCRIPTION
These are ok as-is since the validation is done in `_iter_next`, but this should help detect other issues found via fuzzing.

Helps #61.