### PR TITLE
Fix `LinkedList` and `ListNode` crashes with invalid data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Moved `PolyCollisionShape2D` class to the `physics` component.
 - Updated third-party image libraries.
 
+### Fixed
+- Crashes with `LinkedList` when dealing with invalid data.
+  - `insert_before/after(null, value)` no longer pushes front/back an element.
+
 ## [1.0] - 2021-05-24
 
 Initial release.

--- a/core/types/linked_list.cpp
+++ b/core/types/linked_list.cpp
@@ -57,12 +57,6 @@ void LinkedList::create_from(const Variant &p_value) {
 }
 
 ListNode *LinkedList::push_back(const Variant &value) {
-	if (!_data) {
-		_data = memnew(ListData);
-		_data->first = nullptr;
-		_data->last = nullptr;
-		_data->size_cache = 0;
-	}
 	ListNode *n = memnew(ListNode);
 	n->value = value;
 
@@ -90,12 +84,6 @@ void LinkedList::pop_back() {
 }
 
 ListNode *LinkedList::push_front(const Variant &value) {
-	if (!_data) {
-		_data = memnew(ListData);
-		_data->first = nullptr;
-		_data->last = nullptr;
-		_data->size_cache = 0;
-	}
 	ListNode *n = memnew(ListNode);
 	n->value = value;
 	n->prev_ptr = 0;
@@ -136,11 +124,9 @@ Array LinkedList::get_elements() {
 }
 
 ListNode *LinkedList::insert_after(ListNode *p_node, const Variant &p_value) {
-	CRASH_COND(p_node && (!_data || p_node->data != _data));
+	ERR_FAIL_COND_V(!p_node, nullptr);
+	ERR_FAIL_COND_V(p_node->data != _data, nullptr);
 
-	if (!p_node) {
-		return push_back(p_value);
-	}
 	ListNode *n = memnew(ListNode);
 	n->value = p_value;
 	n->prev_ptr = p_node;
@@ -160,11 +146,9 @@ ListNode *LinkedList::insert_after(ListNode *p_node, const Variant &p_value) {
 }
 
 ListNode *LinkedList::insert_before(ListNode *p_node, const Variant &p_value) {
-	CRASH_COND(p_node && (!_data || p_node->data != _data));
+	ERR_FAIL_COND_V(!p_node, nullptr);
+	ERR_FAIL_COND_V(p_node->data != _data, nullptr);
 
-	if (!p_node) {
-		return push_back(p_value);
-	}
 	ListNode *n = memnew(ListNode);
 	n->value = p_value;
 	n->prev_ptr = p_node->prev_ptr;
@@ -262,7 +246,9 @@ void LinkedList::invert() {
 }
 
 void LinkedList::move_to_back(ListNode *p_I) {
+	ERR_FAIL_COND(!p_I);
 	ERR_FAIL_COND(p_I->data != _data);
+
 	if (!p_I->next_ptr) {
 		return;
 	}
@@ -284,7 +270,9 @@ void LinkedList::move_to_back(ListNode *p_I) {
 }
 
 void LinkedList::move_to_front(ListNode *p_I) {
+	ERR_FAIL_COND(!p_I);
 	ERR_FAIL_COND(p_I->data != _data);
+
 	if (!p_I->prev_ptr) {
 		return;
 	}
@@ -306,6 +294,10 @@ void LinkedList::move_to_front(ListNode *p_I) {
 }
 
 void LinkedList::move_before(ListNode *p_A, ListNode *p_B) {
+	ERR_FAIL_COND(!p_A || !p_B);
+	ERR_FAIL_COND(p_A->data != _data);
+	ERR_FAIL_COND(p_B->data != _data);
+
 	if (p_A->prev_ptr) {
 		p_A->prev_ptr->next_ptr = p_A->next_ptr;
 	} else {
@@ -434,6 +426,13 @@ void ListNode::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::NIL, "value", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT), "set_value", "get_value");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "next"), "", "get_next");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "prev"), "", "get_prev");
+}
+
+LinkedList::LinkedList() {
+	_data = memnew(ListData);
+	_data->first = nullptr;
+	_data->last = nullptr;
+	_data->size_cache = 0;
 }
 
 LinkedList::~LinkedList() {

--- a/core/types/linked_list.h
+++ b/core/types/linked_list.h
@@ -181,7 +181,7 @@ public:
 		}
 		memdelete_arr(aux_buffer);
 	}
