### PR TITLE
Add `GridRect` GUI node

### DIFF
--- a/config.py
+++ b/config.py
@@ -38,7 +38,7 @@ def configure(env):
     for name in disabled:
         children = goost.get_child_components(name)
         for child_name in children:
-            print("Goost: disabling `%s` component (%s)." % (child_name, name))
+            print("Goost: Disabling `%s` component (part of `%s`)." % (child_name, name))
             env["goost_%s_enabled" % (child_name)] = False
 
     def help_format(env, opt, help, default, actual, aliases):

--- a/doc/GridRect.xml
+++ b/doc/GridRect.xml
@@ -32,31 +32,58 @@
 				Return [code]true[/code] to draw the current line using default parameters, or [code]false[/code] to discard it. You can still draw the line using [method CanvasItem.draw_line] method, or any other drawing method.
 			</description>
 		</method>
-		<method name="point_to_view">
+		<method name="clear_cell_metadata">
+			<return type="void">
+			</return>
+			<description>
+				Clears all cell metadata from the grid previously assigned with [method set_cell_metadata].
+			</description>
+		</method>
+		<method name="get_cell_metadata" qualifiers="const">
+			<return type="Variant">
+			</return>
+			<argument index="0" name="cell" type="Vector2">
+			</argument>
+			<description>
+				Returns metadata for individual cell on the grid previously assigned with [method set_cell_metadata] (only integer coordinates are accepted). See also [member metadata_show_tooltip].
+			</description>
+		</method>
+		<method name="point_to_view" qualifiers="const">
 			<return type="Vector2">
 			</return>
 			<argument index="0" name="point" type="Vector2">
 			</argument>
 			<description>
-				Converts a point specified in grid coordinates to local position of this control. See also [method point_to_view_snapped].
+				Converts a point specified in grid coordinates to local position of this control.
 			</description>
 		</method>
-		<method name="view_to_point">
+		<method name="set_cell_metadata">
+			<return type="void">
+			</return>
+			<argument index="0" name="cell" type="Vector2">
+			</argument>
+			<argument index="1" name="metadata" type="Variant">
+			</argument>
+			<description>
+				Assigns metadata for individual cell on the grid (only integer coordinates are accepted). See also [member metadata_show_tooltip].
+			</description>
+		</method>
+		<method name="view_to_point" qualifiers="const">
 			<return type="Vector2">
 			</return>
 			<argument index="0" name="position" type="Vector2">
 			</argument>
 			<description>
-				Converts a local position of this control to grid coordinates.
+				Converts a local position of this control to grid coordinates. See also [method view_to_point_snapped].
 			</description>
 		</method>
-		<method name="view_to_point_snapped">
+		<method name="view_to_point_snapped" qualifiers="const">
 			<return type="Vector2">
 			</return>
 			<argument index="0" name="position" type="Vector2">
 			</argument>
 			<description>
-				Converts a point specified in grid coordinates to local position of this control. The point is snapped to grid line intersections when [member cell_origin] is set to [constant CELL_ORIGIN_TOP_LEFT], or snapped to grid cell center if [member cell_origin] is set to [constant CELL_ORIGIN_CENTER]. See also [method point_to_view].
+				Converts a point specified in grid coordinates to local position of this control. The point is snapped to grid line intersections when [member cell_origin] is set to [constant CELL_ORIGIN_TOP_LEFT], or snapped to grid cell center if [member cell_origin] is set to [constant CELL_ORIGIN_CENTER]. See also [method view_to_point].
 			</description>
 		</method>
 	</methods>

--- a/doc/GridRect.xml
+++ b/doc/GridRect.xml
@@ -73,6 +73,9 @@
 		<member name="metadata_show_tooltip" type="bool" setter="set_metadata_show_tooltip" getter="is_showing_metadata_tooltip" default="true">
 			If [code]true[/code], displays a tooltip on hover with coordinates snapped to the grid.
 		</member>
+		<member name="origin_axes_line_width" type="float" setter="set_origin_axes_line_width" getter="get_origin_axes_line_width" default="1.0">
+			The width of main axes lines (X and Y). Only relevant when [member origin_axes_visible] is set to [code]true[/code].
+		</member>
 		<member name="origin_axes_visible" type="bool" setter="set_origin_axes_visible" getter="is_origin_axes_visible" default="false">
 			If [code]true[/code], displays main axes (X and Y).
 		</member>

--- a/doc/GridRect.xml
+++ b/doc/GridRect.xml
@@ -62,7 +62,7 @@
 	</methods>
 	<members>
 		<member name="cell_line_width" type="float" setter="set_cell_line_width" getter="get_cell_line_width" default="1.0">
-			The width of minor lines.
+			The width of cell lines.
 		</member>
 		<member name="cell_origin" type="int" setter="set_cell_origin" getter="get_cell_origin" enum="GridRect.CellOrigin" default="0">
 			Determines the cell's origin offset for drawing and snapping.
@@ -74,7 +74,7 @@
 			The number of horizontal divisions along the [constant AXIS_X].
 		</member>
 		<member name="divisions_line_width" type="float" setter="set_divisions_line_width" getter="get_divisions_line_width" default="1.0">
-			The width of major lines.
+			The width of division lines.
 		</member>
 		<member name="divisions_vertical" type="int" setter="set_divisions_vertical" getter="get_divisions_vertical" default="8">
 			The number of horizontal divisions along the [constant AXIS_Y].
@@ -125,10 +125,10 @@
 		<constant name="AXIS_Y" value="1" enum="Axis">
 			Vertical axis.
 		</constant>
-		<constant name="LINE_MINOR" value="0" enum="Line">
+		<constant name="LINE_CELL" value="0" enum="Line">
 			Cell lines.
 		</constant>
-		<constant name="LINE_MAJOR" value="1" enum="Line">
+		<constant name="LINE_DIVISION" value="1" enum="Line">
 			Division lines.
 		</constant>
 		<constant name="LINE_AXIS" value="2" enum="Line">

--- a/doc/GridRect.xml
+++ b/doc/GridRect.xml
@@ -128,5 +128,8 @@
 		<constant name="LINE_MAJOR" value="1" enum="Line">
 			Subdivision lines.
 		</constant>
+		<constant name="LINE_AXIS" value="2" enum="Line">
+			Origin axes lines (X and Y).
+		</constant>
 	</constants>
 </class>

--- a/doc/GridRect.xml
+++ b/doc/GridRect.xml
@@ -4,8 +4,8 @@
 		Draws a rectangular grid.
 	</brief_description>
 	<description>
-		A control which allows to draw rectangular grid. Provides basic methods for converting between grid and view coordinates with or without snapping.
-		The drawing can be customized via virtual [method _draw_line] method.
+		A control which allows to draw a rectangular grid of any size. Provides basic methods for converting between grid and view coordinates with or without snapping, see methods [method view_to_point] and [method point_to_view]. The drawing can be completely customized by overriding [method _draw_line] method.
+		[b]Note[/b]: the scope of this class is mostly limited to drawing, and does not provide additional features like dragging, scrolling or zooming as seen in classes like [GraphEdit], but nonetheless possible to implement via script by modifying [member origin_offset] and [member origin_scale] properties.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -70,6 +70,15 @@
 		<member name="cell_size" type="Vector2" setter="set_cell_size" getter="get_cell_size" default="Vector2( 32, 32 )">
 			The size of individual cells drawn via grid line intersections.
 		</member>
+		<member name="divisions_horizontal" type="int" setter="set_divisions_horizontal" getter="get_divisions_horizontal" default="8">
+			The number of horizontal divisions along the [constant AXIS_X].
+		</member>
+		<member name="divisions_line_width" type="float" setter="set_divisions_line_width" getter="get_divisions_line_width" default="1.0">
+			The width of major lines.
+		</member>
+		<member name="divisions_vertical" type="int" setter="set_divisions_vertical" getter="get_divisions_vertical" default="8">
+			The number of horizontal divisions along the [constant AXIS_Y].
+		</member>
 		<member name="metadata_show_tooltip" type="bool" setter="set_metadata_show_tooltip" getter="is_showing_metadata_tooltip" default="true">
 			If [code]true[/code], displays a tooltip on hover with coordinates snapped to the grid.
 		</member>
@@ -89,15 +98,6 @@
 			The scale that zoom in or out the grid coordinates.
 		</member>
 		<member name="rect_clip_content" type="bool" setter="set_clip_contents" getter="is_clipping_contents" override="true" default="true" />
-		<member name="subdivisions_horizontal" type="int" setter="set_subdivisions_horizontal" getter="get_subdivisions_horizontal" default="8">
-			The number of horizontal subdivisions along the [constant AXIS_X].
-		</member>
-		<member name="subdivisions_line_width" type="float" setter="set_subdivisions_line_width" getter="get_subdivisions_line_width" default="1.0">
-			The width of major lines.
-		</member>
-		<member name="subdivisions_vertical" type="int" setter="set_subdivisions_vertical" getter="get_subdivisions_vertical" default="8">
-			The number of horizontal subdivisions along the [constant AXIS_Y].
-		</member>
 	</members>
 	<signals>
 		<signal name="point_clicked">
@@ -129,7 +129,7 @@
 			Cell lines.
 		</constant>
 		<constant name="LINE_MAJOR" value="1" enum="Line">
-			Subdivision lines.
+			Division lines.
 		</constant>
 		<constant name="LINE_AXIS" value="2" enum="Line">
 			Origin axes lines (X and Y).

