### PR TITLE
Use `config.py` to enable or disable GIF module

### DIFF
--- a/modules/SCSub
+++ b/modules/SCSub
@@ -59,9 +59,6 @@ if not env["godot_modules_enabled"]:
     for name, enabled in godot_modules.items():
         f.write("module_%s_enabled = \"%s\"\n" % (name, "yes" if enabled else "no"))
 
-if ARGUMENTS.get("goost_image_enabled", "yes") == "no":
-    f.write("module_gif_enabled = \"no\"\n")
-
 f.close()
 
 if "profile" in ARGUMENTS:

--- a/modules/gif/config.py
+++ b/modules/gif/config.py
@@ -1,4 +1,8 @@
 def can_build(env, platform):
+    # This module is part of the Goost project, but can be built independently.
+    # Refer to https://github.com/goostengine/goost for more information.
+    if "goost_image_enabled" in env:
+        return env["goost_image_enabled"]
     return True
 
 


### PR DESCRIPTION
The previous way of disabling the module was a bit hacky. Since GIF module could be compiled independently of Goost, we still need a way to automatically disable the module if it's built as part of Goost where `goost_image_enabled=no` might be specified.

We rely on implicit module detection order. Since Goost is detected first, it's configuration is copied to base env in Godot, so other nested modules can refer to those options. If an option is not present, it means that the module is built independently of Goost.