### PR TITLE
Refactor the process of configuring components and classes

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -215,4 +215,7 @@ if not skip_build:
     print("Building Godot with %s ..." % module_name.capitalize())
 
 # Run SCons to build Godot with the module, check the build configuration etc.
-run(env.build_args, godot_dir.abspath)
+try:
+    run(env.build_args, godot_dir.abspath)
+except:
+    Exit(255)

--- a/SConstruct
+++ b/SConstruct
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 # Upstream: https://github.com/goostengine/goost
-# Version: 2.1 (Godot Engine 3.3+)
+# Version: 2.1.1 (Godot Engine 3.3+)
 # License: MIT
 #
 # `SConstruct` which allows to build any C++ module just like Godot Engine.

--- a/SCsub
+++ b/SCsub
@@ -1,19 +1,16 @@
 #!/usr/bin/env python
-
 import re
 import glob
 
-import goost
 import builders
 
 Import("env")
 env_goost = env.Clone()
 
 # Define components to build.
-for name in goost.get_components():
+for name in env["goost_components_enabled"]:
     opt = "goost_%s_enabled" % (name)
-    if env_goost[opt]:
-        env_goost.Prepend(CPPDEFINES=[opt.upper()])
+    env_goost.Prepend(CPPDEFINES=[opt.upper()])
 
 # Generate sources with a list of enabled and disabled classes.
 env.CommandNoCache(
@@ -85,7 +82,7 @@ def goost_add_source_files(self, sources, files, warn_duplicates=True):
     for path in files:
         # Skip compiling sources of disabled Goost classes.
         skip = False
-        for c in goost.classes_disabled:
+        for c in self["goost_classes_disabled"]:
             n = "%s.*\.cpp" % to_snake_case(c)
             if re.search(n, path):
                 skip = True

--- a/SCsub
+++ b/SCsub
@@ -13,8 +13,13 @@ for name in env["goost_components_enabled"]:
     env_goost.Prepend(CPPDEFINES=[opt.upper()])
 
 # Generate sources with a list of enabled and disabled classes.
+classgen_sources = ["goost.py"]
+if File("custom.py").exists():
+    # Can be configured via `custom.py`, track changes there as well.
+    classgen_sources.append("custom.py")
+
 env.CommandNoCache(
-    ["classes_enabled.gen.h", "classes_enabled.gen.cpp"], "goost.py",
+    ["classes_enabled.gen.h", "classes_enabled.gen.cpp"], classgen_sources,
     builders.make_classes_enabled,
 )
 # Generate version header.
@@ -34,15 +39,6 @@ env.CommandNoCache(
 )
 
 env_goost.Prepend(CPPDEFINES={"SCALE_FACTOR" : env["goost_scale_factor"]})
-
-# Build subdirs, the build order is dependent on the link order.
-subdirs = [
-    "core",
-    "scene",
-    "editor",
-    "thirdparty",
-    # "modules", # Built automatically if `custom_modules_recursive=yes` (default).
-]
 
 # Inject our own version of `add_source_files` (found in methods.py in Godot).
 # This is needed to filter out the sources of disabled classes without
@@ -101,7 +97,19 @@ def goost_add_source_files(self, sources, files, warn_duplicates=True):
 env_goost.__class__.add_source_files = goost_add_source_files
 
 # Add sources.
-SConscript(dirs=subdirs, name="SCsub", exports="env_goost")
+Export("env_goost")
+
+if env["goost_core_enabled"]:
+    SConscript("core/SCsub")
+
+if env["goost_scene_enabled"]:
+    SConscript("scene/SCsub")
+
+if env["goost_editor_enabled"]:
+    SConscript("editor/SCsub")
+
+SConscript("thirdparty/SCsub")
+
 env_goost.add_source_files(env.modules_sources, "*.cpp")
 
 # Restore the method back (not sure if needed, but good for consistency).

--- a/builders.py
+++ b/builders.py
@@ -9,11 +9,11 @@ def make_classes_enabled(target, source, env):
 
     h.write("// THIS FILE IS GENERATED, DO NOT EDIT!\n\n")
     h.write("#pragma once\n\n")
-    for c in goost.classes_enabled:
+    for c in env["goost_classes_enabled"]:
         h.write("#define GOOST_%s\n" % c)
     h.write("\n")
     h.write("namespace goost {\n")
-    for c in goost.classes_disabled:
+    for c in env["goost_classes_disabled"]:
         h.write("template <> void register_class<%s>();\n" % c)
     h.write("}\n")
     h.close()
@@ -27,7 +27,7 @@ def make_classes_enabled(target, source, env):
     cpp.write("#include \"classes_enabled.gen.h\"\n")
     cpp.write("\n")
     cpp.write("namespace goost {\n")
-    for c in goost.classes_disabled:
+    for c in env["goost_classes_disabled"]:
         cpp.write("template <> void register_class<%s>() {}\n" % c)
     cpp.write("}\n")
     cpp.close()

--- a/config.py
+++ b/config.py
@@ -98,6 +98,8 @@ def configure_components(env, config, enabled_by_default):
 
     def disable_child_components(name):
         for child_name in goost.get_child_components(name):
+            if child_name in to_disable:
+                continue
             print("Goost: Disabling `%s` component (part of `%s`)." % (child_name, name))
             env["goost_%s_enabled" % child_name] = False
             to_disable.append(child_name)
@@ -105,6 +107,8 @@ def configure_components(env, config, enabled_by_default):
  
     def enable_parent_components(name):
         for parent_name in goost.get_parent_components(name):
+            if parent_name in to_enable:
+                continue
             print("Goost: Enabling `%s` component (parent of `%s`)." % (parent_name, name))
             env["goost_%s_enabled" % parent_name] = True
             to_enable.append(parent_name)
@@ -118,6 +122,7 @@ def configure_components(env, config, enabled_by_default):
         components["disabled"] = to_disable
     else:
         # Enable parent components, if any.
+        # This is needed because otherwise child components won't build at all.
         to_enable = components["enabled"]
         for name in components["enabled"]:
             enable_parent_components(name)

--- a/config.py
+++ b/config.py
@@ -32,7 +32,7 @@ def configure(env):
 
     # From command-line (CLI arguments override arguments specified via file).
 
-    opts.Add(BoolVariable("goost_components_enabled_by_default",
+    opts.Add(BoolVariable("goost_components_enabled",
             "Set to `no` to disable all components by default, and enable each component of interest manually", True))
 
     # Get a list of all components and add them, regardless of configuration.
@@ -73,9 +73,9 @@ def configure(env):
 def configure_components(env, config, enabled_by_default):
     from SCons.Script import ARGUMENTS
 
-    if "goost_components_enabled_by_default" in ARGUMENTS:
+    if "goost_components_enabled" in ARGUMENTS:
         # Override from command-line.
-        enabled_by_default = env["goost_components_enabled_by_default"]
+        enabled_by_default = env["goost_components_enabled"]
 
     for name in goost.get_components()["enabled"]: # All enabled by default.
         c = "goost_%s_enabled" % name

--- a/config.py
+++ b/config.py
@@ -8,18 +8,6 @@ def can_build(env, platform):
 def configure(env):
     from SCons.Script import Variables, BoolVariable, Help, Exit
 
-    # Check dependencies.
-    dependencies_satisfied = True
-    for c in goost.classes_enabled:
-        resolved = goost.resolve_dependency(goost.classes[c])
-        for cr in resolved:
-            if cr not in goost.classes_enabled:
-                dependencies_satisfied = False
-                print("Goost: Cannot disable `%s` class, because `%s` class depends on it." % (cr, c))
-
-    if not dependencies_satisfied:
-        Exit(255)
-
     opts = Variables()
     for name in goost.get_components():
         opts.Add(BoolVariable("goost_%s_enabled" % (name), "Build %s component." % (name), True))
@@ -29,13 +17,13 @@ def configure(env):
     opts.Update(env)
 
     # Get a list of components which got disabled.
-    disabled = []
+    components_disabled = []
     for name in goost.get_components():
         if not env["goost_%s_enabled" % (name)]:
-            disabled.append(name)
+            components_disabled.append(name)
 
     # Implicitly disable child components.
-    for name in disabled:
+    for name in components_disabled:
         children = goost.get_child_components(name)
         for child_name in children:
             print("Goost: Disabling `%s` component (part of `%s`)." % (child_name, name))

--- a/config.py
+++ b/config.py
@@ -6,7 +6,7 @@ def can_build(env, platform):
 
 
 def configure(env):
-    from SCons.Script import Variables, BoolVariable, Help, Exit
+    from SCons.Script import Variables, BoolVariable, Help
 
     opts = Variables()
 
@@ -59,12 +59,13 @@ def configure(env):
 
     components = configure_components(env, components_config, components_enabled_by_default)
     classes = configure_classes(env, classes_config, classes_enabled_by_default)
-    
-    for class_name in classes["enabled"]:
-        for component_name in goost.get_class_components(class_name):
-            if component_name in components["disabled"]:
-                print("Goost: Cannot enable class `%s`, because component `%s` is disabled, skipping."
-                        % (class_name, component_name))
+
+    if env["verbose"]:
+        for class_name in classes["enabled"]:
+            for component_name in goost.get_class_components(class_name):
+                if component_name in components["disabled"]:
+                    print("Goost: Skipping class `%s`, because component `%s` is disabled."
+                            % (class_name, component_name))
 
     # Generate help text.
     Help(opts.GenerateHelpText(env))

--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -1,8 +1,6 @@
 #include "editor_about.h"
 #include "editor/editor_node.h"
 
-#include "goost/core/goost_engine.h"
-
 #include "goost/core/authors.gen.h"
 #include "goost/core/license.gen.h"
 #include "goost/core/version.gen.h"
@@ -103,12 +101,15 @@ GoostEditorAbout::GoostEditorAbout() {
 	version_info_vbc->add_child(v_spacer);
 
 	version_btn = memnew(LinkButton);
+	String strver = itos(GOOST_VERSION_MAJOR) + "." + itos(GOOST_VERSION_MINOR);
+	if (GOOST_VERSION_PATCH != 0) {
+		strver += "." + itos(GOOST_VERSION_PATCH);
+	}
+	strver += "-" + String(GOOST_VERSION_STATUS);
 	String hash = String(GOOST_VERSION_HASH);
 	if (hash.length() != 0) {
 		hash = " " + vformat("[%s]", hash.left(9));
 	}
-	Dictionary version_info = GoostEngine::get_singleton()->get_version_info();
-	String strver = version_info["string"];
 	String version = vformat("Goost v%s", strver + hash);
 	String year = itos(GOOST_VERSION_YEAR);
 

--- a/goost.py
+++ b/goost.py
@@ -27,30 +27,23 @@ components = [
 def get_components(config={}, enabled_by_default=True):
     import sys
 
-    components_set = set()
-
-    for name in components:
-        parts = name.split("/")
-        components_set.update(parts)
-
-    components_list = list(components_set)
-    components_list.sort()
+    component_list = get_component_list()
 
     if not config:
-        for name in components_list:
+        for name in component_list:
             config[name] = enabled_by_default
 
     components_enabled = []
+    components_enabled = component_list.copy()
     components_disabled = []
-    components_enabled = components_list.copy()
-    components_disabled = components_list.copy()
+    components_disabled = component_list.copy()
 
     try:
         if enabled_by_default:
             components_disabled.clear()
             for name, enabled in config.items():
                 if not enabled:
-                    if not name in components_set:
+                    if not name in component_list:
                         raise NameError("Goost: Requested to disable non-existing component `%s`" % name)
                     components_enabled.remove(name)
                     components_disabled.append(name)
@@ -58,7 +51,7 @@ def get_components(config={}, enabled_by_default=True):
             components_enabled.clear()
             for name, enabled in config.items():
                 if enabled:
-                    if not name in components_set:
+                    if not name in component_list:
                         raise NameError("Goost: Requested to enable non-existing component `%s`" % name)
                     components_enabled.append(name)
                     components_disabled.remove(name)
@@ -71,6 +64,19 @@ def get_components(config={}, enabled_by_default=True):
         "disabled": components_disabled,
     }
     return ret
+
+
+def get_component_list():
+    component_set = set()
+
+    for name in components:
+        parts = name.split("/")
+        component_set.update(parts)
+
+    component_list = list(component_set)
+    component_list.sort()
+
+    return component_list
 
 
 def get_child_components(parent):
@@ -105,59 +111,65 @@ def get_parent_components(child):
 
 
 class GoostClass:
-   def __init__(self, name, deps=[]):
-      self.name = name
-      self.deps = []
+    def __init__(self, name):
+        self.name = name
+        self.deps = []
+        self.component = ""
 
-   def add_depencency(self, goost_class):
-      self.deps.append(goost_class)
+    def add_depencency(self, goost_class):
+        self.deps.append(goost_class)
 
-# A list of classes currently implemented in the extension, excluding any
+# A dictionary of classes currently implemented in the extension, excluding any
 # classes provided from within `modules/` directory.
 # 
 # This is used by `config.py::get_doc_classes()` and to disable each of the
 # class via user-defined `custom.py::goost_classes_disabled` array of classes.
 #
-classes = [
-    "GoostEngine",
-    "GoostGeometry2D",
-    "GoostImage",
-    "GradientTexture2D",
-    "GridRect",
-    "ImageBlender",
-    "ImageIndexed",
-    "InvokeState",
-    "LightTexture",
-    "LinkedList",
-    "ListNode",
-    "PolyBoolean2D",
-    "PolyBooleanParameters2D",
-    "PolyDecomp2D",
-    "PolyDecompParameters2D",
-    "PolyOffset2D",
-    "PolyOffsetParameters2D",
-    "PolyNode2D",
-    "PolyCircle2D",
-    "PolyRectangle2D",
-    "PolyShape2D",
-    "PolyCollisionShape2D",
-    "Random",
-    "Random2D",
-    "ShapeCast2D",
-    "VariantMap",
-    "VariantResource",
-    "VisualShape2D",
-]
+# The key is the class name, and value is component that this class is part of.
+# If applicable, only rightmost components are specified here.
+classes = {
+    "GoostEngine": "core",
+    "GoostGeometry2D": "math",
+    "GoostImage": "image",
+    "GradientTexture2D": "scene",
+    "GridRect": "gui",
+    "ImageBlender": "image",
+    "ImageIndexed": "image",
+    "InvokeState": "core",
+    "LightTexture": "scene",
+    "LinkedList": "core",
+    "ListNode": "core",
+    "PolyBoolean2D": "math",
+    "PolyBooleanParameters2D": "math",
+    "PolyDecomp2D": "math",
+    "PolyDecompParameters2D": "math",
+    "PolyOffset2D": "math",
+    "PolyOffsetParameters2D": "math",
+    "PolyNode2D": "core",
+    "PolyCircle2D": "scene",
+    "PolyRectangle2D": "scene",
+    "PolyShape2D": "scene",
+    "PolyCollisionShape2D": "scene",
+    "Random": "math",
+    "Random2D": "math",
+    "ShapeCast2D": "physics",
+    "VariantMap": "core",
+    "VariantResource": "core",
+    "VisualShape2D": "scene",
+}
 
-# Convert to dictionary, because we need to instantiate `GoostClass` nodes.
+# Instantiate `GoostClass` nodes.
 _classes = {}
-for c in classes:
-    _classes[c] = GoostClass(c)
+for name in classes:
+    _classes[name] = GoostClass(name)
+    if not classes[name] in get_component_list():
+        raise NameError("Component `%s` is not defined" % classes[name])
+    _classes[name].component = classes[name]
 classes = _classes
 
 # Class dependencies. If disabling classes above cause build errors,
 # it's likely a dependency issue. If so, define them here explicitly.
-#
+
 classes["GoostEngine"].add_depencency(classes["InvokeState"])
 
 classes["GoostGeometry2D"].add_depencency(classes["PolyBoolean2D"])
@@ -238,3 +250,9 @@ def get_classes(config={}, enabled_by_default=True):
         "disabled": classes_disabled,
     }
     return ret
+
+
+def get_class_components(name):
+    components = get_parent_components(classes[name].component)
+    components.append(classes[name].component)
+    return components

--- a/goost.py
+++ b/goost.py
@@ -256,3 +256,42 @@ def get_class_components(name):
     components = get_parent_components(classes[name].component)
     components.append(classes[name].component)
     return components
+
+
+config_template = """# custom.py
+
+components_enabled_by_default = True
+components = {
+    # "editor": False,
+}
+
+classes_enabled_by_default = True
+classes = {
+    # "LinkedList": False,
+}
+"""
+
+if __name__ == "__main__":
+    import os
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--generate-config", action="store_true", required=True,
+            help="Generates `custom.py` file to configure Goost components and classes.")
+    args = parser.parse_args()
+
+    def write_config():
+        with open("custom.py", "w") as f:
+            f.write(config_template)
+
+    if args.generate_config:
+        if os.path.exists("custom.py"):
+            print("Goost: The `custom.py` file already exists!")
+            try:
+                overwrite = input("Overwrite anyway? (y/N): ")
+                if overwrite.lower() == "y":
+                    write_config()
+            except KeyboardInterrupt:
+                print("n")
+        else:
+            write_config()

--- a/goost.py
+++ b/goost.py
@@ -29,12 +29,16 @@ def get_components(config={}, enabled_by_default=True):
 
     components_set = set()
 
-    for n in components:
-        parts = n.split("/")
+    for name in components:
+        parts = name.split("/")
         components_set.update(parts)
 
     components_list = list(components_set)
     components_list.sort()
+
+    if not config:
+        for name in components_list:
+            config[name] = enabled_by_default
 
     components_enabled = []
     components_disabled = []
@@ -42,30 +46,25 @@ def get_components(config={}, enabled_by_default=True):
     components_disabled = components_list.copy()
 
     try:
-        if config:
-            if enabled_by_default:
-                components_disabled.clear()
-                for name, enabled in config.items():
-                    if not enabled:
-                        if not name in components_set:
-                            raise NameError("Goost: Requested to disable non-existing component `%s`" % name)
-                        components_enabled.remove(name)
-                        components_disabled.append(name)
-            else:
-                components_enabled.clear()
-                for name, enabled in config.items():
-                    if enabled:
-                        if not name in components_set:
-                            raise NameError("Goost: Requested to enable non-existing component `%s`" % name)
-                        components_enabled.append(name)
-                        components_disabled.remove(name)
+        if enabled_by_default:
+            components_disabled.clear()
+            for name, enabled in config.items():
+                if not enabled:
+                    if not name in components_set:
+                        raise NameError("Goost: Requested to disable non-existing component `%s`" % name)
+                    components_enabled.remove(name)
+                    components_disabled.append(name)
+        else:
+            components_enabled.clear()
+            for name, enabled in config.items():
+                if enabled:
+                    if not name in components_set:
+                        raise NameError("Goost: Requested to enable non-existing component `%s`" % name)
+                    components_enabled.append(name)
+                    components_disabled.remove(name)
     except NameError as e:
         print(e)
         sys.exit(255)
-
-    if not config:
-        # All components are enabled by default.
-        components_disabled.clear()
 
     ret = {
         "enabled": components_enabled,
@@ -196,36 +195,35 @@ def resolve_dependency(goost_class):
 def get_classes(config={}, enabled_by_default=True):
     import sys
 
+    if not config:
+        for c in classes:
+            config[c] = enabled_by_default
+
     classes_enabled = []
     classes_disabled = []
     for c in classes:
         classes_enabled.append(c)
         classes_disabled.append(c)
     try:
-        if config:
-            if enabled_by_default:
-                classes_disabled.clear()
-                for name, enabled in config.items():
-                    if not enabled:
-                        if not name in classes:
-                            raise NameError("Goost: Requested to disable non-existing class `%s`" % name)
-                        classes_enabled.remove(name)
-                        classes_disabled.append(name)
-            else:
-                classes_enabled.clear()
-                for name, enabled in config.items():
-                    if enabled:
-                        if not name in classes:
-                            raise NameError("Goost: Requested to enable non-existing class `%s`" % name)
-                        classes_enabled.append(name)
-                        classes_disabled.remove(name)
+        if enabled_by_default:
+            classes_disabled.clear()
+            for name, enabled in config.items():
+                if not enabled:
+                    if not name in classes:
+                        raise NameError("Goost: Requested to disable non-existing class `%s`" % name)
+                    classes_enabled.remove(name)
+                    classes_disabled.append(name)
+        else:
+            classes_enabled.clear()
+            for name, enabled in config.items():
+                if enabled:
+                    if not name in classes:
+                        raise NameError("Goost: Requested to enable non-existing class `%s`" % name)
+                    classes_enabled.append(name)
+                    classes_disabled.remove(name)
     except NameError as e:
         print(e)
         sys.exit(255)
-
-    if not config:
-        # All classes are enabled by default.
-        classes_disabled.clear()
 
     # Check dependencies.
     for c in classes_enabled:


### PR DESCRIPTION
The changes are mostly mandated by a new feature of enabling or disabling all components/classes *by default*, so that you can do things like:

```
scons goost_components_enabled=no goost_image_enabled=yes
```

Instead of:

```
scons goost_math_enabled=no goost_scene_enabled=no goost_editor_enabled=no goost_physics_enabled=no ...
```

Even then, it's not really practical to specify all those options via command-line interface, so now you can also create `custom.py` at the root of Goost repository to configure both enabled components and even individual classes:

```python
# custom.py

components_enabled_by_default = False
components = {
    "math": True,
    "gui": False,
}

classes_enabled_by_default = True
classes = {
    "GoostEngine": True,
    "LinkedList": False,
    "VariantMap": False,
    "VariantResource": False,
}
```

This is part of #49.

Also, if some classes depend on others, you don't have to worry about enabling them manually, dependencies are going to be satisfied automatically.

Of course, there will be some limitations (disabling something may cause build/link error). If so, please feel free to report them to see how those can be resolved.

Note that you cannot enable or disable individual classes via command-line interface, only via `custom.py` (in most cases, you don't have to configure classes).

This slightly breaks compatibility (previously you could use `custom.py` to disable a *list* classes), but since I haven't documented this feature so far, it should be fine.