--- a/doc/GridRect.xml
+++ b/doc/GridRect.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GridRect" inherits="Control" version="3.4">
+	<brief_description>
+		Draws a rectangular grid.
+	</brief_description>
+	<description>
+		A control which allows to draw rectangular grid. Provides basic methods for converting between grid and view coordinates with or without snapping.
+		The drawing can be customized via virtual [method _draw_line] method.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="_draw_line" qualifiers="virtual">
+			<return type="bool">
+			</return>
+			<argument index="0" name="from" type="Vector2">
+			</argument>
+			<argument index="1" name="to" type="Vector2">
+			</argument>
+			<argument index="2" name="color" type="Color">
+			</argument>
+			<argument index="3" name="width" type="float">
+			</argument>
+			<argument index="4" name="line" type="Dictionary">
+			</argument>
+			<description>
+				Called before drawing a grid line. The first four parameters match the interface of [method CanvasItem.draw_line].
+				The [code]line[/code] parameter is a [Dictionary] which contains the following fields:
+				[code]step[/code]: The line's step, which describes the current grid integer coordinate along the axis (can be negative or positive).
+				[code]axis[/code]: The line's axis along which it's drawn, one of [enum Axis] values.
+				[code]type[/code]: The line's type, one of [enum Line] values.
+				Return [code]true[/code] to draw the current line using default parameters, or [code]false[/code] to discard it. You can still draw the line using [method CanvasItem.draw_line] method, or any other drawing method.
+			</description>
+		</method>
+		<method name="point_to_view">
+			<return type="Vector2">
+			</return>
+			<argument index="0" name="point" type="Vector2">
+			</argument>
+			<description>
+				Converts a point specified in grid coordinates to local position of this control. See also [method point_to_view_snapped].
+			</description>
+		</method>
+		<method name="view_to_point">
+			<return type="Vector2">
+			</return>
+			<argument index="0" name="position" type="Vector2">
+			</argument>
+			<description>
+				Converts a local position of this control to grid coordinates.
+			</description>
+		</method>
+		<method name="view_to_point_snapped">
+			<return type="Vector2">
+			</return>
+			<argument index="0" name="position" type="Vector2">
+			</argument>
+			<description>
+				Converts a point specified in grid coordinates to local position of this control. The point is snapped to grid line intersections when [member cell_origin] is set to [constant CELL_ORIGIN_TOP_LEFT], or snapped to grid cell center if [member cell_origin] is set to [constant CELL_ORIGIN_CENTER]. See also [method point_to_view].
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="cell_line_width" type="float" setter="set_cell_line_width" getter="get_cell_line_width" default="1.0">
+			The width of minor lines.
+		</member>
+		<member name="cell_origin" type="int" setter="set_cell_origin" getter="get_cell_origin" enum="GridRect.CellOrigin" default="0">
+			Determines the cell's origin offset for drawing and snapping.
+		</member>
+		<member name="cell_size" type="Vector2" setter="set_cell_size" getter="get_cell_size" default="Vector2( 32, 32 )">
+			The size of individual cells drawn via grid line intersections.
+		</member>
+		<member name="metadata_show_tooltip" type="bool" setter="set_metadata_show_tooltip" getter="is_showing_metadata_tooltip" default="true">
+			If [code]true[/code], displays a tooltip on hover with coordinates snapped to the grid.
+		</member>
+		<member name="origin_axes_visible" type="bool" setter="set_origin_axes_visible" getter="is_origin_axes_visible" default="false">
+			If [code]true[/code], displays main axes (X and Y).
+		</member>
+		<member name="origin_centered" type="bool" setter="set_origin_centered" getter="is_origin_centered" default="false">
+			If [code]true[/code], the origin is centered to this control's center. The [member origin_offset] will additionally shift the origin away from the center.
+		</member>
+		<member name="origin_offset" type="Vector2" setter="set_origin_offset" getter="get_origin_offset" default="Vector2( 0, 0 )">
+			The offset that shifts the origin. Can be interpreted as a scroll offset.
+		</member>
+		<member name="origin_scale" type="Vector2" setter="set_origin_scale" getter="get_origin_scale" default="Vector2( 1, 1 )">
+			The scale that zoom in or out the grid coordinates.
+		</member>
+		<member name="rect_clip_content" type="bool" setter="set_clip_contents" getter="is_clipping_contents" override="true" default="true" />
+		<member name="subdivisions_horizontal" type="int" setter="set_subdivisions_horizontal" getter="get_subdivisions_horizontal" default="8">
+			The number of horizontal subdivisions along the [constant AXIS_X].
+		</member>
+		<member name="subdivisions_line_width" type="float" setter="set_subdivisions_line_width" getter="get_subdivisions_line_width" default="1.0">
+			The width of major lines.
+		</member>
+		<member name="subdivisions_vertical" type="int" setter="set_subdivisions_vertical" getter="get_subdivisions_vertical" default="8">
+			The number of horizontal subdivisions along the [constant AXIS_Y].
+		</member>
+	</members>
+	<signals>
+		<signal name="point_clicked">
+			<argument index="0" name="point" type="Vector2">
+			</argument>
+			<argument index="1" name="point_snapped" type="Vector2">
+			</argument>
+			<argument index="2" name="local_position" type="Vector2">
+			</argument>
+			<description>
+				Emitted when the grid is clicked. The [code]point[/code] and [code]point_snapped[/code] are specified in grid coordinates and are computed with [method view_to_point] and [method view_to_point_snapped] respectively. The [code]local_position[/code] is the position in pixels relative to this control.
+			</description>
+		</signal>
+	</signals>
+	<constants>
+		<constant name="CELL_ORIGIN_TOP_LEFT" value="0" enum="CellOrigin">
+			Cell's top-left offset, corresponds to [code]Vector2(0, 0)[/code].
+		</constant>
+		<constant name="CELL_ORIGIN_CENTER" value="1" enum="CellOrigin">
+			Cell's center offset, corresponds to [code]cell_size * Vector2(0.5, 0.5)[/code].
+		</constant>
+		<constant name="AXIS_X" value="0" enum="Axis">
+			Horizontal axis.
+		</constant>
+		<constant name="AXIS_Y" value="1" enum="Axis">
+			Vertical axis.
+		</constant>
+		<constant name="LINE_MINOR" value="0" enum="Line">
+			Cell lines.
+		</constant>
+		<constant name="LINE_MAJOR" value="1" enum="Line">
+			Subdivision lines.
+		</constant>
+	</constants>
+</class>

--- a/editor/icons/icon_grid_rect.svg
+++ b/editor/icons/icon_grid_rect.svg
@@ -1,0 +1,1 @@
+<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><ellipse cx="3" cy="3" fill="#6e6e6e"/><g fill="#a5efac"><path d="m1 1h14v.999976h-14z"/><path d="m1 7.5h14v.999992h-14z"/><path d="m1 14h14v1.000024h-14z"/><path d="m1 1h1v14.000025h-1z"/><path d="m7.5 1h1v14.00005h-1z"/><path d="m14 1h1v13.999975h-1z"/></g></svg>

