### PR TITLE
CI: Fix missing `--no-window` in Linux server builds

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Run unit tests
         run: |
-          python run.py tests
+          python run.py --windowed tests
 
   linux-template:
     runs-on: "ubuntu-20.04"


### PR DESCRIPTION
Used for running tests. `--no-window` is implemented per editor platforms now, but somehow it's missing in server builds, so we hack it.