### PR TITLE
SCons: Do not search for Godot source in parent directory

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -39,8 +39,6 @@ godot_dir = Dir("godot")
 godot_search_dirs = [
     # Try environment variable pointing to the Godot source, should be first.
     Dir(os.getenv("GODOT_SOURCE_PATH")),
-    # Search for the Godot source in the parent directory.
-    Dir("../godot"),
     # Use the Godot source within the module, should be last.
     # If not found, the source is fetched from the remote URL.
     Dir("godot"),


### PR DESCRIPTION
This is error prone, we cannot be sure if the path pointing to `../godot` is exactly what we need, it would require more sophisticated approach of checking if that's Godot in the first place, or just a directory named Godot.

It's possible to improve the detection logic, especially if you use `GODOT_SOURCE_PATH` env var, yet this fixes  #69 and future limitations.