--- a/goost.py
+++ b/goost.py
@@ -59,6 +59,7 @@ classes = [
     "GoostGeometry2D",
     "GoostImage",
     "GradientTexture2D",
+    "GridRect",
     "ImageBlender",
     "ImageIndexed",
     "InvokeState",

--- a/goost.py
+++ b/goost.py
@@ -9,6 +9,7 @@ components = [
     "core/image",
     "core/math",
     "scene/physics",
+    "scene/gui",
     "editor",
 ]
 
@@ -39,13 +40,7 @@ def get_child_components(parent):
             comp_list.append(p)
     
     return comp_list
-#
-# Complete list of all classes currently implemented in the extension,
-# excluding any classes provided from within `modules/` directory.
-# 
-# This is used by config.py::get_doc_classes(), and potentially allow to disable
-# each of the class in the future.
-#
+
 class GoostClass:
    def __init__(self, name, deps=[]):
       self.name = name
@@ -54,6 +49,12 @@ class GoostClass:
    def add_depencency(self, goost_class):
       self.deps.append(goost_class)
 
+# A list of classes currently implemented in the extension, excluding any
+# classes provided from within `modules/` directory.
+# 
+# This is used by `config.py::get_doc_classes()` and to disable each of the
+# class via user-defined `custom.py::goost_classes_disabled` array of classes.
+#
 classes = [
     "GoostEngine",
     "GoostGeometry2D",
@@ -91,7 +92,7 @@ for c in classes:
     _classes[c] = GoostClass(c)
 classes = _classes
 
-# Define dependencies.
+# Define dependencies explicitly.
 classes["GoostEngine"].add_depencency(classes["InvokeState"])
 classes["GoostGeometry2D"].add_depencency(classes["PolyBoolean2D"])
 classes["GoostGeometry2D"].add_depencency(classes["PolyDecomp2D"])

--- a/register_types.h
+++ b/register_types.h
@@ -9,6 +9,7 @@
 #include "scene/2d/poly_generators_2d.h"
 #include "scene/2d/poly_shape_2d.h"
 #include "scene/2d/visual_shape_2d.h"
+#include "scene/gui/grid_rect.h"
 #include "scene/physics/2d/shape_cast_2d.h"
 #include "scene/resources/gradient_texture_2d.h"
 #include "scene/resources/light_texture.h"

--- a/scene/SCsub
+++ b/scene/SCsub
@@ -7,6 +7,8 @@ SConscript("2d/SCsub", exports="env_goost")
 if not env["disable_3d"]:
     SConscript("3d/SCsub", exports="env_goost")
 
+SConscript("gui/SCsub", exports="env_goost")
+
 if env["goost_physics_enabled"]:
     SConscript("physics/SCsub", exports="env_goost")
 

--- a/scene/SCsub
+++ b/scene/SCsub
@@ -7,7 +7,8 @@ SConscript("2d/SCsub", exports="env_goost")
 if not env["disable_3d"]:
     SConscript("3d/SCsub", exports="env_goost")
 
-SConscript("gui/SCsub", exports="env_goost")
+if env["goost_gui_enabled"]:
+    SConscript("gui/SCsub", exports="env_goost")
 
 if env["goost_physics_enabled"]:
     SConscript("physics/SCsub", exports="env_goost")

--- a/scene/gui/SCsub
+++ b/scene/gui/SCsub
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+Import("env")
+Import("env_goost")
+
+env_goost.add_source_files(env.modules_sources, "*.cpp")

--- a/scene/gui/grid_rect.cpp
+++ b/scene/gui/grid_rect.cpp
@@ -3,8 +3,6 @@
 #include "core/engine.h"
 #include "core/variant_parser.h"
 
-#include "core/method_bind_ext.gen.inc"
-
 void GridRect::set_cell_size(const Vector2 &p_size) {
 	cell_size = p_size;
 	update();
@@ -17,6 +15,21 @@ void GridRect::set_cell_origin(CellOrigin p_origin) {
 
 void GridRect::set_cell_line_width(float p_width) {
 	cell_line_width = MAX(0.0f, p_width);
+	update();
+}
+
+void GridRect::set_divisions_horizontal(int p_count) {
+	divisions_horizontal = MAX(0, p_count);
+	update();
+}
+
+void GridRect::set_divisions_vertical(int p_count) {
+	divisions_vertical = MAX(0, p_count);
+	update();
+}
+
+void GridRect::set_divisions_line_width(float p_width) {
+	divisions_line_width = MAX(0.0f, p_width);
 	update();
 }
 
@@ -43,21 +56,6 @@ void GridRect::set_origin_axes_visible(bool p_visible) {
 
 void GridRect::set_origin_axes_line_width(float p_width) {
 	origin_axes_line_width = MAX(0, p_width);
-	update();
-}
-
-void GridRect::set_subdivisions_horizontal(int p_count) {
-	subdivisions_horizontal = MAX(0, p_count);
-	update();
-}
-
-void GridRect::set_subdivisions_vertical(int p_count) {
-	subdivisions_vertical = MAX(0, p_count);
-	update();
-}
-
-void GridRect::set_subdivisions_line_width(float p_width) {
-	subdivisions_line_width = MAX(0.0f, p_width);
 	update();
 }
 
@@ -136,11 +134,11 @@ void GridRect::_draw_grid_vertical(int from, int to, const Vector2 &p_ofs, Line 
 			width = cell_line_width;
 			color = _minor_color;
 		} else if (p_type == LINE_MAJOR) {
-			bool should_draw = subdivisions_vertical != 0 && (ABS(i) % subdivisions_vertical == 0);
+			bool should_draw = divisions_vertical != 0 && (ABS(i) % divisions_vertical == 0);
 			if (!should_draw) {
 				continue;
 			}
-			width = subdivisions_line_width;
+			width = divisions_line_width;
 			color = _major_color;
 		} else if (p_type == LINE_AXIS) {
 			bool should_draw = origin_axes_visible && i == 0;
@@ -180,11 +178,11 @@ void GridRect::_draw_grid_horizontal(int from, int to, const Vector2 &p_ofs, Lin
 			width = cell_line_width;
 			color = _minor_color;
 		} else if (p_type == LINE_MAJOR) {
-			bool should_draw = subdivisions_horizontal != 0 && (ABS(i) % subdivisions_horizontal == 0);
+			bool should_draw = divisions_horizontal != 0 && (ABS(i) % divisions_horizontal == 0);
 			if (!should_draw) {
 				continue;
 			}
-			width = subdivisions_line_width;
+			width = divisions_line_width;
 			color = _major_color;
 		} else if (p_type == LINE_AXIS) {
 			bool should_draw = origin_axes_visible && i == 0;
@@ -363,14 +361,14 @@ void GridRect::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_origin_axes_line_width", "width"), &GridRect::set_origin_axes_line_width);
 	ClassDB::bind_method(D_METHOD("get_origin_axes_line_width"), &GridRect::get_origin_axes_line_width);
 
-	ClassDB::bind_method(D_METHOD("set_subdivisions_horizontal", "count"), &GridRect::set_subdivisions_horizontal);
-	ClassDB::bind_method(D_METHOD("get_subdivisions_horizontal"), &GridRect::get_subdivisions_horizontal);
+	ClassDB::bind_method(D_METHOD("set_divisions_horizontal", "count"), &GridRect::set_divisions_horizontal);
+	ClassDB::bind_method(D_METHOD("get_divisions_horizontal"), &GridRect::get_divisions_horizontal);
 
-	ClassDB::bind_method(D_METHOD("set_subdivisions_vertical", "count"), &GridRect::set_subdivisions_vertical);
-	ClassDB::bind_method(D_METHOD("get_subdivisions_vertical"), &GridRect::get_subdivisions_vertical);
+	ClassDB::bind_method(D_METHOD("set_divisions_vertical", "count"), &GridRect::set_divisions_vertical);
+	ClassDB::bind_method(D_METHOD("get_divisions_vertical"), &GridRect::get_divisions_vertical);
 
-	ClassDB::bind_method(D_METHOD("set_subdivisions_line_width", "width"), &GridRect::set_subdivisions_line_width);
-	ClassDB::bind_method(D_METHOD("get_subdivisions_line_width"), &GridRect::get_subdivisions_line_width);
+	ClassDB::bind_method(D_METHOD("set_divisions_line_width", "width"), &GridRect::set_divisions_line_width);
+	ClassDB::bind_method(D_METHOD("get_divisions_line_width"), &GridRect::get_divisions_line_width);
 
 	ClassDB::bind_method(D_METHOD("set_metadata_show_tooltip", "enabled"), &GridRect::set_metadata_show_tooltip);
 	ClassDB::bind_method(D_METHOD("is_showing_metadata_tooltip"), &GridRect::is_showing_metadata_tooltip);
@@ -403,17 +401,17 @@ void GridRect::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "cell_origin", PROPERTY_HINT_ENUM, "Top-left,Center"), "set_cell_origin", "get_cell_origin");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "cell_line_width", PROPERTY_HINT_RANGE, "0.0,5.0,0.5,or_greater"), "set_cell_line_width", "get_cell_line_width");
 
+	ADD_GROUP("Divisions", "divisions");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "divisions_horizontal", PROPERTY_HINT_RANGE, "0,16,1,or_greater"), "set_divisions_horizontal", "get_divisions_horizontal");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "divisions_vertical", PROPERTY_HINT_RANGE, "0,16,1,or_greater"), "set_divisions_vertical", "get_divisions_vertical");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "divisions_line_width", PROPERTY_HINT_RANGE, "0.0,5.0,0.5,or_greater"), "set_divisions_line_width", "get_divisions_line_width");
+
 	ADD_GROUP("Origin", "origin");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "origin_offset"), "set_origin_offset", "get_origin_offset");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "origin_scale"), "set_origin_scale", "get_origin_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "origin_centered"), "set_origin_centered", "is_origin_centered");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "origin_axes_visible"), "set_origin_axes_visible", "is_origin_axes_visible");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "origin_axes_line_width", PROPERTY_HINT_RANGE, "0.0,5.0,0.5,or_greater"), "set_origin_axes_line_width", "get_origin_axes_line_width");
-
-	ADD_GROUP("Subdivisions", "subdivisions");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "subdivisions_horizontal", PROPERTY_HINT_RANGE, "0,16,1,or_greater"), "set_subdivisions_horizontal", "get_subdivisions_horizontal");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "subdivisions_vertical", PROPERTY_HINT_RANGE, "0,16,1,or_greater"), "set_subdivisions_vertical", "get_subdivisions_vertical");
-	ADD_PROPERTY(PropertyInfo(Variant::REAL, "subdivisions_line_width", PROPERTY_HINT_RANGE, "0.0,5.0,0.5,or_greater"), "set_subdivisions_line_width", "get_subdivisions_line_width");
 
 	ADD_GROUP("Metadata", "metadata");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "metadata_show_tooltip"), "set_metadata_show_tooltip", "is_showing_metadata_tooltip");

