### PR TITLE
Refactor includes of Goost types and classes

### DIFF
--- a/core/image/register_image_types.cpp
+++ b/core/image/register_image_types.cpp
@@ -1,6 +1,7 @@
 #include "register_image_types.h"
-#include "goost/register_types.h"
+
 #include "goost/classes_enabled.gen.h"
+#include "goost/goost.h"
 
 #include "core/engine.h"
 

--- a/core/math/geometry/register_geometry_types.cpp
+++ b/core/math/geometry/register_geometry_types.cpp
@@ -1,7 +1,7 @@
 #include "register_geometry_types.h"
 
-#include "goost/register_types.h"
 #include "goost/classes_enabled.gen.h"
+#include "goost/goost.h"
 
 static _GoostGeometry2D *_goost_geometry_2d = nullptr;
 static Ref<_PolyBoolean2D> _poly_boolean_2d;

--- a/core/math/register_math_types.cpp
+++ b/core/math/register_math_types.cpp
@@ -1,8 +1,8 @@
 #include "register_math_types.h"
 #include "geometry/register_geometry_types.h"
 
-#include "goost/register_types.h"
 #include "goost/classes_enabled.gen.h"
+#include "goost/goost.h"
 
 static Ref<Random> _random;
 

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -1,7 +1,7 @@
 #include "register_core_types.h"
 
 #include "goost/classes_enabled.gen.h"
-#include "goost/register_types.h"
+#include "goost/goost.h"
 
 #include "core/engine.h"
 #include "scene/main/scene_tree.h"

--- a/core/script/register_script_types.cpp
+++ b/core/script/register_script_types.cpp
@@ -1,11 +1,11 @@
 #include "register_script_types.h"
 
-#include "goost/register_types.h"
 #include "goost/classes_enabled.gen.h"
+#include "goost/goost.h"
 
-#include "mixin_script/mixin_script.h"
 #include "mixin_script/editor/mixin_script_editor.h"
 #include "mixin_script/editor/mixin_script_editor_plugin.h"
+#include "mixin_script/mixin_script.h"
 
 #include "core/script_language.h"
 #include "editor/editor_node.h"

--- a/goost.h
+++ b/goost.h
@@ -1,0 +1,42 @@
+#ifndef GOOST_H
+#define GOOST_H
+
+#include "core/goost_engine.h"
+#include "core/image/goost_image.h"
+#include "core/image/goost_image_bind.h"
+#include "core/image/image_blender.h"
+#include "core/image/image_indexed.h"
+#include "core/invoke_state.h"
+#include "core/math/geometry/2d/goost_geometry_2d.h"
+#include "core/math/geometry/2d/goost_geometry_2d_bind.h"
+#include "core/math/geometry/2d/poly/boolean/poly_boolean.h"
+#include "core/math/geometry/2d/poly/decomp/poly_decomp.h"
+#include "core/math/geometry/2d/poly/offset/poly_offset.h"
+#include "core/math/geometry/2d/poly/poly_backends.h"
+#include "core/math/geometry/2d/random_2d.h"
+#include "core/math/random.h"
+#include "core/script/mixin_script/mixin_script.h"
+#include "core/types/linked_list.h"
+#include "core/types/variant_map.h"
+#include "core/types/variant_resource.h"
+
+#include "scene/2d/editor/poly_node_2d_editor_plugin.h"
+#include "scene/2d/editor/visual_shape_2d_editor_plugin.h"
+#include "scene/2d/poly_generators_2d.h"
+#include "scene/2d/poly_shape_2d.h"
+#include "scene/2d/visual_shape_2d.h"
+#include "scene/gui/grid_rect.h"
+#include "scene/main/stopwatch.h"
+#include "scene/physics/2d/poly_collision_shape_2d.h"
+#include "scene/physics/2d/shape_cast_2d.h"
+#include "scene/resources/gradient_texture_2d.h"
+#include "scene/resources/light_texture.h"
+
+namespace goost {
+template <typename T>
+void register_class() {
+	ClassDB::register_class<T>();
+}
+} // namespace goost
+
+#endif // GOOST_H

--- a/register_types.h
+++ b/register_types.h
@@ -3,45 +3,12 @@
 
 #include "core/engine.h"
 
-#include "scene/2d/editor/poly_node_2d_editor_plugin.h"
-#include "scene/2d/editor/visual_shape_2d_editor_plugin.h"
-#include "scene/2d/poly_generators_2d.h"
-#include "scene/2d/poly_shape_2d.h"
-#include "scene/2d/visual_shape_2d.h"
-#include "scene/gui/grid_rect.h"
-#include "scene/main/stopwatch.h"
-#include "scene/physics/2d/poly_collision_shape_2d.h"
-#include "scene/physics/2d/shape_cast_2d.h"
-#include "scene/resources/gradient_texture_2d.h"
-#include "scene/resources/light_texture.h"
-
-#include "core/script/mixin_script/mixin_script.h"
-#include "core/goost_engine.h"
-#include "core/image/goost_image.h"
-#include "core/image/goost_image_bind.h"
-#include "core/image/image_blender.h"
-#include "core/image/image_indexed.h"
-#include "core/invoke_state.h"
-#include "core/math/geometry/2d/goost_geometry_2d.h"
-#include "core/math/geometry/2d/goost_geometry_2d_bind.h"
-#include "core/math/geometry/2d/poly/boolean/poly_boolean.h"
-#include "core/math/geometry/2d/poly/decomp/poly_decomp.h"
-#include "core/math/geometry/2d/poly/offset/poly_offset.h"
-#include "core/math/geometry/2d/poly/poly_backends.h"
-#include "core/math/geometry/2d/random_2d.h"
-#include "core/math/random.h"
-#include "core/types/linked_list.h"
-#include "core/types/variant_map.h"
-#include "core/types/variant_resource.h"
+// Do not include `goost.h` here.
+//
+// This may lead to clashes with Godot's namespace, or produce include errors
+// when `module_goost_enabled=no` is specified via command-line.
 
 void register_goost_types();
 void unregister_goost_types();
-
-namespace goost {
-template <typename T>
-void register_class() {
-	ClassDB::register_class<T>();
-}
-} // namespace goost
 
 #endif // GOOST_REGISTER_TYPES

--- a/scene/physics/register_physics_types.cpp
+++ b/scene/physics/register_physics_types.cpp
@@ -1,7 +1,7 @@
 #include "register_physics_types.h"
 
-#include "goost/register_types.h"
 #include "goost/classes_enabled.gen.h"
+#include "goost/goost.h"
 
 namespace goost {
 

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -1,7 +1,7 @@
 #include "register_scene_types.h"
 
 #include "goost/classes_enabled.gen.h"
-#include "goost/register_types.h"
+#include "goost/goost.h"
 
 #include "physics/register_physics_types.h"
 


### PR DESCRIPTION
Removed Goost includes from module's `register_types.h`, because sometimes it can lead to unexpected include errors.