### PR TITLE
CI: Generate Mono glue

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           scons platform=linuxbsd tools=yes target=release_debug module_mono_enabled=yes mono_glue=no copy_mono_root=yes
 
-      - name: Generate Mono glue
+      - name: Generate Mono Glue
         run: |
           pushd godot
           xvfb-run ./bin/godot.x11.opt.tools.64.goost.mono --generate-mono-glue modules/mono/glue || true
@@ -109,6 +109,10 @@ jobs:
           python -m pip install scons
           python --version
           scons --version
+
+      - name: Clone Godot repository
+        run: |
+          scons skip_build=yes
 
       - name: Download Glue
         uses: actions/download-artifact@v2

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -129,7 +129,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: godot.x11.opt.tools.64.goost.mono
-          path: godot/bin/godot.x11.opt.tools.64.goost.mono
+          path: godot/bin/*
 
   linux-template:
     runs-on: "ubuntu-20.04"

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -13,16 +13,15 @@ env:
   SCONS_CACHE_LIMIT: 4096
 
 jobs:
-  linux-editor:
+  mono-glue:
     runs-on: "ubuntu-20.04"
-    name: Editor w/ Mono (target=release_debug, tools=yes)
+    name: Generate Mono Glue
 
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
 
-      # Install all packages except SCons
       - name: Configure dependencies
         run: |
           sudo apt-get install build-essential pkg-config libx11-dev libxcursor-dev \
@@ -52,16 +51,123 @@ jobs:
           python --version
           scons --version
 
+      - name: Compilation (module_mono_enabled=yes mono_glue=no)
+        env:
+          SCONS_CACHE: ${{github.workspace}}/.scons_cache/
+        run: |
+          scons platform=linuxbsd tools=yes target=release_debug module_mono_enabled=yes mono_glue=no copy_mono_root=yes
+
+      - name: Generate Mono glue
+        run: |
+          pushd godot
+          xvfb-run ./bin/godot.x11.opt.tools.64.goost.mono --generate-mono-glue modules/mono/glue || true
+          popd
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: mono-glue
+          path: |
+            godot/modules/mono/glue/**.gen.*
+            godot/modules/mono/glue/GodotSharp/GodotSharp/Generated/
+            godot/modules/mono/glue/GodotSharp/GodotSharpEditor/Generated/
+
+  linux-editor-mono:
+    runs-on: "ubuntu-20.04"
+    name: Linux Editor w/ Mono (target=release_debug, tools=yes)
+    needs: mono-glue
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Configure dependencies
+        run: |
+          sudo apt-get install build-essential pkg-config libx11-dev libxcursor-dev \
+            libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libudev-dev libxi-dev libxrandr-dev yasm
+
+      - name: Load .scons_cache directory
+        id: linux-editor-cache
+        uses: actions/cache@v2
+        with:
+          path: ${{github.workspace}}/.scons_cache/
+          key: ${{github.job}}-${{env.GOOST_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+          restore-keys: |
+            ${{github.job}}-${{env.GOOST_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+            ${{github.job}}-${{env.GOOST_BASE_BRANCH}}-${{github.ref}}
+            ${{github.job}}-${{env.GOOST_BASE_BRANCH}}
+
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+          architecture: 'x64'
+
+      - name: Configuring Python packages
+        run: |
+          python -c "import sys; print(sys.version)"
+          python -m pip install scons
+          python --version
+          scons --version
+
+      - name: Download Glue
+        uses: actions/download-artifact@v2
+        with:
+          name: mono-glue
+          path: godot/modules/mono/glue
+
       - name: Compilation
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons platform=linuxbsd tools=yes target=release_debug module_mono_enabled=yes mono_glue=no
+          scons platform=linuxbsd tools=yes target=release_debug module_mono_enabled=yes mono_glue=yes mono_static=yes copy_mono_root=yes
 
       - uses: actions/upload-artifact@v2
         with:
           name: godot.x11.opt.tools.64.goost.mono
           path: godot/bin/godot.x11.opt.tools.64.goost.mono
+
+  linux-template:
+    runs-on: "ubuntu-20.04"
+    name: Template (target=release, tools=no)
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Configure dependencies
+        run: |
+          sudo apt-get install build-essential pkg-config libx11-dev libxcursor-dev \
+            libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libudev-dev libxi-dev libxrandr-dev yasm
+
+      - name: Load .scons_cache directory
+        id: linux-template-cache
+        uses: actions/cache@v2
+        with:
+          path: ${{github.workspace}}/.scons_cache/
+          key: ${{github.job}}-${{env.GOOST_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+          restore-keys: |
+            ${{github.job}}-${{env.GOOST_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+            ${{github.job}}-${{env.GOOST_BASE_BRANCH}}-${{github.ref}}
+            ${{github.job}}-${{env.GOOST_BASE_BRANCH}}
+
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+          architecture: 'x64'
+
+      - name: Configuring Python packages
+        run: |
+          python -c "import sys; print(sys.version)"
+          python -m pip install scons
+          python --version
+          scons --version
+
+      - name: Compilation
+        env:
+          SCONS_CACHE: ${{github.workspace}}/.scons_cache/
+        run: |
+          scons platform=linuxbsd target=release tools=no module_mono_enabled=yes mono_glue=no
 
   linux-server:
     runs-on: "ubuntu-20.04"
@@ -70,7 +176,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # Install all packages except SCons.
       - name: Configure dependencies
         run: |
           sudo apt-get install build-essential pkg-config libx11-dev libxcursor-dev \
@@ -128,46 +233,3 @@ jobs:
       - name: Run unit tests
         run: |
           python run.py --windowed tests
-
-  linux-template:
-    runs-on: "ubuntu-20.04"
-    name: Template w/ Mono (target=release, tools=no)
-
-    steps:
-      - uses: actions/checkout@v2
-
-      # Install all packages except SCons.
-      - name: Configure dependencies
-        run: |
-          sudo apt-get install build-essential pkg-config libx11-dev libxcursor-dev \
-            libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libudev-dev libxi-dev libxrandr-dev yasm
-
-      - name: Load .scons_cache directory
-        id: linux-template-cache
-        uses: actions/cache@v2
-        with:
-          path: ${{github.workspace}}/.scons_cache/
-          key: ${{github.job}}-${{env.GOOST_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
-          restore-keys: |
-            ${{github.job}}-${{env.GOOST_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
-            ${{github.job}}-${{env.GOOST_BASE_BRANCH}}-${{github.ref}}
-            ${{github.job}}-${{env.GOOST_BASE_BRANCH}}
-
-      - name: Set up Python 3.x
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.x'
-          architecture: 'x64'
-
-      - name: Configuring Python packages
-        run: |
-          python -c "import sys; print(sys.version)"
-          python -m pip install scons
-          python --version
-          scons --version
-
-      - name: Compilation
-        env:
-          SCONS_CACHE: ${{github.workspace}}/.scons_cache/
-        run: |
-          scons platform=linuxbsd target=release tools=no module_mono_enabled=yes mono_glue=no

--- a/SConstruct
+++ b/SConstruct
@@ -124,6 +124,11 @@ if godot_dir == Dir("godot"):
         if godot_check_if_branch(env["godot_version"]):
             run(["git", "pull"], godot_dir.abspath)
 
+if ARGUMENTS.get("skip_build") == "yes":
+    # We're only interested in cloning Godot repository given supplied version.
+    print("Skipping the build.")
+    Exit()
+
 # Setup base SCons arguments to the Godot build command.
 # Copy all from the command line, except for options in this SConstruct.
 env.build_args = ["scons"]


### PR DESCRIPTION
Should help catch C# glue generation errors much earlier, there was numerous occasions in the past where a mono build would fail, such as https://github.com/goostengine/goost/commit/6c93c9baf901110be081dc1031d5b9d53f33e30c, Xrayez/godot-anl#22 etc.

Credits to https://github.com/Zylann/godot_voxel/blob/master/.github/workflows/mono.yml.