### PR TITLE
Revert "CI: Use Azure repositories"

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -22,6 +22,13 @@ jobs:
         with:
           submodules: recursive
 
+      # Azure repositories are not reliable, prevent Azure giving packages.
+      - name: Make apt sources.list use the default Ubuntu repositories
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/*
+          sudo cp -f misc/ci/sources.list /etc/apt/sources.list
+          sudo apt-get update
+
       - name: Configure dependencies
         run: |
           sudo apt-get install build-essential pkg-config libx11-dev libxcursor-dev \
@@ -81,6 +88,13 @@ jobs:
         with:
           submodules: recursive
 
+      # Azure repositories are not reliable, prevent Azure giving packages.
+      - name: Make apt sources.list use the default Ubuntu repositories
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/*
+          sudo cp -f misc/ci/sources.list /etc/apt/sources.list
+          sudo apt-get update
+
       - name: Configure dependencies
         run: |
           sudo apt-get install build-essential pkg-config libx11-dev libxcursor-dev \
@@ -138,6 +152,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # Azure repositories are not reliable, prevent Azure giving packages.
+      - name: Make apt sources.list use the default Ubuntu repositories
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/*
+          sudo cp -f misc/ci/sources.list /etc/apt/sources.list
+          sudo apt-get update
+
       - name: Configure dependencies
         run: |
           sudo apt-get install build-essential pkg-config libx11-dev libxcursor-dev \
@@ -179,6 +200,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      # Azure repositories are not reliable, prevent Azure giving packages.
+      - name: Make apt sources.list use the default Ubuntu repositories
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/*
+          sudo cp -f misc/ci/sources.list /etc/apt/sources.list
+          sudo apt-get update
 
       - name: Configure dependencies
         run: |

--- a/misc/ci/sources.list
+++ b/misc/ci/sources.list
@@ -1,0 +1,4 @@
+deb http://archive.ubuntu.com/ubuntu/ focal main restricted universe multiverse
+deb http://archive.ubuntu.com/ubuntu/ focal-updates main restricted universe multiverse
+deb http://archive.ubuntu.com/ubuntu/ focal-security main restricted universe multiverse
+deb http://archive.ubuntu.com/ubuntu/ focal-backports main restricted universe multiverse


### PR DESCRIPTION
Turns out these do fail even now: 1e2074ec94954b9d043168bf99aca6b043a6e836

This reverts commit 39b3df76dfa6ab1773e4c74f453a7d64510557b7, except for Javascript/Android, where these are not needed.
