### PR TITLE
Make `Random2D.point_in_region` accept a `Rect2` over endpoints

### DIFF
--- a/core/math/2d/random_2d.cpp
+++ b/core/math/2d/random_2d.cpp
@@ -15,10 +15,11 @@ real_t Random2D::get_rotation() {
 	return randf_range(0.0, Math_TAU);
 }
 
-Vector2 Random2D::point_in_region(const Vector2 &p_pos, const Vector2 &p_end) {
+Vector2 Random2D::point_in_region(const Rect2 &p_region) {
 	Point2 point;
-	point.x = randf_range(p_pos.x, p_end.x);
-	point.y = randf_range(p_pos.y, p_end.y);
+	const Vector2& end = p_region.position + p_region.size;
+	point.x = randf_range(p_region.position.x, end.x);
+	point.y = randf_range(p_region.position.y, end.y);
 	return point;
 }
 
@@ -120,7 +121,7 @@ void Random2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_direction"), &Random2D::get_direction);
 	ClassDB::bind_method(D_METHOD("get_rotation"), &Random2D::get_rotation);
 
-	ClassDB::bind_method(D_METHOD("point_in_region", "position_start", "position_end"), &Random2D::point_in_region);
+	ClassDB::bind_method(D_METHOD("point_in_region", "region"), &Random2D::point_in_region);
 	ClassDB::bind_method(D_METHOD("point_in_circle", "radius_min", "radius_max"), &Random2D::point_in_circle, DEFVAL(0.0), DEFVAL(1.0));
 	ClassDB::bind_method(D_METHOD("point_in_triangle", "triangle"), &Random2D::point_in_triangle);
 	ClassDB::bind_method(D_METHOD("point_in_polygon", "polygon", "point_count"), &Random2D::point_in_polygon, DEFVAL(1));

--- a/core/math/2d/random_2d.h
+++ b/core/math/2d/random_2d.h
@@ -19,7 +19,7 @@ public:
 	real_t get_rotation();
 	Vector2 get_direction(); // Unit vector.
 
-	Vector2 point_in_region(const Vector2 &p_pos, const Vector2 &p_end);
+	Vector2 point_in_region(const Rect2 &p_region);
 	Vector2 point_in_circle(real_t p_min_radius = 0.0, real_t p_max_radius = 1.0);
 	Vector2 point_in_triangle(const Vector<Point2> &p_triangle);
 	Variant point_in_polygon(const Variant &p_polygon, int p_point_count = 1);

--- a/doc/Random2D.xml
+++ b/doc/Random2D.xml
@@ -49,15 +49,13 @@
 		<method name="point_in_region">
 			<return type="Vector2">
 			</return>
-			<argument index="0" name="position_start" type="Vector2">
-			</argument>
-			<argument index="1" name="position_end" type="Vector2">
+			<argument index="0" name="region" type="Rect2">
 			</argument>
 			<description>
-				Generates a random point in the area specified by top-left and bottom-right corners of a rectangle.
+				Generates a random point in the area specified by top-left and bottom-right corners of a [Rect2].
 				[codeblock]
 				var rect := Rect2(-100, -100, 100, 100) # Position and size.
-				var point = Random2D.point_in_region(rect.position, rect.end)
+				var point = Random2D.point_in_region(rect)
 				[/codeblock]
 			</description>
 		</method>

--- a/tests/project/goost/core/math/test_random_2d.gd
+++ b/tests/project/goost/core/math/test_random_2d.gd
@@ -61,7 +61,7 @@ func test_point_within_circle_range():
 func test_point_in_region():
 	var rect = Rect2(Vector2(-100, -100), Vector2(200, 200))
 	for i in 100:
-		var point = Random2D.point_in_region(rect.position, rect.end)
+		var point = Random2D.point_in_region(rect)
 		assert_true(rect.has_point(point))
 
 


### PR DESCRIPTION
1. We cannot be sure if two endpoints are exactly top-left and bottom-right. `Rect2` should handle this logic on it's own.
2. Should make it more consistent with future `Random3D.point_in_region` where an equivalent `AABB` structure could be used (specifying three endpoints wouldn't be as intuitive compared to 2D).