--- a/scene/gui/grid_rect.cpp
+++ b/scene/gui/grid_rect.cpp
@@ -1,0 +1,392 @@
+#include "grid_rect.h"
+
+#include "core/engine.h"
+#include "core/variant_parser.h"
+
+#include "core/method_bind_ext.gen.inc"
+
+void GridRect::set_cell_size(const Vector2 &p_size) {
+	cell_size = p_size;
+	update();
+}
+
+void GridRect::set_cell_origin(CellOrigin p_origin) {
+	cell_origin = p_origin;
+	update();
+}
+
+void GridRect::set_cell_line_width(float p_width) {
+	cell_line_width = p_width;
+	update();
+}
+
+void GridRect::set_origin_offset(Vector2 p_offset) {
+	origin_offset = p_offset;
+	update();
+}
+
+void GridRect::set_origin_scale(Vector2 p_scale) {
+	origin_scale = p_scale;
+	update();
+}
+
+void GridRect::set_origin_centered(bool p_centered) {
+	origin_centered = p_centered;
+	update();
+}
+
+void GridRect::set_origin_axes_visible(bool p_visible) {
+	origin_axes_visible = p_visible;
+	update();
+}
+
+void GridRect::set_subdivisions_horizontal(int p_count) {
+	subdivisions_horizontal = p_count;
+	update();
+}
+
+void GridRect::set_subdivisions_vertical(int p_count) {
+	subdivisions_vertical = p_count;
+	update();
+}
+
+void GridRect::set_subdivisions_line_width(float p_width) {
+	subdivisions_line_width = p_width;
+	update();
+}
+
+void GridRect::set_metadata_show_tooltip(bool p_enabled) {
+	metadata_show_tooltip = p_enabled;
+	update();
+}
+
+Vector2 GridRect::_get_final_offset(CellOrigin p_cell_origin) {
+	Vector2 ofs = origin_offset;
+	if (origin_centered) {
+		ofs += -get_size() / 2;
+	}
+	if (p_cell_origin == CELL_ORIGIN_CENTER) {
+		ofs -= (cell_size * origin_scale) / 2;
+	}
+	return ofs;
+}
+
+Vector2 GridRect::view_to_point(const Vector2 &p_position) {
+	const Vector2 &ofs = _get_final_offset(cell_origin);
+	return (p_position + ofs) / (cell_size * origin_scale);
+}
+
+Vector2 GridRect::view_to_point_snapped(const Vector2 &p_position) {
+	const Vector2 &ofs = _get_final_offset(cell_origin);
+	return ((p_position + ofs) / (cell_size * origin_scale)).snapped(Vector2(1, 1));
+}
+
+Vector2 GridRect::point_to_view(const Vector2 &p_point) {
+	const Vector2 &ofs = _get_final_offset(cell_origin);
+	return p_point * cell_size * origin_scale - ofs;
+}
+
+void GridRect::set_metadata(const Vector2 &p_point, const Variant &p_metadata) {
+	metadata.insert(p_point, p_metadata);
+}
+
+Variant GridRect::get_metadata(const Vector2 &p_point) {
+	Variant ret;
+	if (metadata.has(p_point)) {
+		ret = metadata[p_point];
+	}
+	return ret;
+}
+
+void GridRect::_gui_input(const Ref<InputEvent> &p_event) {
+	Ref<InputEventMouseMotion> mm = p_event;
+	if (mm.is_valid()) {
+		_point_snapped = view_to_point_snapped(mm->get_position()); // For tooltip.
+	}
+	Ref<InputEventMouseButton> mb = p_event;
+	if (mb.is_valid()) {
+		if (mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
+			const Vector2 &point = view_to_point(mb->get_position());
+			const Vector2 &snapped = view_to_point_snapped(mb->get_position());
+			emit_signal("point_clicked", point, snapped, mb->get_position());
+		}
+	}
+}
+
+bool GridRect::_draw_line(const Vector2 &p_from, const Vector2 &p_to, const Color &p_color, float p_width, const Dictionary &p_line) {
+	auto script = get_script_instance();
+	if (script && script->has_method("_draw_line")) {
+		return script->call("_draw_line", p_from, p_to, p_color, p_width, p_line);
+	}
+	return true; // Draw everything by default.
+}
+
+void GridRect::_draw_grid_vertical(int from, int to, const Vector2 &p_ofs, Line p_type) {
+	for (int i = from; i < to + 1; ++i) {
+		Color color;
+		float width;
+		if (subdivisions_vertical != 0 && (ABS(i) % subdivisions_vertical == 0)) {
+			if (p_type != LINE_MAJOR) {
+				continue;
+			}
+			color = _major_color;
+			width = subdivisions_line_width;
+		} else {
+			if (p_type != LINE_MINOR) {
+				continue;
+			}
+			color = _minor_color;
+			width = cell_line_width;
+		}
+		if (origin_axes_visible && i == 0) {
+			width = subdivisions_line_width;
+			color = _axis_y_color;
+		}
+		Vector2 scale = origin_scale.abs();
+		real_t base_ofs = i * cell_size.x * scale.x - p_ofs.x * scale.x;
+		Vector2 from_pos = Vector2(base_ofs, 0);
+		Vector2 to_pos = Vector2(base_ofs, get_size().y);
+
+		current_line["step"] = i;
+		current_line["axis"] = AXIS_Y;
+		current_line["type"] = p_type;
+
+		bool to_draw = _draw_line(from_pos, to_pos, color, width, current_line);
+		if (to_draw) {
+			draw_line(from_pos, to_pos, color, width);
+		}
+	}
+}
+
+void GridRect::_draw_grid_horizontal(int from, int to, const Vector2 &p_ofs, Line p_type) {
+	for (int i = from; i < to + 1; ++i) {
+		Color color;
+		float width;
+		if (subdivisions_horizontal != 0 && (ABS(i) % subdivisions_horizontal == 0)) {
+			if (p_type != LINE_MAJOR) {
+				continue;
+			}
+			color = _major_color;
+			width = subdivisions_line_width;
+		} else {
+			if (p_type != LINE_MINOR) {
+				continue;
+			}
+			color = _minor_color;
+			width = cell_line_width;
+		}
+		if (origin_axes_visible && i == 0) {
+			width = subdivisions_line_width;
+			color = _axis_x_color;
+		}
+		Vector2 scale = origin_scale.abs();
+		real_t base_ofs = i * cell_size.y * scale.y - p_ofs.y * scale.y;
+		Vector2 from_pos = Vector2(0, base_ofs);
+		Vector2 to_pos = Vector2(get_size().x, base_ofs);
+
+		current_line["step"] = i;
+		current_line["axis"] = AXIS_X;
+		current_line["type"] = p_type;
+
+		bool to_draw = _draw_line(from_pos, to_pos, color, width, current_line);
+		if (to_draw) {
+			draw_line(from_pos, to_pos, color, width);
+		}
+	}
+}
+
+void GridRect::_update_colors() {
+	if (has_color_override("line_minor")) {
+		_minor_color = get_color("line_minor");
+	} else if (has_color("grid_minor", "GraphEdit")) {
+		// Reuse grid colors from GraphEdit.
+		_minor_color = get_color("grid_minor", "GraphEdit");
+	} else {
+		_minor_color = Color(1, 1, 1, 0.07);
+	}
+
+	if (has_color_override("line_major")) {
+		_major_color = get_color("line_major");
+	} else if (has_color("grid_major", "GraphEdit")) {
+		// Reuse grid colors from GraphEdit.
+		_major_color = get_color("grid_major", "GraphEdit");
+	} else {
+		_major_color = Color(1, 1, 1, 0.15);
+	}
+
+	if (origin_axes_visible) {
+		if (has_color_override("axis_x")) {
+			_axis_x_color = get_color("axis_x");
+		} else if (has_color("axis_x_color", "Editor")) {
+			_axis_x_color = get_color("axis_x_color", "Editor");
+		} else {
+			_axis_x_color = Color(0.96, 0.20, 0.32);
+		}
+
+		if (has_color_override("axis_y")) {
+			_axis_y_color = get_color("axis_y");
+		} else if (has_color("axis_y_color", "Editor")) {
+			_axis_y_color = get_color("axis_y_color", "Editor");
+		} else {
+			_axis_y_color = Color(0.53, 0.84, 0.01);
+		}
+	}
+}
+
+void GridRect::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			_update_colors();
+			update();
+		} break;
+		case NOTIFICATION_DRAW: {
+			if (has_color_override("background")) {
+				draw_rect(Rect2(Vector2(), get_size()), get_color("background"));
+			} else if (has_stylebox("bg", "GraphEdit")) {
+				// Reuse GraphEdit's styling.
+				draw_style_box(get_stylebox("bg", "GraphEdit"), Rect2(Vector2(), get_size()));
+			} else {
+				draw_rect(Rect2(Vector2(), get_size()), Color::html("#2C2A32"));
+			}
+			const Vector2 &size = get_size() / origin_scale.abs();
+			Vector2 ofs = origin_offset / origin_scale.abs();
+			if (origin_centered) {
+				ofs += -size / 2;
+			}
+			const Vector2 &from = (ofs / cell_size).floor();
+			const Vector2 &to = (size / cell_size).floor() + Vector2(1, 1);
+
+			// Draw major lines first to prevent cross artifacts.
+			_draw_grid_vertical(from.x, from.x + to.x, ofs, LINE_MAJOR);
+			_draw_grid_horizontal(from.y, from.y + to.y, ofs, LINE_MAJOR);
+			// Draw minor lines last on top of major ones.
+			_draw_grid_vertical(from.x, from.x + to.x, ofs, LINE_MINOR);
+			_draw_grid_horizontal(from.y, from.y + to.y, ofs, LINE_MINOR);
+
+			if (!Engine::get_singleton()->is_editor_hint() && metadata_show_tooltip) {
+				String hint_tooltip = String(_point_snapped);
+				Variant data = get_metadata(_point_snapped);
+				if (data.get_type() != Variant::NIL) {
+					String data_str;
+					VariantWriter::write_to_string(data, data_str);
+					hint_tooltip += "\n" + data_str;
+				}
+				set_tooltip(hint_tooltip);
+			}
+		} break;
+		case NOTIFICATION_THEME_CHANGED: {
+			_update_colors();
+		} break;
+	}
+}
+
+void GridRect::_get_property_list(List<PropertyInfo> *p_list) const {
+	// Reuse overriding mechanism.
+	Vector<String> props;
+	props.push_back("line_minor");
+	props.push_back("line_major");
+	props.push_back("axis_x");
+	props.push_back("axis_y");
+	props.push_back("background");
+
+	for (int i = 0; i < props.size(); ++i) {
+		const String &prop = props[i];
+		uint32_t usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CHECKABLE;
+		if (has_color_override(prop)) {
+			usage |= PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_CHECKED;
+		}
+		PropertyInfo pi;
+		pi.name = "custom_colors/" + prop;
+		pi.type = Variant::COLOR;
+		pi.hint = PROPERTY_HINT_NONE;
+		pi.usage = usage;
+		p_list->push_back(pi);
+	}
+}
+
+void GridRect::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_cell_size", "size"), &GridRect::set_cell_size);
+	ClassDB::bind_method(D_METHOD("get_cell_size"), &GridRect::get_cell_size);
+
+	ClassDB::bind_method(D_METHOD("set_cell_origin", "origin"), &GridRect::set_cell_origin);
+	ClassDB::bind_method(D_METHOD("get_cell_origin"), &GridRect::get_cell_origin);
+
+	ClassDB::bind_method(D_METHOD("set_cell_line_width", "width"), &GridRect::set_cell_line_width);
+	ClassDB::bind_method(D_METHOD("get_cell_line_width"), &GridRect::get_cell_line_width);
+
+	ClassDB::bind_method(D_METHOD("set_origin_offset", "offset"), &GridRect::set_origin_offset);
+	ClassDB::bind_method(D_METHOD("get_origin_offset"), &GridRect::get_origin_offset);
+
+	ClassDB::bind_method(D_METHOD("set_origin_scale", "scale"), &GridRect::set_origin_scale);
+	ClassDB::bind_method(D_METHOD("get_origin_scale"), &GridRect::get_origin_scale);
+
+	ClassDB::bind_method(D_METHOD("set_origin_centered", "centered"), &GridRect::set_origin_centered);
+	ClassDB::bind_method(D_METHOD("is_origin_centered"), &GridRect::is_origin_centered);
+
+	ClassDB::bind_method(D_METHOD("set_origin_axes_visible", "visible"), &GridRect::set_origin_axes_visible);
+	ClassDB::bind_method(D_METHOD("is_origin_axes_visible"), &GridRect::is_origin_axes_visible);
+
+	ClassDB::bind_method(D_METHOD("set_subdivisions_horizontal", "count"), &GridRect::set_subdivisions_horizontal);
+	ClassDB::bind_method(D_METHOD("get_subdivisions_horizontal"), &GridRect::get_subdivisions_horizontal);
+
+	ClassDB::bind_method(D_METHOD("set_subdivisions_vertical", "count"), &GridRect::set_subdivisions_vertical);
+	ClassDB::bind_method(D_METHOD("get_subdivisions_vertical"), &GridRect::get_subdivisions_vertical);
+
+	ClassDB::bind_method(D_METHOD("set_subdivisions_line_width", "width"), &GridRect::set_subdivisions_line_width);
+	ClassDB::bind_method(D_METHOD("get_subdivisions_line_width"), &GridRect::get_subdivisions_line_width);
+
+	ClassDB::bind_method(D_METHOD("set_metadata_show_tooltip", "enabled"), &GridRect::set_metadata_show_tooltip);
+	ClassDB::bind_method(D_METHOD("is_showing_metadata_tooltip"), &GridRect::is_showing_metadata_tooltip);
+
+	ClassDB::bind_method(D_METHOD("view_to_point", "position"), &GridRect::view_to_point);
+	ClassDB::bind_method(D_METHOD("view_to_point_snapped", "position"), &GridRect::view_to_point_snapped);
+	ClassDB::bind_method(D_METHOD("point_to_view", "point"), &GridRect::point_to_view);
+
+	ClassDB::bind_method(D_METHOD("_gui_input"), &GridRect::_gui_input);
+
+	BIND_VMETHOD(MethodInfo(Variant::BOOL, "_draw_line",
+			PropertyInfo(Variant::VECTOR2, "from"),
+			PropertyInfo(Variant::VECTOR2, "to"),
+			PropertyInfo(Variant::COLOR, "color"),
+			PropertyInfo(Variant::REAL, "width"),
+			PropertyInfo(Variant::DICTIONARY, "line")));
+
+	BIND_ENUM_CONSTANT(CELL_ORIGIN_TOP_LEFT);
+	BIND_ENUM_CONSTANT(CELL_ORIGIN_CENTER);
+
+	BIND_ENUM_CONSTANT(AXIS_X);
+	BIND_ENUM_CONSTANT(AXIS_Y);
+
+	BIND_ENUM_CONSTANT(LINE_MINOR);
+	BIND_ENUM_CONSTANT(LINE_MAJOR);
+
+	ADD_GROUP("Cell", "cell");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "cell_size"), "set_cell_size", "get_cell_size");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "cell_origin", PROPERTY_HINT_ENUM, "Top-left,Center"), "set_cell_origin", "get_cell_origin");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "cell_line_width", PROPERTY_HINT_RANGE, "0.0,3.0,0.5,or_greater"), "set_cell_line_width", "get_cell_line_width");
+
+	ADD_GROUP("Origin", "origin");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "origin_offset"), "set_origin_offset", "get_origin_offset");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "origin_scale"), "set_origin_scale", "get_origin_scale");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "origin_centered"), "set_origin_centered", "is_origin_centered");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "origin_axes_visible"), "set_origin_axes_visible", "is_origin_axes_visible");
+
+	ADD_GROUP("Subdivisions", "subdivisions");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "subdivisions_horizontal", PROPERTY_HINT_RANGE, "0,16,1,or_greater"), "set_subdivisions_horizontal", "get_subdivisions_horizontal");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "subdivisions_vertical", PROPERTY_HINT_RANGE, "0,16,1,or_greater"), "set_subdivisions_vertical", "get_subdivisions_vertical");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "subdivisions_line_width", PROPERTY_HINT_RANGE, "0.0,3.0,0.5,or_greater"), "set_subdivisions_line_width", "get_subdivisions_line_width");
+
+	ADD_GROUP("Metadata", "metadata");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "metadata_show_tooltip"), "set_metadata_show_tooltip", "is_showing_metadata_tooltip");
+
+	ADD_SIGNAL(MethodInfo("point_clicked", PropertyInfo(Variant::VECTOR2, "point"), PropertyInfo(Variant::VECTOR2, "point_snapped"), PropertyInfo(Variant::VECTOR2, "local_position")));
+}
+
+GridRect::GridRect() {
+	set_clip_contents(true);
+
+	// add_color_override("line_minor", get_color("grid_minor", "GraphEdit"));
+	// add_color_override("line_major", get_color("grid_major", "GraphEdit"));
+	// add_color_override("axis_x", Color(0.96, 0.20, 0.32));
+	// add_color_override("axis_y", Color(0.53, 0.84, 0.01));
+}

