### PR TITLE
Add a method to convert angle to vector in `GoostGeometry2D`

### DIFF
--- a/core/math/2d/geometry/goost_geometry_2d.cpp
+++ b/core/math/2d/geometry/goost_geometry_2d.cpp
@@ -235,3 +235,7 @@ Vector<Point2> GoostGeometry2D::circle(real_t p_radius, real_t p_max_error) {
 
 	return regular_polygon(vertex_count, p_radius); // vertex count == edge count
 }
+
+Vector2 GoostGeometry2D::to_vector(real_t p_angle) {
+	return Vector2(Math::cos(p_angle), Math::sin(p_angle));
+}

--- a/core/math/2d/geometry/goost_geometry_2d.h
+++ b/core/math/2d/geometry/goost_geometry_2d.h
@@ -35,6 +35,9 @@ public:
 	/* Polygon/shapes generation methods */
 	static Vector<Point2> regular_polygon(int p_edge_count, real_t p_size);
 	static Vector<Point2> circle(real_t p_radius, real_t p_max_error = 0.25);
+	
+	/* Trigonometry utilities */
+	static Vector2 to_vector(real_t p_angle);
 };
 
 #endif // GOOST_GEOMETRY_2D_H

--- a/core/math/2d/geometry/goost_geometry_2d_bind.cpp
+++ b/core/math/2d/geometry/goost_geometry_2d_bind.cpp
@@ -134,6 +134,10 @@ Vector<Point2> _GoostGeometry2D::circle(real_t p_radius, real_t p_max_error) con
 	return GoostGeometry2D::circle(p_radius, p_max_error);
 }
 
+Vector2 _GoostGeometry2D::to_vector(real_t p_radians) const {
+	return GoostGeometry2D::to_vector(p_radians);
+}
+
 void _GoostGeometry2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("merge_polygons", "polygon_a", "polygon_b"), &_GoostGeometry2D::merge_polygons);
 	ClassDB::bind_method(D_METHOD("clip_polygons", "polygon_a", "polygon_b"), &_GoostGeometry2D::clip_polygons);
@@ -159,6 +163,8 @@ void _GoostGeometry2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("regular_polygon", "sides", "size"), &_GoostGeometry2D::regular_polygon);
 	ClassDB::bind_method(D_METHOD("circle", "radius", "max_error"), &_GoostGeometry2D::circle, DEFVAL(0.25));
+	
+	ClassDB::bind_method(D_METHOD("to_vector", "angle"), &_GoostGeometry2D::to_vector);
 }
 
 _GoostGeometry2D::_GoostGeometry2D() {

--- a/core/math/2d/geometry/goost_geometry_2d_bind.h
+++ b/core/math/2d/geometry/goost_geometry_2d_bind.h
@@ -41,6 +41,8 @@ public:
 	Vector<Point2> regular_polygon(int p_edge_count, real_t p_size) const;
 	Vector<Point2> circle(real_t p_radius, real_t p_max_error) const;
 
+	_FORCE_INLINE_ Vector2 to_vector(real_t p_radians) const;
+
 	_GoostGeometry2D();
 };
 

--- a/doc/GoostGeometry2D.xml
+++ b/doc/GoostGeometry2D.xml
@@ -199,6 +199,20 @@
 				The order of vertices returned is counterclockwise which makes it an outer polygon by default. To convert it to an inner polygon specifically, use [method PoolVector2Array.invert].
 			</description>
 		</method>
+		<method name="to_vector" qualifiers="const">
+			<return type="Vector2">
+			</return>
+			<argument index="0" name="angle" type="float">
+			</argument>
+			<description>
+				Converts an [code]angle[/code] radians to unit [Vector2]. Equivalent to [code]Vector2(cos(angle), sin(angle))[/code] and [code]Vector2.RIGHT.rotated(angle)[/code].
+				[codeblock]
+				print(GoostGeometry2D.to_vector(0)) # Prints Vector2(1, 0).
+				print(Vector2(1, 0).angle()) # Prints 0, which is the angle used above.
+				print(GoostGeometry2D.to_vector(PI / 2)) # Prints Vector2(0, 1).
+				[/codeblock]
+			</description>
+		</method>
 		<method name="triangulate_polygon" qualifiers="const">
 			<return type="Array">
 			</return>

--- a/tests/project/goost/core/math/2d/geometry/test_geometry_2d.gd
+++ b/tests/project/goost/core/math/2d/geometry/test_geometry_2d.gd
@@ -127,3 +127,12 @@ func test_regular_polygon():
 func test_circle():
 	solution = GoostGeometry2D.circle(SIZE, 0.25)
 	assert_eq(solution.size(), 32)
+
+
+func test_to_vector():
+	assert_true(GoostGeometry2D.to_vector(0).is_equal_approx(Vector2.RIGHT))
+	assert_true(GoostGeometry2D.to_vector(PI / 2).is_equal_approx(Vector2.DOWN))
+	assert_true(GoostGeometry2D.to_vector(PI).is_equal_approx(Vector2.LEFT))
+	assert_true(GoostGeometry2D.to_vector(-PI / 2).is_equal_approx(Vector2.UP))
+	assert_true(GoostGeometry2D.to_vector(deg2rad(-137)).is_equal_approx(Vector2(-0.731354, -0.681998)))
+	assert_true(GoostGeometry2D.to_vector(deg2rad(180)).is_equal_approx(Vector2.LEFT))


### PR DESCRIPTION
Not using `angle_to_vector` name because it may be too verbose.

See equivalent PR godotengine/godot#48237 for Godot 4.x where `Vector2.from_angle()` is proposed to be added as a static method.

There's also a 3.x version of the above PR which does the same thing godotengine/godot#48249, so awaiting for some decision making from the Godot core developers before merging *this* PR.

It might also make sense to have this available as `polar_to_vector()` which would accept the `length` as argument, but this could be achieved with simple multiplication. But, other methods could be implemented as noted in https://github.com/godotengine/godot/pull/48237#issuecomment-831885680.

When comparing different method names and usages:

```gdscript
Vector2(cos(angle), sin(angle))  # GDScript way.
Vector2.RIGHT.rotated(angle)     # GDScript way # 2.
GoostGeometry2D.to_vector(angle) # This PR.
Vector2.from_angle(angle)        # godotengine/godot#48237.
```