### PR TITLE
Add various pixel-generation methods to `GoostGeometry2D`

### DIFF
--- a/core/math/2d/geometry/goost_geometry_2d.cpp
+++ b/core/math/2d/geometry/goost_geometry_2d.cpp
@@ -513,7 +513,7 @@ Vector<Point2i> GoostGeometry2D::pixel_line(const Point2i &p_start, const Point2
 // "A Fast Bresenham Type Algorithm For Drawing Circles" by John Kennedy:
 // https://web.engr.oregonstate.edu/~sllu/bcircle.pdf
 //
-Vector<Point2i> GoostGeometry2D::pixel_circle(const Point2i &p_origin, int p_radius) {
+Vector<Point2i> GoostGeometry2D::pixel_circle(int p_radius, const Point2i &p_origin) {
 	ERR_FAIL_COND_V(p_radius < 0, Vector<Point2i>());
 
 	Vector<Point2i> circle;

--- a/core/math/2d/geometry/goost_geometry_2d.cpp
+++ b/core/math/2d/geometry/goost_geometry_2d.cpp
@@ -473,7 +473,7 @@ Vector<Point2> GoostGeometry2D::circle(real_t p_radius, real_t p_max_error) {
 // Implementation borrowed from `TileMap` editor plugin:
 // https://github.com/godotengine/godot/blob/0d819ae5f5/editor/plugins/tile_map_editor_plugin.cpp#L982-L1023
 //
-Vector<Point2i> GoostGeometry2D::bresenham_line(const Point2i &p_start, const Point2i &p_end) {
+Vector<Point2i> GoostGeometry2D::pixel_line(const Point2i &p_start, const Point2i &p_end) {
 	Vector<Point2i> points;
 
 	int dx = ABS(p_end.x - p_start.x);
@@ -566,7 +566,7 @@ Vector<Point2i> GoostGeometry2D::polyline_to_pixels(const Vector<Point2> &p_poin
 	}
 	// Produce points in between.
 	for (int i = 0; i < points.size() - 1; ++i) {
-		Vector<Point2i> line = bresenham_line(points[i], points[i + 1]);
+		Vector<Point2i> line = pixel_line(points[i], points[i + 1]);
 		// Do not add last point, but include last point on the final line.
 		const int last = i < points.size() - 2 ? 1 : 0;
 		for (int j = 0; j < line.size() - last; ++j) {
@@ -592,7 +592,7 @@ Vector<Point2i> GoostGeometry2D::polygon_to_pixels(const Vector<Point2> &p_point
 	}
 	// Produce points in between.
 	for (int i = 0; i < points.size(); ++i) {
-		Vector<Point2i> line = bresenham_line(points[i], points[(i + 1) % points.size()]);
+		Vector<Point2i> line = pixel_line(points[i], points[(i + 1) % points.size()]);
 		for (int j = 0; j < line.size() - 1; ++j) { // Do not add last point.
 			polygon.push_back(line[j]);
 		}

--- a/core/math/2d/geometry/goost_geometry_2d.cpp
+++ b/core/math/2d/geometry/goost_geometry_2d.cpp
@@ -476,8 +476,8 @@ Vector<Point2> GoostGeometry2D::circle(real_t p_radius, real_t p_max_error) {
 Vector<Point2i> GoostGeometry2D::bresenham_line(const Point2i &p_start, const Point2i &p_end) {
 	Vector<Point2i> points;
 
-	real_t dx = ABS(p_end.x - p_start.x);
-	real_t dy = ABS(p_end.y - p_start.y);
+	int dx = ABS(p_end.x - p_start.x);
+	int dy = ABS(p_end.y - p_start.y);
 
 	int x = p_start.x;
 	int y = p_start.y;
@@ -486,7 +486,7 @@ Vector<Point2i> GoostGeometry2D::bresenham_line(const Point2i &p_start, const Po
 	int sy = p_start.y > p_end.y ? -1 : 1;
 
 	if (dx > dy) {
-		real_t err = dx / 2;
+		int err = dx / 2;
 		for (; x != p_end.x; x += sx) {
 			points.push_back(Point2i(x, y));
 			err -= dy;
@@ -496,7 +496,7 @@ Vector<Point2i> GoostGeometry2D::bresenham_line(const Point2i &p_start, const Po
 			}
 		}
 	} else {
-		real_t err = dy / 2;
+		int err = dy / 2;
 		for (; y != p_end.y; y += sy) {
 			points.push_back(Point2i(x, y));
 			err -= dx;
@@ -508,4 +508,94 @@ Vector<Point2i> GoostGeometry2D::bresenham_line(const Point2i &p_start, const Po
 	}
 	points.push_back(Point2i(x, y));
 	return points;
+}
+
+// "A Fast Bresenham Type Algorithm For Drawing Circles" by John Kennedy:
+// https://web.engr.oregonstate.edu/~sllu/bcircle.pdf
+//
+Vector<Point2i> GoostGeometry2D::pixel_circle(const Point2i &p_origin, int p_radius) {
+	ERR_FAIL_COND_V(p_radius < 0, Vector<Point2i>());
+
+	Vector<Point2i> circle;
+	const int cx = p_origin.x;
+	const int cy = p_origin.y;
+
+	int x = p_radius;
+	int y = 0;
+	int dx = 1 - 2 * p_radius;
+	int dy = 1;
+
+	int rerr = 0;
+
+	while (x >= y) {
+		// This takes advantage of the fact that the circle is symmetrical.
+		circle.push_back(Point2i(cx + x, cy + y));
+		circle.push_back(Point2i(cx - x, cy + y));
+		circle.push_back(Point2i(cx - x, cy - y));
+		circle.push_back(Point2i(cx + x, cy - y));
+		circle.push_back(Point2i(cx + y, cy + x));
+		circle.push_back(Point2i(cx - y, cy + x));
+		circle.push_back(Point2i(cx - y, cy - x));
+		circle.push_back(Point2i(cx + y, cy - x));
+
+		y += 1;
+		rerr += dy;
+		dy += 2;
+		if (2 * rerr + dx > 0) {
+			x -= 1;
+			rerr += dx;
+			dx += 2;
+		}
+	}
+	return circle;
+}
+
+Vector<Point2i> GoostGeometry2D::polyline_to_pixels(const Vector<Point2> &p_points) {
+	ERR_FAIL_COND_V(p_points.size() < 2, Vector<Point2i>());
+
+	Vector<Point2i> polyline;
+
+	Vector<Point2i> points;
+	// Round to nearest integer.
+	for (int i = 0; i < p_points.size(); ++i) {
+		const Point2 &p = p_points[i].round();
+		if (points.size() > 0 && p.is_equal_approx(points[points.size() - 1])) {
+			continue; // Do not add duplicate points.
+		}
+		points.push_back(p);
+	}
+	// Produce points in between.
+	for (int i = 0; i < points.size() - 1; ++i) {
+		Vector<Point2i> line = bresenham_line(points[i], points[i + 1]);
+		// Do not add last point, but include last point on the final line.
+		const int last = i < points.size() - 2 ? 1 : 0;
+		for (int j = 0; j < line.size() - last; ++j) {
+			polyline.push_back(line[j]);
+		}
+	}
+	return polyline;
+}
+
+Vector<Point2i> GoostGeometry2D::polygon_to_pixels(const Vector<Point2> &p_points) {
+	ERR_FAIL_COND_V(p_points.size() < 3, Vector<Point2i>());
+
+	Vector<Point2i> polygon;
+
+	Vector<Point2i> points;
+	// Round to nearest integer.
+	for (int i = 0; i < p_points.size(); ++i) {
+		const Point2 &p = p_points[i].round();
+		if (points.size() > 0 && p.is_equal_approx(points[points.size() - 1])) {
+			continue; // Do not add duplicate points.
+		}
+		points.push_back(p);
+	}
+	// Produce points in between.
+	for (int i = 0; i < points.size(); ++i) {
+		Vector<Point2i> line = bresenham_line(points[i], points[(i + 1) % points.size()]);
+		for (int j = 0; j < line.size() - 1; ++j) { // Do not add last point.
+			polygon.push_back(line[j]);
+		}
+	}
+	return polygon;
 }

--- a/core/math/2d/geometry/goost_geometry_2d.h
+++ b/core/math/2d/geometry/goost_geometry_2d.h
@@ -42,7 +42,11 @@ public:
 	/* Polygon/primitives generation methods */
 	static Vector<Point2> regular_polygon(int p_edge_count, real_t p_size);
 	static Vector<Point2> circle(real_t p_radius, real_t p_max_error = 0.25);
+
 	static Vector<Point2i> bresenham_line(const Point2i &p_start, const Point2i &p_end);
+	static Vector<Point2i> pixel_circle(const Point2i &p_origin, int p_radius);
+	static Vector<Point2i> polyline_to_pixels(const Vector<Point2> &p_points);
+	static Vector<Point2i> polygon_to_pixels(const Vector<Point2> &p_points);
 };
 
 #endif // GOOST_GEOMETRY_2D_H

--- a/core/math/2d/geometry/goost_geometry_2d.h
+++ b/core/math/2d/geometry/goost_geometry_2d.h
@@ -43,7 +43,7 @@ public:
 	static Vector<Point2> regular_polygon(int p_edge_count, real_t p_size);
 	static Vector<Point2> circle(real_t p_radius, real_t p_max_error = 0.25);
 
-	static Vector<Point2i> bresenham_line(const Point2i &p_start, const Point2i &p_end);
+	static Vector<Point2i> pixel_line(const Point2i &p_start, const Point2i &p_end);
 	static Vector<Point2i> pixel_circle(const Point2i &p_origin, int p_radius);
 	static Vector<Point2i> polyline_to_pixels(const Vector<Point2> &p_points);
 	static Vector<Point2i> polygon_to_pixels(const Vector<Point2> &p_points);

--- a/core/math/2d/geometry/goost_geometry_2d.h
+++ b/core/math/2d/geometry/goost_geometry_2d.h
@@ -44,7 +44,7 @@ public:
 	static Vector<Point2> circle(real_t p_radius, real_t p_max_error = 0.25);
 
 	static Vector<Point2i> pixel_line(const Point2i &p_start, const Point2i &p_end);
-	static Vector<Point2i> pixel_circle(const Point2i &p_origin, int p_radius);
+	static Vector<Point2i> pixel_circle(int p_radius, const Point2i &p_origin = Point2i(0, 0));
 	static Vector<Point2i> polyline_to_pixels(const Vector<Point2> &p_points);
 	static Vector<Point2i> polygon_to_pixels(const Vector<Point2> &p_points);
 };

--- a/core/math/2d/geometry/goost_geometry_2d_bind.cpp
+++ b/core/math/2d/geometry/goost_geometry_2d_bind.cpp
@@ -155,8 +155,8 @@ Vector<Point2> _GoostGeometry2D::circle(real_t p_radius, real_t p_max_error) con
 }
 
 // Note: this can be converted to use `Vector2i` in Godot 4.x.
-Vector<Point2> _GoostGeometry2D::bresenham_line(const Point2 &p_start, const Point2 &p_end) const {
-	const Vector<Point2i> &line = GoostGeometry2D::bresenham_line(p_start, p_end);
+Vector<Point2> _GoostGeometry2D::pixel_line(const Point2 &p_start, const Point2 &p_end) const {
+	const Vector<Point2i> &line = GoostGeometry2D::pixel_line(p_start, p_end);
 	Vector<Point2> ret;
 	for (int i = 0; i < line.size(); ++i) {
 		ret.push_back(line[i]);
@@ -222,7 +222,7 @@ void _GoostGeometry2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("regular_polygon", "sides", "size"), &_GoostGeometry2D::regular_polygon);
 	ClassDB::bind_method(D_METHOD("circle", "radius", "max_error"), &_GoostGeometry2D::circle, DEFVAL(0.25));
-	ClassDB::bind_method(D_METHOD("bresenham_line", "start", "end"), &_GoostGeometry2D::bresenham_line);
+	ClassDB::bind_method(D_METHOD("pixel_line", "start", "end"), &_GoostGeometry2D::pixel_line);
 	ClassDB::bind_method(D_METHOD("pixel_circle", "origin", "radius"), &_GoostGeometry2D::pixel_circle);
 	ClassDB::bind_method(D_METHOD("polyline_to_pixels", "points"), &_GoostGeometry2D::polyline_to_pixels);
 	ClassDB::bind_method(D_METHOD("polygon_to_pixels", "points"), &_GoostGeometry2D::polygon_to_pixels);

--- a/core/math/2d/geometry/goost_geometry_2d_bind.cpp
+++ b/core/math/2d/geometry/goost_geometry_2d_bind.cpp
@@ -164,6 +164,33 @@ Vector<Point2> _GoostGeometry2D::bresenham_line(const Point2 &p_start, const Poi
 	return ret;
 }
 
+Vector<Point2> _GoostGeometry2D::pixel_circle(const Point2 &p_origin, int p_radius) const {
+	const Vector<Point2i> &circle = GoostGeometry2D::pixel_circle(p_origin, p_radius);
+	Vector<Point2> ret;
+	for (int i = 0; i < circle.size(); ++i) {
+		ret.push_back(circle[i]);
+	}
+	return ret;
+}
+
+Vector<Point2> _GoostGeometry2D::polyline_to_pixels(const Vector<Point2> &p_points) const {
+	const Vector<Point2i> &polyline = GoostGeometry2D::polyline_to_pixels(p_points);
+	Vector<Point2> ret;
+	for (int i = 0; i < polyline.size(); ++i) {
+		ret.push_back(polyline[i]);
+	}
+	return ret;
+}
+
+Vector<Point2> _GoostGeometry2D::polygon_to_pixels(const Vector<Point2> &p_points) const {
+	const Vector<Point2i> &polygon = GoostGeometry2D::polygon_to_pixels(p_points);
+	Vector<Point2> ret;
+	for (int i = 0; i < polygon.size(); ++i) {
+		ret.push_back(polygon[i]);
+	}
+	return ret;
+}
+
 void _GoostGeometry2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("merge_polygons", "polygon_a", "polygon_b"), &_GoostGeometry2D::merge_polygons);
 	ClassDB::bind_method(D_METHOD("clip_polygons", "polygon_a", "polygon_b"), &_GoostGeometry2D::clip_polygons);
@@ -196,6 +223,9 @@ void _GoostGeometry2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("regular_polygon", "sides", "size"), &_GoostGeometry2D::regular_polygon);
 	ClassDB::bind_method(D_METHOD("circle", "radius", "max_error"), &_GoostGeometry2D::circle, DEFVAL(0.25));
 	ClassDB::bind_method(D_METHOD("bresenham_line", "start", "end"), &_GoostGeometry2D::bresenham_line);
+	ClassDB::bind_method(D_METHOD("pixel_circle", "origin", "radius"), &_GoostGeometry2D::pixel_circle);
+	ClassDB::bind_method(D_METHOD("polyline_to_pixels", "points"), &_GoostGeometry2D::polyline_to_pixels);
+	ClassDB::bind_method(D_METHOD("polygon_to_pixels", "points"), &_GoostGeometry2D::polygon_to_pixels);
 }
 
 _GoostGeometry2D::_GoostGeometry2D() {

--- a/core/math/2d/geometry/goost_geometry_2d_bind.cpp
+++ b/core/math/2d/geometry/goost_geometry_2d_bind.cpp
@@ -164,8 +164,8 @@ Vector<Point2> _GoostGeometry2D::pixel_line(const Point2 &p_start, const Point2 
 	return ret;
 }
 
-Vector<Point2> _GoostGeometry2D::pixel_circle(const Point2 &p_origin, int p_radius) const {
-	const Vector<Point2i> &circle = GoostGeometry2D::pixel_circle(p_origin, p_radius);
+Vector<Point2> _GoostGeometry2D::pixel_circle(int p_radius, const Point2 &p_origin) const {
+	const Vector<Point2i> &circle = GoostGeometry2D::pixel_circle(p_radius, p_origin);
 	Vector<Point2> ret;
 	for (int i = 0; i < circle.size(); ++i) {
 		ret.push_back(circle[i]);
@@ -222,8 +222,9 @@ void _GoostGeometry2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("regular_polygon", "sides", "size"), &_GoostGeometry2D::regular_polygon);
 	ClassDB::bind_method(D_METHOD("circle", "radius", "max_error"), &_GoostGeometry2D::circle, DEFVAL(0.25));
+
 	ClassDB::bind_method(D_METHOD("pixel_line", "start", "end"), &_GoostGeometry2D::pixel_line);
-	ClassDB::bind_method(D_METHOD("pixel_circle", "origin", "radius"), &_GoostGeometry2D::pixel_circle);
+	ClassDB::bind_method(D_METHOD("pixel_circle", "radius", "origin"), &_GoostGeometry2D::pixel_circle, DEFVAL(Vector2(0, 0)));
 	ClassDB::bind_method(D_METHOD("polyline_to_pixels", "points"), &_GoostGeometry2D::polyline_to_pixels);
 	ClassDB::bind_method(D_METHOD("polygon_to_pixels", "points"), &_GoostGeometry2D::polygon_to_pixels);
 }

--- a/core/math/2d/geometry/goost_geometry_2d_bind.h
+++ b/core/math/2d/geometry/goost_geometry_2d_bind.h
@@ -46,7 +46,11 @@ public:
 
 	Vector<Point2> regular_polygon(int p_edge_count, real_t p_size) const;
 	Vector<Point2> circle(real_t p_radius, real_t p_max_error) const;
+
 	Vector<Point2> bresenham_line(const Point2 &p_start, const Point2 &p_end) const;
+	Vector<Point2> pixel_circle(const Point2 &p_origin, int p_radius) const;
+	Vector<Point2> polyline_to_pixels(const Vector<Point2> &p_points) const;
+	Vector<Point2> polygon_to_pixels(const Vector<Point2> &p_points) const;
 
 	_GoostGeometry2D();
 };

--- a/core/math/2d/geometry/goost_geometry_2d_bind.h
+++ b/core/math/2d/geometry/goost_geometry_2d_bind.h
@@ -48,7 +48,7 @@ public:
 	Vector<Point2> circle(real_t p_radius, real_t p_max_error) const;
 
 	Vector<Point2> pixel_line(const Point2 &p_start, const Point2 &p_end) const;
-	Vector<Point2> pixel_circle(const Point2 &p_origin, int p_radius) const;
+	Vector<Point2> pixel_circle(int p_radius, const Point2 &p_origin = Point2(0, 0)) const;
 	Vector<Point2> polyline_to_pixels(const Vector<Point2> &p_points) const;
 	Vector<Point2> polygon_to_pixels(const Vector<Point2> &p_points) const;
 

--- a/core/math/2d/geometry/goost_geometry_2d_bind.h
+++ b/core/math/2d/geometry/goost_geometry_2d_bind.h
@@ -47,7 +47,7 @@ public:
 	Vector<Point2> regular_polygon(int p_edge_count, real_t p_size) const;
 	Vector<Point2> circle(real_t p_radius, real_t p_max_error) const;
 
-	Vector<Point2> bresenham_line(const Point2 &p_start, const Point2 &p_end) const;
+	Vector<Point2> pixel_line(const Point2 &p_start, const Point2 &p_end) const;
 	Vector<Point2> pixel_circle(const Point2 &p_origin, int p_radius) const;
 	Vector<Point2> polyline_to_pixels(const Vector<Point2> &p_points) const;
 	Vector<Point2> polygon_to_pixels(const Vector<Point2> &p_points) const;

--- a/doc/GoostGeometry2D.xml
+++ b/doc/GoostGeometry2D.xml
@@ -20,17 +20,6 @@
 				Computes the axis-aligned bounding rectangle of given points.
 			</description>
 		</method>
-		<method name="bresenham_line" qualifiers="const">
-			<return type="PoolVector2Array">
-			</return>
-			<argument index="0" name="start" type="Vector2">
-			</argument>
-			<argument index="1" name="end" type="Vector2">
-			</argument>
-			<description>
-				Returns an array of 2D-dimensional raster coordinates going through a segment determined by [code]start[/code] and [code]end[/code] points. The line is a close approximation to a straight line between those points.
-			</description>
-		</method>
 		<method name="circle" qualifiers="const">
 			<return type="PoolVector2Array">
 			</return>
@@ -163,6 +152,17 @@
 				[b]Note:[/b] pixels are created per circle's octant for performance reasons, so you should not rely on the order of returned pixels. If you do need ordered points, consider using methods such as [method polygon_to_pixels] and [method circle] with lower values for [code]max_error[/code] parameter, but take in mind that the quality of the returned points is going to be sub-optimal in comparison.
 			</description>
 		</method>
+		<method name="pixel_line" qualifiers="const">
+			<return type="PoolVector2Array">
+			</return>
+			<argument index="0" name="start" type="Vector2">
+			</argument>
+			<argument index="1" name="end" type="Vector2">
+			</argument>
+			<description>
+				Returns an array of 2D-dimensional raster coordinates going through a segment determined by [code]start[/code] and [code]end[/code] points using a Bresenham type algorithm. The line is a close approximation to a straight line between those points.
+			</description>
+		</method>
 		<method name="point_in_polygon" qualifiers="const">
 			<return type="int">
 			</return>
@@ -207,7 +207,7 @@
 			<argument index="0" name="points" type="PoolVector2Array">
 			</argument>
 			<description>
-				Returns an array of 2D-dimensional raster coordinates approximating a polygon going through [code]points[/code] using [method bresenham_line]. Point coordinates in the input [code]points[/code] are rounded to nearest integer values.
+				Returns an array of 2D-dimensional raster coordinates approximating a polygon going through [code]points[/code] using [method pixel_line]. Point coordinates in the input [code]points[/code] are rounded to nearest integer values.
 				[b]Note:[/b] this method does not fill the interior of the polygon. If you need this to raster polygons onto an image, use [method GoostImage.render_polygon] instead.
 			</description>
 		</method>
@@ -226,7 +226,7 @@
 			<argument index="0" name="points" type="PoolVector2Array">
 			</argument>
 			<description>
-				Returns an array of 2D-dimensional raster coordinates approximating a polyline going through [code]points[/code] using [method bresenham_line]. Point coordinates in the input [code]points[/code] are rounded to nearest integer values.
+				Returns an array of 2D-dimensional raster coordinates approximating a polyline going through [code]points[/code] using [method pixel_line]. Point coordinates in the input [code]points[/code] are rounded to nearest integer values.
 			</description>
 		</method>
 		<method name="regular_polygon" qualifiers="const">

--- a/doc/GoostGeometry2D.xml
+++ b/doc/GoostGeometry2D.xml
@@ -143,9 +143,9 @@
 		<method name="pixel_circle" qualifiers="const">
 			<return type="PoolVector2Array">
 			</return>
-			<argument index="0" name="origin" type="Vector2">
+			<argument index="0" name="radius" type="int">
 			</argument>
-			<argument index="1" name="radius" type="int">
+			<argument index="1" name="origin" type="Vector2" default="Vector2( 0, 0 )">
 			</argument>
 			<description>
 				Returns an array of 2D-dimensional raster coordinates approximating a circle using a Bresenham type algorithm.

--- a/doc/GoostGeometry2D.xml
+++ b/doc/GoostGeometry2D.xml
@@ -151,6 +151,18 @@
 				Performs [constant PolyBoolean2D.OP_UNION] between individual polygons. If you need to merge multiple polygons, use [method PolyBoolean2D.merge_polygons] instead.
 			</description>
 		</method>
+		<method name="pixel_circle" qualifiers="const">
+			<return type="PoolVector2Array">
+			</return>
+			<argument index="0" name="origin" type="Vector2">
+			</argument>
+			<argument index="1" name="radius" type="int">
+			</argument>
+			<description>
+				Returns an array of 2D-dimensional raster coordinates approximating a circle using a Bresenham type algorithm.
+				[b]Note:[/b] pixels are created per circle's octant for performance reasons, so you should not rely on the order of returned pixels. If you do need ordered points, consider using methods such as [method polygon_to_pixels] and [method circle] with lower values for [code]max_error[/code] parameter, but take in mind that the quality of the returned points is going to be sub-optimal in comparison.
+			</description>
+		</method>
 		<method name="point_in_polygon" qualifiers="const">
 			<return type="int">
 			</return>
@@ -189,6 +201,16 @@
 				Returns the perimeter of an arbitrary polygon. See also [method polyline_length].
 			</description>
 		</method>
+		<method name="polygon_to_pixels" qualifiers="const">
+			<return type="PoolVector2Array">
+			</return>
+			<argument index="0" name="points" type="PoolVector2Array">
+			</argument>
+			<description>
+				Returns an array of 2D-dimensional raster coordinates approximating a polygon going through [code]points[/code] using [method bresenham_line]. Point coordinates in the input [code]points[/code] are rounded to nearest integer values.
+				[b]Note:[/b] this method does not fill the interior of the polygon. If you need this to raster polygons onto an image, use [method GoostImage.render_polygon] instead.
+			</description>
+		</method>
 		<method name="polyline_length" qualifiers="const">
 			<return type="float">
 			</return>
@@ -196,6 +218,15 @@
 			</argument>
 			<description>
 				Returns the total length of the segments representing the polyline. See also [method polygon_perimeter].
+			</description>
+		</method>
+		<method name="polyline_to_pixels" qualifiers="const">
+			<return type="PoolVector2Array">
+			</return>
+			<argument index="0" name="points" type="PoolVector2Array">
+			</argument>
+			<description>
+				Returns an array of 2D-dimensional raster coordinates approximating a polyline going through [code]points[/code] using [method bresenham_line]. Point coordinates in the input [code]points[/code] are rounded to nearest integer values.
 			</description>
 		</method>
 		<method name="regular_polygon" qualifiers="const">

--- a/tests/project/goost/core/math/2d/geometry/test_geometry_2d.gd
+++ b/tests/project/goost/core/math/2d/geometry/test_geometry_2d.gd
@@ -187,6 +187,51 @@ func test_bresenham_line():
 	assert_eq(line[15], Vector2(10, 3))
 
 
+func test_pixel_circle():
+	var circle = GoostGeometry2D.pixel_circle(Vector2(0, 0), 16)
+	# for i in circle.size():
+		# gut.p("%s: %s" % [i, circle[i]])
+	assert_eq(circle.size(), 96)
+	assert_eq(circle[0], Vector2(16, 0))
+	assert_eq(circle[3], Vector2(16, 0))
+	assert_eq(circle[50], Vector2(-15, -6))
+	assert_eq(circle[52], Vector2(6, 15))
+	assert_eq(circle[93], Vector2(-11, 12))
+	assert_eq(circle[95], Vector2(11, -12))
+
+
+func test_polyline_to_pixels():
+	var input = [Vector2(0, 0), Vector2(0.01, 0.01), Vector2(10, 10),
+			Vector2(10.001, 10.001), Vector2(20, 10), Vector2(20, 20), Vector2(20.3, 20.3)]
+	var polyline = GoostGeometry2D.polyline_to_pixels(input)
+
+	assert_eq(polyline.size(), 31)
+
+	var pixel_set = {}
+	for pixel in polyline:
+		pixel_set[pixel] = true
+	assert_eq(pixel_set.keys().size(), polyline.size(), "Should not contain duplicate points here")
+
+	assert_eq(polyline[0], input[0], "Starting point should be the same as in input")
+	assert_eq(polyline[-1], input[-2], "Ending point should be the same as in input (without last rounded duplicate)")
+
+
+func test_polygon_to_pixels():
+	var input = [Vector2(-3, -3), Vector2(3, -3), Vector2(3, 3), Vector2(-3, 3), Vector2(-3.3, -3.3)]
+	var polygon = GoostGeometry2D.polygon_to_pixels(input)
+
+	assert_eq(polygon.size(), 24)
+
+	var pixel_set = {}
+	for pixel in polygon:
+		gut.p(pixel)
+		pixel_set[pixel] = true
+	assert_eq(pixel_set.keys().size(), polygon.size(), "Should not contain duplicate points here")
+
+	assert_eq(polygon[0], input[0], "Starting point should be the same as in input")
+	assert_ne(polygon[-1], input[-2], "Ending point should NOT be the same as in input (without last rounded duplicate)")
+
+
 func test_simplify_polyline():
 	var input = [Vector2(20, 51), Vector2(32, 13), Vector2(34, 13), Vector2(37, 13), Vector2(40, 18), Vector2(47, 46)]
 	var control = [Vector2(20, 51), Vector2(32, 13), Vector2(40, 18), Vector2(47, 46)]

--- a/tests/project/goost/core/math/2d/geometry/test_geometry_2d.gd
+++ b/tests/project/goost/core/math/2d/geometry/test_geometry_2d.gd
@@ -188,7 +188,7 @@ func test_pixel_line():
 
 
 func test_pixel_circle():
-	var circle = GoostGeometry2D.pixel_circle(Vector2(0, 0), 16)
+	var circle = GoostGeometry2D.pixel_circle(16)
 	# for i in circle.size():
 		# gut.p("%s: %s" % [i, circle[i]])
 	assert_eq(circle.size(), 96)

--- a/tests/project/goost/core/math/2d/geometry/test_geometry_2d.gd
+++ b/tests/project/goost/core/math/2d/geometry/test_geometry_2d.gd
@@ -129,46 +129,46 @@ func test_circle():
 	assert_eq(solution.size(), 32)
 
 
-func test_bresenham_line():
-	var line = GoostGeometry2D.bresenham_line(Vector2(0, 0), Vector2(5, 0))
+func test_pixel_line():
+	var line = GoostGeometry2D.pixel_line(Vector2(0, 0), Vector2(5, 0))
 	assert_eq(line.size(), 6)
 	for x in 6:
 		assert_eq(line[x], Vector2(x, 0))
 
-	line = GoostGeometry2D.bresenham_line(Vector2(0, 0), Vector2(-10, 0))
+	line = GoostGeometry2D.pixel_line(Vector2(0, 0), Vector2(-10, 0))
 	assert_eq(line.size(), 11)
 	for x in 11:
 		assert_eq(line[x], Vector2(-x, 0))
 
-	line = GoostGeometry2D.bresenham_line(Vector2(0, 0), Vector2(0, 5))
+	line = GoostGeometry2D.pixel_line(Vector2(0, 0), Vector2(0, 5))
 	assert_eq(line.size(), 6)
 	for x in 6:
 		assert_eq(line[x], Vector2(0, x))
 
-	line = GoostGeometry2D.bresenham_line(Vector2(0, 0), Vector2(0, -10))
+	line = GoostGeometry2D.pixel_line(Vector2(0, 0), Vector2(0, -10))
 	assert_eq(line.size(), 11)
 	for x in 11:
 		assert_eq(line[x], Vector2(0, -x))
 
-	line = GoostGeometry2D.bresenham_line(Vector2(-5, -5), Vector2(5, 5))
+	line = GoostGeometry2D.pixel_line(Vector2(-5, -5), Vector2(5, 5))
 	assert_eq(line.size(), 11)
 	assert_eq(line[0], Vector2(-5, -5))
 	assert_eq(line[5], Vector2(0, 0))
 	assert_eq(line[10], Vector2(5, 5))
 
-	line = GoostGeometry2D.bresenham_line(Vector2(5, -5), Vector2(-5, 5))
+	line = GoostGeometry2D.pixel_line(Vector2(5, -5), Vector2(-5, 5))
 	assert_eq(line.size(), 11)
 	assert_eq(line[0], Vector2(5, -5))
 	assert_eq(line[5], Vector2(0, 0))
 	assert_eq(line[10], Vector2(-5, 5))
 
-	line = GoostGeometry2D.bresenham_line(Vector2(5, -5), Vector2(-5, 5))
+	line = GoostGeometry2D.pixel_line(Vector2(5, -5), Vector2(-5, 5))
 	assert_eq(line.size(), 11)
 	assert_eq(line[0], Vector2(5, -5))
 	assert_eq(line[5], Vector2(0, 0))
 	assert_eq(line[10], Vector2(-5, 5))
 
-	line = GoostGeometry2D.bresenham_line(Vector2(-5, -5), Vector2(10, 3))
+	line = GoostGeometry2D.pixel_line(Vector2(-5, -5), Vector2(10, 3))
 	assert_eq(line[0], Vector2(-5, -5))
 	assert_eq(line[1], Vector2(-4, -4))
 	assert_eq(line[2], Vector2(-3, -4))
@@ -224,7 +224,6 @@ func test_polygon_to_pixels():
 
 	var pixel_set = {}
 	for pixel in polygon:
-		gut.p(pixel)
 		pixel_set[pixel] = true
 	assert_eq(pixel_set.keys().size(), polygon.size(), "Should not contain duplicate points here")
 


### PR DESCRIPTION
Having `bresenham_line()` is nice, but proves to be difficult to use via script (have to handle rounding, potentially avoiding duplicate points etc.)

### Pixelated circle

Adds `pixel_circle()` method.

![image](https://user-images.githubusercontent.com/17108460/118399469-f1d2ac80-b665-11eb-8ae0-35b84d015cda.png)

### Pixelated polygon/polyline

Adds `polygon_to_pixels()` and `polyline_to_pixels()` methods.

![image](https://user-images.githubusercontent.com/17108460/118399452-d9629200-b665-11eb-9d8e-5cdec0619a36.png)

---

This PR also renames `bresenham_line()` to `pixel_line()` for consistency with added features, also see other rationale in the commit description.