-	LinkedList() {}
+	LinkedList();
 	~LinkedList();
 };
 

--- a/tests/project/goost/core/types/test_linked_list.gd
+++ b/tests/project/goost/core/types/test_linked_list.gd
@@ -132,21 +132,6 @@ func test_insert_after_back():
 	assert_eq(list.back.value, "Godot")
 
 
-func test_insert_after_null():
-	populate_test_data(list)
-	var _n = list.insert_after(null, "Godot")
-	assert_eq(list.back.value, "Godot")
-
-
-func test_insert_before_null():
-	populate_test_data(list)
-	var _n = list.insert_before(null, "Godot")
-	# Not sure about this, see issue upstream from which this was ported:
-	# https://github.com/godotengine/godot/issues/42116
-	# But consistency with builtin List<Variant> is more important currently.
-	assert_eq(list.back.value, "Godot")
-
-
 func test_size():
 	var nodes = populate_test_data(list)
 	var original_size = nodes.size()
@@ -638,3 +623,56 @@ func test_cleanup():
 	assert_not_null(n)
 	list = null
 	assert_freed(list, "List")
+
+
+# TODO: cannot test for now in automated manner, need to be able to disable error
+# printing first, which is not possible to do via GDScript.
+#
+# Prepend "Test" to the class name in order to run these.
+class InvalidData extends "res://addons/gut/test.gd":
+	var list: LinkedList
+
+	func before_each():
+		list = LinkedList.new()
+
+	# Goost fails on null rather than pushing to back.
+	# See https://github.com/godotengine/godot/issues/42116.
+	func test_insert_after_null():
+		var _n = list.push_back(Color.blue)
+		_n = list.insert_after(null, "Godot")
+		assert_eq(list.back.value, Color.blue)
+
+	# Goost fails on null rather than pushing to front.
+	# See https://github.com/godotengine/godot/issues/42116.
+	func test_insert_before_null():
+		var _n = list.push_back(Color.blue)
+		_n = list.insert_before(null, "Godot")
+		assert_eq(list.back.value, Color.blue)
+
+	func test_swap():
+		list.swap(ClassDB.instance("ListNode"), ClassDB.instance("ListNode"))
+		list.swap(null, ClassDB.instance("ListNode"))
+		list.swap(ClassDB.instance("ListNode"), null)
+
+	func test_stuff3():
+		var _n = list.insert_before(null, Array([]))
+		_n = list.insert_after(ClassDB.instance("ListNode"), Array([]))
+
+	# TODO: Should memdelete(this) or prevent with ERR_FAIL_COND?
+	# func test_list_node_erase_not_exists():
+	# 	var n = ClassDB.instance("ListNode")
+	# 	node.erase()
+	# 	node.set_value("1769126663") # GDScript parser error Attempted to run on null instance.
+
+	func test_move_to_front():
+		list.move_to_front(null)
+		list.move_to_front(ClassDB.instance("ListNode"))
+
+	func test_move_to_back():
+		list.move_to_back(null)
+		list.move_to_back(ClassDB.instance("ListNode"))
+
+	func test_move_before():
+		list.move_before(null, null)
+		list.move_before(null, ClassDB.instance("ListNode"))
+		list.move_before(ClassDB.instance("ListNode"), null)


### PR DESCRIPTION
Removed `CRASH_COND`, should use `ERR_FAIL_COND` macros instead.
`insert_before/after(null, value)` no longer pushes front/back an element.

Part of #105.