### PR TITLE
Fix `GoostGeometry2D` and `PolyDecomp2D` crashes with invalid data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Crashes with `LinkedList` when dealing with invalid data.
   - `insert_before/after(null, value)` no longer pushes front/back an element.
+- Out of memory error when calling `GoostGeometry2D.simplify_polyline()` with `epsilon = 0`.
+- Crashes while decomposing empty polygons with `PolyDecomp2D` when using `polypartition` geometry backend.
 
 ## [1.0] - 2021-05-24
 

--- a/core/math/geometry/2d/goost_geometry_2d.cpp
+++ b/core/math/geometry/2d/goost_geometry_2d.cpp
@@ -119,6 +119,10 @@ Vector<Point2> GoostGeometry2D::simplify_polyline(const Vector<Point2> &p_polyli
 	if (p_polyline.size() <= 2) {
 		return p_polyline;
 	}
+	if (p_epsilon <= 0.0) {
+		// Retain all points.
+		return p_polyline;
+	}
 	Vector<bool> points_to_retain;
 	points_to_retain.resize(p_polyline.size());
 

--- a/core/math/geometry/2d/poly/decomp/polypartition/poly_decomp_polypartition.cpp
+++ b/core/math/geometry/2d/poly/decomp/polypartition/poly_decomp_polypartition.cpp
@@ -61,7 +61,9 @@ Vector<Vector<Point2>> partition(List<TriangulatorPoly> &p_out_poly) {
 
 Vector<Vector<Point2>> PolyDecomp2DPolyPartition::triangulate_ec(const Vector<Vector<Point2>> &p_polygons) {
 	List<TriangulatorPoly> in_poly = configure(DECOMP_TRIANGLES_EC, p_polygons);
-
+	if (in_poly.empty()) {
+		return Vector<Vector<Point2>>();
+	}
 	TriangulatorPartition tpart;
 	List<TriangulatorPoly> out_poly;
 
@@ -74,7 +76,9 @@ Vector<Vector<Point2>> PolyDecomp2DPolyPartition::triangulate_ec(const Vector<Ve
 
 Vector<Vector<Point2>> PolyDecomp2DPolyPartition::triangulate_opt(const Vector<Vector<Point2>> &p_polygons) {
 	List<TriangulatorPoly> in_poly = configure(DECOMP_TRIANGLES_OPT, p_polygons);
-
+	if (in_poly.empty()) {
+		return Vector<Vector<Point2>>();
+	}
 	TriangulatorPartition tpart;
 	List<TriangulatorPoly> out_poly;
 
@@ -87,7 +91,9 @@ Vector<Vector<Point2>> PolyDecomp2DPolyPartition::triangulate_opt(const Vector<V
 
 Vector<Vector<Point2>> PolyDecomp2DPolyPartition::triangulate_mono(const Vector<Vector<Point2>> &p_polygons) {
 	List<TriangulatorPoly> in_poly = configure(DECOMP_TRIANGLES_MONO, p_polygons);
-
+	if (in_poly.empty()) {
+		return Vector<Vector<Point2>>();
+	}
 	TriangulatorPartition tpart;
 	List<TriangulatorPoly> out_poly;
 
@@ -101,7 +107,9 @@ Vector<Vector<Point2>> PolyDecomp2DPolyPartition::triangulate_mono(const Vector<
 
 Vector<Vector<Point2>> PolyDecomp2DPolyPartition::decompose_convex_hm(const Vector<Vector<Point2>> &p_polygons) {
 	List<TriangulatorPoly> in_poly = configure(DECOMP_CONVEX_HM, p_polygons);
-
+	if (in_poly.empty()) {
+		return Vector<Vector<Point2>>();
+	}
 	TriangulatorPartition tpart;
 	List<TriangulatorPoly> out_poly;
 
@@ -114,7 +122,9 @@ Vector<Vector<Point2>> PolyDecomp2DPolyPartition::decompose_convex_hm(const Vect
 
 Vector<Vector<Point2>> PolyDecomp2DPolyPartition::decompose_convex_opt(const Vector<Vector<Point2>> &p_polygons) {
 	List<TriangulatorPoly> in_poly = configure(DECOMP_CONVEX_OPT, p_polygons);
-
+	if (in_poly.empty()) {
+		return Vector<Vector<Point2>>();
+	}
 	TriangulatorPartition tpart;
 	List<TriangulatorPoly> out_poly;
 

--- a/tests/project/goost/core/math/2d/geometry/poly/test_poly_decomp.gd
+++ b/tests/project/goost/core/math/2d/geometry/poly/test_poly_decomp.gd
@@ -88,3 +88,9 @@ func test_decompose_polygons_convex_opt():
 	solution = PolyDecomp2D.decompose_polygons([poly_boundary], PolyDecomp2D.DECOMP_CONVEX_OPT)
 	assert_eq(solution.size(), 1)
 	assert_eq(solution[0].size(), 8)
+
+
+# TODO: re-enable once error printing can be disabled.
+# func test_decompose_polygon_empty():
+# 	PolyDecomp2D.decompose_polygons(Array([]), PolyDecomp2D.DECOMP_TRIANGLES_OPT)
+# 	PolyDecomp2D.decompose_polygons(Array([]), PolyDecomp2D.DECOMP_CONVEX_OPT)

--- a/tests/project/goost/core/math/2d/geometry/test_geometry_2d.gd
+++ b/tests/project/goost/core/math/2d/geometry/test_geometry_2d.gd
@@ -243,6 +243,16 @@ func test_simplify_polyline():
 		assert_eq(simplified[i], control[i])
 
 
+func test_simplify_polyline_zero_epsilon():
+	var input = PoolVector2Array([
+		Vector2(-2.182464, -3.504493),
+		Vector2(-2.662979, -1.333622),
+		Vector2(2.71501, 1.567903),
+	])
+	var simplified = GoostGeometry2D.simplify_polyline(input, 0)
+	assert_eq(input.size(), simplified.size())
+
+
 func test_smooth_polygon():
 	var input = [Vector2(26, 20), Vector2(73, 23), Vector2(72, 62), Vector2(29, 57)]
 	var control = [Vector2(26, 20), Vector2(49.311768, 15.934073), Vector2(73, 23),


### PR DESCRIPTION
- Fixes out of memory error when calling `GoostGeometry2D.simplify_polyline()` with `epsilon = 0`
- Fixes crashes while decomposing empty polygons with `PolyDecomp2D` when using `polypartition` geometry backend

Part of #105.