### PR TITLE
CI: Refactor build options, disable debug symbols

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   GOOST_BASE_BRANCH: gd3
-  SCONSFLAGS: godot_modules_enabled=no platform=android verbose=yes warnings=all werror=yes --jobs=4
+  SCONSFLAGS: godot_modules_enabled=no platform=android verbose=yes warnings=all werror=yes debug_symbols=no --jobs=4
   SCONS_CACHE_LIMIT: 4096
 
 jobs:

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   GOOST_BASE_BRANCH: gd3
-  SCONSFLAGS: godot_modules_enabled=no --jobs=4
+  SCONSFLAGS: godot_modules_enabled=no verbose=yes warnings=all werror=yes debug_symbols=no --jobs=4
   SCONS_CACHE_LIMIT: 4096
 
 jobs:
@@ -48,4 +48,4 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons verbose=yes warnings=all werror=no platform=iphone target=release tools=no
+          scons platform=iphone target=release tools=no

--- a/.github/workflows/javascript_builds.yml
+++ b/.github/workflows/javascript_builds.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   GOOST_BASE_BRANCH: gd3
-  SCONSFLAGS: godot_modules_enabled=no platform=javascript verbose=yes warnings=all werror=yes --jobs=4
+  SCONSFLAGS: godot_modules_enabled=no platform=javascript verbose=yes warnings=all werror=yes debug_symbols=no --jobs=4
   SCONS_CACHE_LIMIT: 4096
   EM_VERSION: 2.0.15
   EM_CACHE_FOLDER: 'emsdk-cache'

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   GOOST_BASE_BRANCH: gd3
-  SCONSFLAGS: godot_modules_enabled=no --jobs=4
+  SCONSFLAGS: godot_modules_enabled=no verbose=yes warnings=all werror=yes debug_symbols=no --jobs=4
   SCONS_CACHE_LIMIT: 4096
 
 jobs:
@@ -61,7 +61,7 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons verbose=yes warnings=all werror=yes platform=linuxbsd tools=yes target=release_debug module_mono_enabled=yes mono_glue=no
+          scons platform=linuxbsd tools=yes target=release_debug module_mono_enabled=yes mono_glue=no
 
       - uses: actions/upload-artifact@v2
         with:
@@ -116,7 +116,7 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons verbose=yes warnings=all werror=yes platform=server tools=yes target=debug
+          scons platform=server tools=yes target=debug debug_symbols=yes
 
       - name: Run unit tests
         run: |
@@ -170,7 +170,7 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons verbose=yes warnings=all werror=yes platform=linuxbsd target=release tools=no module_mono_enabled=yes mono_glue=no
+          scons platform=linuxbsd target=release tools=no module_mono_enabled=yes mono_glue=no
 
   # Goost-specific
 
@@ -222,7 +222,7 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons verbose=yes warnings=all werror=yes platform=linuxbsd tools=yes target=release_debug goost_core_enabled=no
+          scons platform=linuxbsd tools=yes target=release_debug goost_core_enabled=no
 
   linux-goost-server:
     runs-on: "ubuntu-20.04"
@@ -272,7 +272,7 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons verbose=yes warnings=all werror=yes platform=server tools=yes target=debug goost_editor_enabled=no
+          scons platform=server tools=yes target=debug goost_editor_enabled=no
 
   linux-goost-template:
     runs-on: "ubuntu-20.04"
@@ -322,4 +322,4 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons verbose=yes warnings=all werror=yes platform=linuxbsd target=release tools=no goost_scene_enabled=no
+          scons platform=linuxbsd target=release tools=no goost_scene_enabled=no

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   GOOST_BASE_BRANCH: gd3
-  SCONSFLAGS: godot_modules_enabled=no --jobs=4
+  SCONSFLAGS: godot_modules_enabled=no verbose=yes warnings=all werror=yes debug_symbols=no --jobs=4
   SCONS_CACHE_LIMIT: 4096
 
 jobs:
@@ -49,7 +49,7 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons verbose=yes warnings=all werror=yes platform=osx tools=yes target=release_debug
+          scons platform=osx tools=yes target=release_debug
 
       - uses: actions/upload-artifact@v2
         with:
@@ -91,4 +91,4 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons verbose=yes warnings=all werror=yes platform=osx target=release tools=no
+          scons platform=osx target=release tools=no

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   GOOST_BASE_BRANCH: gd3
-  SCONSFLAGS: godot_modules_enabled=no --jobs=4
+  SCONSFLAGS: godot_modules_enabled=no verbose=yes warnings=all werror=yes debug_symbols=no --jobs=4
   SCONS_CACHE_MSVC_CONFIG: true
   SCONS_CACHE_LIMIT: 4096
 
@@ -50,7 +50,7 @@ jobs:
       env:
         SCONS_CACHE: /.scons_cache/
       run: |
-        scons verbose=yes warnings=all werror=yes platform=windows tools=yes target=release_debug
+        scons platform=windows tools=yes target=release_debug
 
     - uses: actions/upload-artifact@v2
       with:
@@ -94,4 +94,4 @@ jobs:
       env:
         SCONS_CACHE: /.scons_cache/
       run: |
-        scons verbose=yes warnings=all werror=yes platform=windows target=release tools=no
+        scons platform=windows target=release tools=no


### PR DESCRIPTION
Linux builds have huge sizes on GitHub. Downloading huge build artifacts ain't no fun.

Debug symbols are only enabled for unit tests, so that crash dump is available to see directly via GitHub.