### PR TITLE
CI: Upgrade Emscripten to 2.0.15

### DIFF
--- a/.github/workflows/javascript_builds.yml
+++ b/.github/workflows/javascript_builds.yml
@@ -11,7 +11,7 @@ env:
   GOOST_BASE_BRANCH: gd3
   SCONSFLAGS: godot_modules_enabled=no platform=javascript verbose=yes warnings=all werror=yes --jobs=4
   SCONS_CACHE_LIMIT: 4096
-  EM_VERSION: 1.39.20
+  EM_VERSION: 2.0.15
   EM_CACHE_FOLDER: 'emsdk-cache'
 
 jobs:


### PR DESCRIPTION
Should fix web builds (as seen in #65).

See godotengine/godot#48263.
