### PR TITLE
Added `Random::decision()` which returns a bool based on a given probability

### DIFF
--- a/core/math/random.cpp
+++ b/core/math/random.cpp
@@ -102,6 +102,10 @@ void Random::shuffle(Array p_array) {
 	}
 }
 
+bool Random::decision(float probability) {
+	return randf() <= probability;
+}
+
 void Random::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("new_instance"), &Random::new_instance);
 
@@ -118,6 +122,7 @@ void Random::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("range", "from", "to"), &Random::range);
 	ClassDB::bind_method(D_METHOD("choice", "from_sequence"), &Random::choice);
 	ClassDB::bind_method(D_METHOD("shuffle", "array"), &Random::shuffle);
+	ClassDB::bind_method(D_METHOD("decision", "probability"), &Random::decision);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "number"), "", "get_number");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "value"), "", "get_value");

--- a/core/math/random.h
+++ b/core/math/random.h
@@ -27,6 +27,7 @@ public:
 	Variant range(const Variant &p_from, const Variant &p_to);
 	Variant choice(const Variant &p_sequence);
 	void shuffle(Array p_array);
+	bool decision(float probability);
 
 	Random() {
 		if (!singleton) {

--- a/doc/Random.xml
+++ b/doc/Random.xml
@@ -111,6 +111,15 @@
 				Shuffles the array such that the items will have a random order. By default, this method uses the global random number generator in [Random] singletons, but unlike in [method Array.shuffle], local instances of [Random] can be created with [method new_instance] to achieve reproducible results given the same seed.
 			</description>
 		</method>
+		<method name="decision">
+			<return type="bool">
+			</return>
+			<argument index="0" name="probability" type="float">
+			</argument>
+			<description>
+				Returns a boolean based on a given [code]probability[/code] value in the range of [code]0.0..1.0[/code]. The higher the probabilty value the higher the chance of this returning true.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="color" type="Color" setter="" getter="get_color" default="Color( 0, 0, 1, 1 )">


### PR DESCRIPTION
I often use something like `randf() < 0.33` to do something based on a given probability. This PR adds this functionality to `Random`. Not sure about the function name. It makes sense to me, but if you have a different suggestion i can change it of course.