--- a/scene/gui/grid_rect.cpp
+++ b/scene/gui/grid_rect.cpp
@@ -96,7 +96,7 @@ void GridRect::set_metadata(const Vector2 &p_point, const Variant &p_metadata) {
 	metadata.insert(p_point, p_metadata);
 }
 
-Variant GridRect::get_metadata(const Vector2 &p_point) {
+Variant GridRect::get_metadata(const Vector2 &p_point) const {
 	Variant ret;
 	if (metadata.has(p_point)) {
 		ret = metadata[p_point];
@@ -285,17 +285,6 @@ void GridRect::_notification(int p_what) {
 			// Draw main axes last.
 			_draw_grid_horizontal(from.y, from.y + to.y, ofs, LINE_AXIS);
 			_draw_grid_vertical(from.x, from.x + to.x, ofs, LINE_AXIS);
-
-			if (!Engine::get_singleton()->is_editor_hint() && metadata_show_tooltip) {
-				String hint_tooltip = String(_point_snapped);
-				Variant data = get_metadata(_point_snapped);
-				if (data.get_type() != Variant::NIL) {
-					String data_str;
-					VariantWriter::write_to_string(data, data_str);
-					hint_tooltip += "\n" + data_str;
-				}
-				set_tooltip(hint_tooltip);
-			}
 		} break;
 		case NOTIFICATION_THEME_CHANGED: {
 			_update_colors();
@@ -333,6 +322,20 @@ void GridRect::_validate_property(PropertyInfo &property) const {
 			property.usage = PROPERTY_USAGE_NOEDITOR;
 		}
 	}
+}
+
+String GridRect::get_tooltip(const Point2 &p_pos) const {
+	if (metadata_show_tooltip) {
+		String text = vformat("(%s, %s)", _point_snapped.x, _point_snapped.y);
+		Variant data = get_metadata(_point_snapped);
+		if (data.get_type() != Variant::NIL) {
+			String data_str;
+			VariantWriter::write_to_string(data, data_str);
+			text += "\n" + data_str;
+		}
+		return text;
+	}
+	return Control::get_tooltip(p_pos);
 }
 
 void GridRect::_bind_methods() {

--- a/scene/gui/grid_rect.cpp
+++ b/scene/gui/grid_rect.cpp
@@ -67,7 +67,7 @@ void GridRect::set_metadata_show_tooltip(bool p_enabled) {
 }
 
 Vector2 GridRect::_get_final_offset(CellOrigin p_cell_origin) {
-	Vector2 ofs = origin_offset;
+	Vector2 ofs = -origin_offset;
 	if (origin_centered) {
 		ofs += -get_size() / 2;
 	}
@@ -269,7 +269,7 @@ void GridRect::_notification(int p_what) {
 				draw_rect(Rect2(Vector2(), get_size()), Color::html("#2C2A32"));
 			}
 			const Vector2 &size = get_size() / origin_scale.abs();
-			Vector2 ofs = origin_offset / origin_scale.abs();
+			Vector2 ofs = -origin_offset / origin_scale.abs();
 			if (origin_centered) {
 				ofs += -size / 2;
 			}

--- a/scene/gui/grid_rect.cpp
+++ b/scene/gui/grid_rect.cpp
@@ -50,6 +50,7 @@ void GridRect::set_origin_centered(bool p_centered) {
 
 void GridRect::set_origin_axes_visible(bool p_visible) {
 	origin_axes_visible = p_visible;
+	_update_colors(); // Only updated when enabled.
 	_change_notify();
 	update();
 }

--- a/scene/gui/grid_rect.cpp
+++ b/scene/gui/grid_rect.cpp
@@ -129,7 +129,7 @@ bool GridRect::_draw_line(const Vector2 &p_from, const Vector2 &p_to, const Colo
 void GridRect::_draw_grid_vertical(int from, int to, const Vector2 &p_ofs, Line p_type) {
 	for (int i = from; i < to + 1; ++i) {
 		Color color;
-		float width;
+		float width = 0.0f;
 
 		if (p_type == LINE_CELL) {
 			width = cell_line_width;
@@ -173,7 +173,7 @@ void GridRect::_draw_grid_vertical(int from, int to, const Vector2 &p_ofs, Line 
 void GridRect::_draw_grid_horizontal(int from, int to, const Vector2 &p_ofs, Line p_type) {
 	for (int i = from; i < to + 1; ++i) {
 		Color color;
-		float width;
+		float width = 0.0f;
 
 		if (p_type == LINE_CELL) {
 			width = cell_line_width;

--- a/scene/gui/grid_rect.cpp
+++ b/scene/gui/grid_rect.cpp
@@ -130,16 +130,16 @@ void GridRect::_draw_grid_vertical(int from, int to, const Vector2 &p_ofs, Line 
 		Color color;
 		float width;
 
-		if (p_type == LINE_MINOR) {
+		if (p_type == LINE_CELL) {
 			width = cell_line_width;
-			color = _minor_color;
-		} else if (p_type == LINE_MAJOR) {
+			color = _cell_color;
+		} else if (p_type == LINE_DIVISION) {
 			bool should_draw = divisions_vertical != 0 && (ABS(i) % divisions_vertical == 0);
 			if (!should_draw) {
 				continue;
 			}
 			width = divisions_line_width;
-			color = _major_color;
+			color = _division_color;
 		} else if (p_type == LINE_AXIS) {
 			bool should_draw = origin_axes_visible && i == 0;
 			if (!should_draw) {
@@ -174,16 +174,16 @@ void GridRect::_draw_grid_horizontal(int from, int to, const Vector2 &p_ofs, Lin
 		Color color;
 		float width;
 
-		if (p_type == LINE_MINOR) {
+		if (p_type == LINE_CELL) {
 			width = cell_line_width;
-			color = _minor_color;
-		} else if (p_type == LINE_MAJOR) {
+			color = _cell_color;
+		} else if (p_type == LINE_DIVISION) {
 			bool should_draw = divisions_horizontal != 0 && (ABS(i) % divisions_horizontal == 0);
 			if (!should_draw) {
 				continue;
 			}
 			width = divisions_line_width;
-			color = _major_color;
+			color = _division_color;
 		} else if (p_type == LINE_AXIS) {
 			bool should_draw = origin_axes_visible && i == 0;
 			if (!should_draw) {
@@ -214,22 +214,22 @@ void GridRect::_draw_grid_horizontal(int from, int to, const Vector2 &p_ofs, Lin
 }
 
 void GridRect::_update_colors() {
-	if (has_color_override("line_minor")) {
-		_minor_color = get_color("line_minor");
+	if (has_color_override("cell")) {
+		_cell_color = get_color("cell");
 	} else if (has_color("grid_minor", "GraphEdit")) {
 		// Reuse grid colors from GraphEdit.
-		_minor_color = get_color("grid_minor", "GraphEdit");
+		_cell_color = get_color("grid_minor", "GraphEdit");
 	} else {
-		_minor_color = Color(1, 1, 1, 0.07);
+		_cell_color = Color(1, 1, 1, 0.07);
 	}
 
-	if (has_color_override("line_major")) {
-		_major_color = get_color("line_major");
+	if (has_color_override("division")) {
+		_division_color = get_color("division");
 	} else if (has_color("grid_major", "GraphEdit")) {
 		// Reuse grid colors from GraphEdit.
-		_major_color = get_color("grid_major", "GraphEdit");
+		_division_color = get_color("grid_major", "GraphEdit");
 	} else {
-		_major_color = Color(1, 1, 1, 0.15);
+		_division_color = Color(1, 1, 1, 0.15);
 	}
 
 	if (origin_axes_visible) {
@@ -274,12 +274,12 @@ void GridRect::_notification(int p_what) {
 			const Vector2 &from = (ofs / cell_size).floor();
 			const Vector2 &to = (size / cell_size).floor() + Vector2(1, 1);
 
-			// Draw minor lines first to prevent cross artifacts.
-			_draw_grid_horizontal(from.y, from.y + to.y, ofs, LINE_MINOR);
-			_draw_grid_vertical(from.x, from.x + to.x, ofs, LINE_MINOR);
-			// Draw major lines on top of minor ones.
-			_draw_grid_horizontal(from.y, from.y + to.y, ofs, LINE_MAJOR);
-			_draw_grid_vertical(from.x, from.x + to.x, ofs, LINE_MAJOR);
+			// Draw cells first to prevent cross artifacts.
+			_draw_grid_horizontal(from.y, from.y + to.y, ofs, LINE_CELL);
+			_draw_grid_vertical(from.x, from.x + to.x, ofs, LINE_CELL);
+			// Draw division lines on top of cells.
+			_draw_grid_horizontal(from.y, from.y + to.y, ofs, LINE_DIVISION);
+			_draw_grid_vertical(from.x, from.x + to.x, ofs, LINE_DIVISION);
 			// Draw main axes last.
 			_draw_grid_horizontal(from.y, from.y + to.y, ofs, LINE_AXIS);
 			_draw_grid_vertical(from.x, from.x + to.x, ofs, LINE_AXIS);
@@ -293,8 +293,8 @@ void GridRect::_notification(int p_what) {
 void GridRect::_get_property_list(List<PropertyInfo> *p_list) const {
 	// Reuse overriding mechanism.
 	Vector<String> props;
-	props.push_back("line_minor");
-	props.push_back("line_major");
+	props.push_back("cell");
+	props.push_back("division");
 	props.push_back("axis_x");
 	props.push_back("axis_y");
 	props.push_back("background");
@@ -392,8 +392,8 @@ void GridRect::_bind_methods() {
 	BIND_ENUM_CONSTANT(AXIS_X);
 	BIND_ENUM_CONSTANT(AXIS_Y);
 
-	BIND_ENUM_CONSTANT(LINE_MINOR);
-	BIND_ENUM_CONSTANT(LINE_MAJOR);
+	BIND_ENUM_CONSTANT(LINE_CELL);
+	BIND_ENUM_CONSTANT(LINE_DIVISION);
 	BIND_ENUM_CONSTANT(LINE_AXIS);
 
 	ADD_GROUP("Cell", "cell");
@@ -421,9 +421,4 @@ void GridRect::_bind_methods() {
 
 GridRect::GridRect() {
 	set_clip_contents(true);
-
-	// add_color_override("line_minor", get_color("grid_minor", "GraphEdit"));
-	// add_color_override("line_major", get_color("grid_major", "GraphEdit"));
-	// add_color_override("axis_x", Color(0.96, 0.20, 0.32));
-	// add_color_override("axis_y", Color(0.53, 0.84, 0.01));
 }

--- a/scene/gui/grid_rect.h
+++ b/scene/gui/grid_rect.h
@@ -17,8 +17,8 @@ public:
 		AXIS_Y,
 	};
 	enum Line {
-		LINE_MINOR,
-		LINE_MAJOR,
+		LINE_CELL,
+		LINE_DIVISION,
 		LINE_AXIS,
 	};
 
@@ -108,8 +108,8 @@ private:
 
 	Vector2 _point_snapped;
 
-	Color _minor_color;
-	Color _major_color;
+	Color _cell_color;
+	Color _division_color;
 	Color _axis_x_color;
 	Color _axis_y_color;
 };

--- a/scene/gui/grid_rect.h
+++ b/scene/gui/grid_rect.h
@@ -81,7 +81,9 @@ public:
 	Vector2 point_to_view(const Vector2 &p_point);
 
 	void set_metadata(const Vector2 &p_point, const Variant &p_metadata);
-	Variant get_metadata(const Vector2 &p_point);
+	Variant get_metadata(const Vector2 &p_point) const;
+
+	virtual String get_tooltip(const Point2 &p_pos) const;
 
 	GridRect();
 

--- a/scene/gui/grid_rect.h
+++ b/scene/gui/grid_rect.h
@@ -76,12 +76,14 @@ public:
 	void set_metadata_show_tooltip(bool p_enable);
 	bool is_showing_metadata_tooltip() const { return metadata_show_tooltip; }
 
-	Vector2 view_to_point(const Vector2 &p_position);
-	Vector2 view_to_point_snapped(const Vector2 &p_position);
-	Vector2 point_to_view(const Vector2 &p_point);
+	Vector2 view_to_point(const Vector2 &p_position) const;
+	Vector2 view_to_point_snapped(const Vector2 &p_position) const;
+	Vector2 point_to_view(const Vector2 &p_point) const;
 
-	void set_metadata(const Vector2 &p_point, const Variant &p_metadata);
-	Variant get_metadata(const Vector2 &p_point) const;
+	// Should use Vector2i in Godot 4.x.
+	void set_cell_metadata(const Vector2 &p_cell, const Variant &p_metadata);
+	Variant get_cell_metadata(const Vector2 &p_cell) const;
+	void clear_cell_metadata() { metadata.clear(); }
 
 	virtual String get_tooltip(const Point2 &p_pos) const;
 
@@ -92,12 +94,11 @@ protected:
 	static void _bind_methods();
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	virtual void _validate_property(PropertyInfo &property) const;
-
 	void _gui_input(const Ref<InputEvent> &p_event);
 
-	Vector2 _get_final_offset(CellOrigin p_cell_origin);
 	virtual bool _draw_line(const Vector2 &p_from, const Vector2 &p_to, const Color &p_color, float p_width, const Dictionary &p_line);
 
+	Vector2 _get_final_offset(CellOrigin p_cell_origin) const;
 	void _draw_grid_vertical(int from, int to, const Vector2 &p_ofs, Line p_type);
 	void _draw_grid_horizontal(int from, int to, const Vector2 &p_ofs, Line p_type);
 	void _update_colors();

--- a/scene/gui/grid_rect.h
+++ b/scene/gui/grid_rect.h
@@ -19,6 +19,7 @@ public:
 	enum Line {
 		LINE_MINOR,
 		LINE_MAJOR,
+		LINE_AXIS,
 	};
 
 protected:

--- a/scene/gui/grid_rect.h
+++ b/scene/gui/grid_rect.h
@@ -1,8 +1,8 @@
 #ifndef GRID_RECT_H
 #define GRID_RECT_H
 
-#include "scene/gui/control.h"
 #include "core/color.h"
+#include "scene/gui/control.h"
 
 class GridRect : public Control {
 	GDCLASS(GridRect, Control);
@@ -27,51 +27,51 @@ protected:
 	CellOrigin cell_origin = CELL_ORIGIN_TOP_LEFT;
 	float cell_line_width = 1.0;
 
+	int divisions_horizontal = 8;
+	int divisions_vertical = 8;
+	float divisions_line_width = 1.0;
 	Vector2 origin_offset;
 	Vector2 origin_scale = Vector2(1, 1);
+
 	bool origin_centered = false;
 	bool origin_axes_visible = false;
 	float origin_axes_line_width = 1.0;
-
-	int subdivisions_horizontal = 8;
-	int subdivisions_vertical = 8;
-	float subdivisions_line_width = 1.0;
 
 	bool metadata_show_tooltip = true;
 
 public:
 	void set_cell_size(const Vector2 &p_size);
 	Vector2 get_cell_size() const { return cell_size; }
-	
+
 	void set_cell_origin(CellOrigin p_origin);
 	CellOrigin get_cell_origin() const { return cell_origin; }
-	
+
 	void set_cell_line_width(float p_width);
 	float get_cell_line_width() const { return cell_line_width; }
-	
+
+	void set_divisions_horizontal(int p_count);
+	int get_divisions_horizontal() const { return divisions_horizontal; }
+
+	void set_divisions_vertical(int p_count);
+	int get_divisions_vertical() const { return divisions_vertical; }
+
+	void set_divisions_line_width(float p_width);
+	float get_divisions_line_width() const { return divisions_line_width; }
+
 	void set_origin_offset(Vector2 p_offset);
 	Vector2 get_origin_offset() const { return origin_offset; }
-	
+
 	void set_origin_scale(Vector2 p_scale);
 	Vector2 get_origin_scale() const { return origin_scale; }
-	
+
 	void set_origin_centered(bool p_centered);
 	bool is_origin_centered() const { return origin_centered; }
-	
+
 	void set_origin_axes_visible(bool p_visible);
 	bool is_origin_axes_visible() const { return origin_axes_visible; }
 
 	void set_origin_axes_line_width(float p_width);
 	float get_origin_axes_line_width() const { return origin_axes_line_width; }
-
-	void set_subdivisions_horizontal(int p_count);
-	int get_subdivisions_horizontal() const { return subdivisions_horizontal; }
-	
-	void set_subdivisions_vertical(int p_count);
-	int get_subdivisions_vertical() const { return subdivisions_vertical; }
-	
-	void set_subdivisions_line_width(float p_width);
-	float get_subdivisions_line_width() const { return subdivisions_line_width; }
 
 	void set_metadata_show_tooltip(bool p_enable);
 	bool is_showing_metadata_tooltip() const { return metadata_show_tooltip; }

--- a/scene/gui/grid_rect.h
+++ b/scene/gui/grid_rect.h
@@ -31,6 +31,7 @@ protected:
 	Vector2 origin_scale = Vector2(1, 1);
 	bool origin_centered = false;
 	bool origin_axes_visible = false;
+	float origin_axes_line_width = 1.0;
 
 	int subdivisions_horizontal = 8;
 	int subdivisions_vertical = 8;
@@ -59,7 +60,10 @@ public:
 	
 	void set_origin_axes_visible(bool p_visible);
 	bool is_origin_axes_visible() const { return origin_axes_visible; }
-	
+
+	void set_origin_axes_line_width(float p_width);
+	float get_origin_axes_line_width() const { return origin_axes_line_width; }
+
 	void set_subdivisions_horizontal(int p_count);
 	int get_subdivisions_horizontal() const { return subdivisions_horizontal; }
 	
@@ -85,6 +89,7 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 	void _get_property_list(List<PropertyInfo> *p_list) const;
+	virtual void _validate_property(PropertyInfo &property) const;
 
 	void _gui_input(const Ref<InputEvent> &p_event);
 

--- a/scene/gui/grid_rect.h
+++ b/scene/gui/grid_rect.h
@@ -1,0 +1,113 @@
+#ifndef GRID_RECT_H
+#define GRID_RECT_H
+
+#include "scene/gui/control.h"
+#include "core/color.h"
+
+class GridRect : public Control {
+	GDCLASS(GridRect, Control);
+
+public:
+	enum CellOrigin {
+		CELL_ORIGIN_TOP_LEFT,
+		CELL_ORIGIN_CENTER,
+	};
+	enum Axis {
+		AXIS_X,
+		AXIS_Y,
+	};
+	enum Line {
+		LINE_MINOR,
+		LINE_MAJOR,
+	};
+
+protected:
+	Vector2 cell_size = Vector2(32, 32);
+	CellOrigin cell_origin = CELL_ORIGIN_TOP_LEFT;
+	float cell_line_width = 1.0;
+
+	Vector2 origin_offset;
+	Vector2 origin_scale = Vector2(1, 1);
+	bool origin_centered = false;
+	bool origin_axes_visible = false;
+
+	int subdivisions_horizontal = 8;
+	int subdivisions_vertical = 8;
+	float subdivisions_line_width = 1.0;
+
+	bool metadata_show_tooltip = true;
+
+public:
+	void set_cell_size(const Vector2 &p_size);
+	Vector2 get_cell_size() const { return cell_size; }
+	
+	void set_cell_origin(CellOrigin p_origin);
+	CellOrigin get_cell_origin() const { return cell_origin; }
+	
+	void set_cell_line_width(float p_width);
+	float get_cell_line_width() const { return cell_line_width; }
+	
+	void set_origin_offset(Vector2 p_offset);
+	Vector2 get_origin_offset() const { return origin_offset; }
+	
+	void set_origin_scale(Vector2 p_scale);
+	Vector2 get_origin_scale() const { return origin_scale; }
+	
+	void set_origin_centered(bool p_centered);
+	bool is_origin_centered() const { return origin_centered; }
+	
+	void set_origin_axes_visible(bool p_visible);
+	bool is_origin_axes_visible() const { return origin_axes_visible; }
+	
+	void set_subdivisions_horizontal(int p_count);
+	int get_subdivisions_horizontal() const { return subdivisions_horizontal; }
+	
+	void set_subdivisions_vertical(int p_count);
+	int get_subdivisions_vertical() const { return subdivisions_vertical; }
+	
+	void set_subdivisions_line_width(float p_width);
+	float get_subdivisions_line_width() const { return subdivisions_line_width; }
+
+	void set_metadata_show_tooltip(bool p_enable);
+	bool is_showing_metadata_tooltip() const { return metadata_show_tooltip; }
+
+	Vector2 view_to_point(const Vector2 &p_position);
+	Vector2 view_to_point_snapped(const Vector2 &p_position);
+	Vector2 point_to_view(const Vector2 &p_point);
+
+	void set_metadata(const Vector2 &p_point, const Variant &p_metadata);
+	Variant get_metadata(const Vector2 &p_point);
+
+	GridRect();
+
+protected:
+	void _notification(int p_what);
+	static void _bind_methods();
+	void _get_property_list(List<PropertyInfo> *p_list) const;
+
+	void _gui_input(const Ref<InputEvent> &p_event);
+
+	Vector2 _get_final_offset(CellOrigin p_cell_origin);
+	virtual bool _draw_line(const Vector2 &p_from, const Vector2 &p_to, const Color &p_color, float p_width, const Dictionary &p_line);
+
+	void _draw_grid_vertical(int from, int to, const Vector2 &p_ofs, Line p_type);
+	void _draw_grid_horizontal(int from, int to, const Vector2 &p_ofs, Line p_type);
+	void _update_colors();
+
+private:
+	Map<Vector2i, Variant> metadata;
+	Dictionary current_line;
+
+	Vector2 _point_snapped;
+
+	Color _minor_color;
+	Color _major_color;
+	Color _axis_x_color;
+	Color _axis_y_color;
+};
+
+VARIANT_ENUM_CAST(GridRect::CellOrigin);
+VARIANT_ENUM_CAST(GridRect::Axis);
+VARIANT_ENUM_CAST(GridRect::Line);
+
+#endif // GRID_RECT_H

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -16,9 +16,9 @@ void register_scene_types() {
 	goost::register_class<GradientTexture2D>();
 	goost::register_class<LightTexture>();
 
-// #ifdef GOOST_GUI_ENABLED
+#ifdef GOOST_GUI_ENABLED
 	goost::register_class<GridRect>();
-// #endif
+#endif
 
 #if defined(TOOLS_ENABLED) && defined(GOOST_EDITOR_ENABLED)
 #if defined(GOOST_CORE_ENABLED) && defined(GOOST_PolyNode2D)
@@ -28,6 +28,7 @@ void register_scene_types() {
 	EditorPlugins::add_by_type<VisualShape2DEditorPlugin>();
 #endif
 #endif
+
 #ifdef GOOST_PHYSICS_ENABLED
 	register_physics_types();
 #endif

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -16,6 +16,10 @@ void register_scene_types() {
 	goost::register_class<GradientTexture2D>();
 	goost::register_class<LightTexture>();
 
+// #ifdef GOOST_GUI_ENABLED
+	goost::register_class<GridRect>();
+// #endif
+
 #if defined(TOOLS_ENABLED) && defined(GOOST_EDITOR_ENABLED)
 #if defined(GOOST_CORE_ENABLED) && defined(GOOST_PolyNode2D)
 	EditorPlugins::add_by_type<PolyNode2DEditorPlugin>();

--- a/tests/project/goost/scene/gui/grid_rect.gd
+++ b/tests/project/goost/scene/gui/grid_rect.gd
@@ -17,7 +17,7 @@ func _ready():
 	yield(test(data), "completed")
 
 	# Offset.
-	$grid.origin_offset = Vector2(-32, -32)
+	$grid.origin_offset = Vector2(32, 32)
 	data = {
 		Vector2(0, 0) : [ Vector2(-1, -1), Vector2(0, 0) ],
 		Vector2(32, 32) : [ Vector2(0, 0), Vector2(32, 32) ],
@@ -45,7 +45,7 @@ func _ready():
 	yield(test(data), "completed")
 
 	# Offset + Scale.
-	$grid.origin_offset = Vector2(-146, -246)
+	$grid.origin_offset = Vector2(146, 246)
 	$grid.origin_scale = Vector2(1.5, 0.5)
 	data = {
 		Vector2(106, 153) : [ Vector2(-1, -6), Vector2(98, 150) ],
@@ -65,7 +65,7 @@ func _ready():
 
 	# Centered origin + origin_offset + origin_scale.
 	$grid.origin_centered = true
-	$grid.origin_offset = Vector2(100, 200)
+	$grid.origin_offset = Vector2(-100, -200)
 	$grid.origin_scale = Vector2(0.74, 1.33)
 	data = {
 		Vector2(1048, 681) : [ Vector2(8, 8), Vector2(1049.439941, 680.47998) ],
@@ -77,7 +77,7 @@ func _ready():
 	# Centered origin + origin_offset + cell_origin
 	$grid.cell_origin = GridRect.CELL_ORIGIN_CENTER
 	$grid.origin_centered = true
-	$grid.origin_offset = Vector2(100, 200)
+	$grid.origin_offset = Vector2(-100, -200)
 	data = {
 		Vector2(985, 374) : [ Vector2(3, 1), Vector2(972, 388) ],
 		Vector2(669, 214) : [ Vector2(-6, -4), Vector2(684, 228) ],

--- a/tests/project/goost/scene/gui/grid_rect.gd
+++ b/tests/project/goost/scene/gui/grid_rect.gd
@@ -1,5 +1,7 @@
 extends Control
 
+signal finished
+
 
 func _ready():
 	$grid.show_behind_parent = true
@@ -91,6 +93,8 @@ func _ready():
 		Vector2(1051, 630) : [ Vector2(-3, -3), Vector2(1056, 636) ],
 	}
 	yield(test(data), "completed")
+
+	emit_signal("finished")
 
 
 func reset_to_default():

--- a/tests/project/goost/scene/gui/grid_rect.gd
+++ b/tests/project/goost/scene/gui/grid_rect.gd
@@ -1,0 +1,136 @@
+extends Control
+
+
+func _ready():
+	$grid.show_behind_parent = true
+
+	# Position : [ Point : Point-to-position ]
+	var data: Dictionary
+	# Default.
+	reset_to_default()
+	data = {
+		Vector2(0, 0) : [ Vector2(0, 0), Vector2(0, 0) ],
+		Vector2(128, 0) : [ Vector2(4, 0), Vector2(128, 0) ],
+		Vector2(32, 32) : [ Vector2(1, 1), Vector2(32, 32) ],
+		Vector2(47.9, 32) : [ Vector2(1, 1), Vector2(32, 32) ],
+	}
+	yield(test(data), "completed")
+
+	# Offset.
+	$grid.origin_offset = Vector2(-32, -32)
+	data = {
+		Vector2(0, 0) : [ Vector2(-1, -1), Vector2(0, 0) ],
+		Vector2(32, 32) : [ Vector2(0, 0), Vector2(32, 32) ],
+		Vector2(47.9, 32) : [ Vector2(0, 0), Vector2(32, 32) ],
+		Vector2(137, 83) : [ Vector2(3, 2), Vector2(128, 96) ],
+	}
+	yield(test(data), "completed")
+
+	# Custom cell size.
+	$grid.cell_size = Vector2(101.53, 56.86)
+	data = {
+		Vector2(776, 431) : [ Vector2(8, 8), Vector2(812.23999, 454.880005) ],
+		Vector2(110, 293) : [ Vector2(1, 5), Vector2(101.529999, 284.299988) ],
+	}
+	yield(test(data), "completed")
+
+	# Scale.
+	$grid.origin_scale = Vector2(0.5, 0.5)
+	data = {
+		Vector2(0, 0) : [ Vector2(0, 0), Vector2(0, 0) ],
+		Vector2(128, 0) : [ Vector2(8, 0), Vector2(128, 0) ],
+		Vector2(67, 58) : [ Vector2(4, 4), Vector2(64, 64) ],
+		Vector2(168, 58) : [ Vector2(11, 4), Vector2(176, 64) ],
+	}
+	yield(test(data), "completed")
+
+	# Offset + Scale.
+	$grid.origin_offset = Vector2(-146, -246)
+	$grid.origin_scale = Vector2(1.5, 0.5)
+	data = {
+		Vector2(106, 153) : [ Vector2(-1, -6), Vector2(98, 150) ],
+		Vector2(279, 184) : [ Vector2(3, -4), Vector2(290, 182) ],
+		Vector2(328, 495) : [ Vector2(4, 16), Vector2(338, 502) ],
+	}
+	yield(test(data), "completed")
+
+	# Centered origin.
+	$grid.origin_centered = true
+	data = {
+		Vector2(902, 426) : [ Vector2(-2, -4), Vector2(896, 412) ],
+		Vector2(1384, 177) : [ Vector2(13, -11), Vector2(1376, 188) ],
+		Vector2(704, 795) : [ Vector2(-8, 8), Vector2(704, 796) ],
+	}
+	yield(test(data), "completed")
+
+	# Centered origin + origin_offset + origin_scale.
+	$grid.origin_centered = true
+	$grid.origin_offset = Vector2(100, 200)
+	$grid.origin_scale = Vector2(0.74, 1.33)
+	data = {
+		Vector2(1048, 681) : [ Vector2(8, 8), Vector2(1049.439941, 680.47998) ],
+		Vector2(300, 221) : [ Vector2(-24, -3), Vector2(291.679993, 212.319992) ],
+		Vector2(671, 1019) : [ Vector2(-8, 16), Vector2(670.559998, 1020.960022) ],
+	}
+	yield(test(data), "completed")
+
+	# Centered origin + origin_offset + cell_origin
+	$grid.cell_origin = GridRect.CELL_ORIGIN_CENTER
+	$grid.origin_centered = true
+	$grid.origin_offset = Vector2(100, 200)
+	data = {
+		Vector2(985, 374) : [ Vector2(3, 1), Vector2(972, 388) ],
+		Vector2(669, 214) : [ Vector2(-6, -4), Vector2(684, 228) ],
+	}
+	yield(test(data), "completed")
+
+	# Flip origin.
+	$grid.origin_centered = true
+	$grid.origin_scale = Vector2(-1, -1)
+	data = {
+		Vector2(1051, 630) : [ Vector2(-3, -3), Vector2(1056, 636) ],
+	}
+	yield(test(data), "completed")
+
+
+func reset_to_default():
+	$grid.cell_size = Vector2(32, 32)
+	$grid.cell_origin = GridRect.CELL_ORIGIN_TOP_LEFT
+	$grid.origin_offset = Vector2()
+	$grid.origin_scale = Vector2.ONE
+	$grid.origin_centered = false
+
+
+func click(position):
+	var event = InputEventMouseButton.new()
+	event.position = position
+	event.pressed = true
+	event.button_index = BUTTON_LEFT
+	Input.call_deferred("parse_input_event", event)
+	var point = yield($grid, "point_clicked")
+	return point
+
+
+var _debug_pos = Vector2()
+
+func test(data):
+	for position in data:
+		var point = click(position)
+		if point is GDScriptFunctionState:
+			point = yield(point, "completed")
+		var snapped_point = point[1]
+		assert(snapped_point == data[position][0])
+		var pos = $grid.point_to_view(snapped_point)
+		_debug_pos = pos
+		assert(pos.is_equal_approx(data[position][1]))
+	reset_to_default()
+
+
+func _process(_delta):
+	$debug_position.text = str(get_global_mouse_position())
+#	$debug_position.text = str(_debug_pos)
+	update()
+
+
+func _draw():
+	draw_circle(_debug_pos, 2, Color.white)

--- a/tests/project/goost/scene/gui/grid_rect.tscn
+++ b/tests/project/goost/scene/gui/grid_rect.tscn
@@ -1,0 +1,25 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://goost/scene/gui/grid_rect.gd" type="Script" id=1]
+
+[node name="test_snap" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+rect_min_size = Vector2( 1920, 1080 )
+rect_clip_content = true
+script = ExtResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="grid" type="GridRect" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="debug_position" type="Label" parent="."]
+margin_right = 40.0
+margin_bottom = 14.0
+text = "(654.694092, 187.68396)"
+__meta__ = {
+"_edit_use_anchors_": false
+}

--- a/tests/project/goost/scene/gui/test_grid_rect.gd
+++ b/tests/project/goost/scene/gui/test_grid_rect.gd
@@ -1,0 +1,25 @@
+extends "res://addons/gut/test.gd"
+
+
+func test_snap():
+	var grid = preload("grid_rect.tscn").instance()
+	add_child(grid)
+	watch_signals(grid)
+	yield(grid, "finished")
+	assert_signal_emitted(grid, "finished")
+	grid.queue_free()
+	grid = null
+
+
+func test_metadata():
+	var grid = GridRect.new()
+	add_child(grid)
+
+	grid.set_cell_metadata(Vector2(-1, 1), Color.blue)
+	assert_eq(grid.get_cell_metadata(Vector2(-1, 1)), Color.blue)
+
+	grid.clear_cell_metadata()
+	assert_eq(grid.get_cell_metadata(Vector2(-1, 1)), null)
+
+	grid.queue_free()
+	grid = null


### PR DESCRIPTION
Resolves godotengine/godot-proposals#2662.

![image](https://user-images.githubusercontent.com/17108460/118662149-73f2da80-b7f8-11eb-9278-740e0e88991c.png)

## Features:

- Infinite grid;
- Offset and scale the grid's origin (can be centered, and main axes can be optionally displayed);
- Flip X/Y axes by using negative origin scale.
- Customize individual lines by overriding `_draw_line()` virtual method (skipping every n-th line, different colors) (thanks to @LikeLakers2 for the idea presented in https://github.com/godotengine/godot-proposals/issues/2662#issuecomment-829522685);
- Convert between grid and view coordinates (with or without snapping);
- Configurable cell's origin, so snapping can work either in top-left or center of the cell (useful for aiding the debugging process of other classes such as `TileMap`).
- Customize colors, including background (can be transparent, which allows to layer many `GridRect` nodes on top of each other).
- Shows grid's coordinates and metadata via tooltip by default.

![image](https://user-images.githubusercontent.com/17108460/118662406-a43a7900-b7f8-11eb-8d1e-7e89fd9302db.png)

Note that this only provides essential features needed to draw grids. Things like scroll, drag, zoom are possible to implement via script as of now. Depending on whether I'll need those features myself, it may be reasonable to add `GridEdit` node which can inherit this class.

### Example project

[grid.zip](https://github.com/goostengine/goost/files/6502039/grid.zip)

Editor builds of this PR (have to be logged in GitHub):

- Windows: https://github.com/goostengine/goost/suites/2769990838/artifacts/61363211
- Linux: https://github.com/goostengine/goost/suites/2769990831/artifacts/61365144
- macOS: https://github.com/goostengine/goost/suites/2769990827/artifacts/61364201

