### PR TITLE
Clipper: Fix `new-delete-type-mismatch` bug in `DisposeOutPt`

### DIFF
--- a/thirdparty/clipper/clipper.10.0.0-r539-new-delete-type-mismatch.patch
+++ b/thirdparty/clipper/clipper.10.0.0-r539-new-delete-type-mismatch.patch
@@ -1,0 +1,22 @@
+diff --git a/thirdparty/clipper/clipper.h b/thirdparty/clipper/clipper.h
+index 453b341..c86f38d 100644
+--- a/thirdparty/clipper/clipper.h
++++ b/thirdparty/clipper/clipper.h
+@@ -97,6 +97,8 @@ public:
+   Point64      pt;
+   OutPt       *next;
+   OutPt       *prev;
++
++  virtual ~OutPt();
+ };
+ 
+ enum OutRecFlag { orInner, orOuter, orOpen};
+@@ -111,6 +113,8 @@ struct OutRec {
+   OutPt       *pts;
+   PolyPath    *polypath;
+   OutRecFlag  flag;
++  
++  virtual ~OutRec();
+ };
+ 
+ //Active: an edge in the AEL that may or may not be 'hot' (part of the clip solution).

--- a/thirdparty/clipper/clipper.h
+++ b/thirdparty/clipper/clipper.h
@@ -97,6 +97,8 @@ public:
   Point64      pt;
   OutPt       *next;
   OutPt       *prev;
+
+  virtual ~OutPt() {};
 };
 
 enum OutRecFlag { orInner, orOuter, orOpen};
@@ -111,6 +113,8 @@ struct OutRec {
   OutPt       *pts;
   PolyPath    *polypath;
   OutRecFlag  flag;
+  
+  virtual ~OutRec() {};
 };
 
 //Active: an edge in the AEL that may or may not be 'hot' (part of the clip solution).


### PR DESCRIPTION
Closes #61 (no crashes and no ASAN failures anymore).

Should be also upstreamed to Clipper repository once the newest version is ported from Delphi to C++. Generated a patch to track the bug fix.

Co-authored-by: @qarmin.