### PR TITLE
Use `#pragma once` in all header files

### DIFF
--- a/core/func_buffer.h
+++ b/core/func_buffer.h
@@ -1,5 +1,4 @@
-#ifndef FUNC_BUFFER_H
-#define FUNC_BUFFER_H
+#pragma once
 
 #include "core/object.h"
 
@@ -32,4 +31,3 @@ public:
 	}
 };
 
-#endif // FUNC_BUFFER_H

--- a/core/goost_engine.h
+++ b/core/goost_engine.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_ENGINE_H
-#define GOOST_ENGINE_H
+#pragma once
 
 #include "core/object.h"
 #include "scene/main/scene_tree.h"
@@ -50,4 +49,3 @@ public:
 	}
 };
 
-#endif // GOOST_ENGINE_H

--- a/core/image/drivers/png/image_loader_indexed_png.h
+++ b/core/image/drivers/png/image_loader_indexed_png.h
@@ -1,5 +1,4 @@
-#ifndef IMAGE_LOADER_INDEXED_PNG_H
-#define IMAGE_LOADER_INDEXED_PNG_H
+#pragma once
 
 #include "core/io/image_loader.h"
 #include "goost/core/image/image_indexed.h"
@@ -16,4 +15,3 @@ public:
 	ImageLoaderIndexedPNG();
 };
 
-#endif

--- a/core/image/drivers/png/resource_saver_indexed_png.h
+++ b/core/image/drivers/png/resource_saver_indexed_png.h
@@ -1,5 +1,4 @@
-#ifndef RESOURCE_SAVER_INDEXED_PNG_H
-#define RESOURCE_SAVER_INDEXED_PNG_H
+#pragma once
 
 #include "core/io/resource_saver.h"
 #include "goost/core/image/image_indexed.h"
@@ -15,4 +14,3 @@ public:
 	ResourceSaverIndexedPNG();
 };
 
-#endif // RESOURCE_SAVER_INDEXED_PNG_H

--- a/core/image/goost_image.h
+++ b/core/image/goost_image.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_IMAGE_H
-#define GOOST_IMAGE_H
+#pragma once
 
 #include "core/image.h"
 
@@ -61,4 +60,3 @@ public:
 	static Color get_pixel_average(const Ref<Image> &p_image, const Rect2 &p_rect = Rect2(), const Ref<Image> &p_mask = nullptr);
 };
 
-#endif

--- a/core/image/goost_image_bind.h
+++ b/core/image/goost_image_bind.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_IMAGE_BIND_H
-#define GOOST_IMAGE_BIND_H
+#pragma once
 
 #include "core/image.h"
 
@@ -75,4 +74,3 @@ VARIANT_ENUM_CAST(_GoostImage::MorphOperation);
 VARIANT_ENUM_CAST(_GoostImage::Direction);
 VARIANT_ENUM_CAST(_GoostImage::WrapMode);
 
-#endif

--- a/core/image/image_blender.h
+++ b/core/image/image_blender.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_IMAGE_BLENDER_H
-#define GOOST_IMAGE_BLENDER_H
+#pragma once
 
 #include "core/image.h"
 #include "core/method_bind_ext.gen.inc"
@@ -75,4 +74,3 @@ public:
 VARIANT_ENUM_CAST(ImageBlender::BlendEquation);
 VARIANT_ENUM_CAST(ImageBlender::BlendFactor);
 
-#endif // GOOST_IMAGE_BLENDER_H

--- a/core/image/image_indexed.h
+++ b/core/image/image_indexed.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_IMAGE_INDEXED_H
-#define GOOST_IMAGE_INDEXED_H
+#pragma once
 
 #include "core/image.h"
 
@@ -74,4 +73,3 @@ public:
 
 VARIANT_ENUM_CAST(ImageIndexed::DitherMode)
 
-#endif // GOOST_IMAGE_INDEXED_H

--- a/core/invoke_state.h
+++ b/core/invoke_state.h
@@ -1,5 +1,4 @@
-#ifndef INVOKE_STATE_H
-#define INVOKE_STATE_H
+#pragma once
 
 #include "core/reference.h"
 #include "scene/main/scene_tree.h"
@@ -30,4 +29,3 @@ public:
 	real_t get_time_left() { return active ? timer->get_time_left() : 0; }
 };
 
-#endif // INVOKE_STATE_H

--- a/core/math/geometry/2d/goost_geometry_2d.h
+++ b/core/math/geometry/2d/goost_geometry_2d.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_GEOMETRY_2D_H
-#define GOOST_GEOMETRY_2D_H
+#pragma once
 
 #include "core/variant.h"
 
@@ -49,4 +48,3 @@ public:
 	static Vector<Point2i> polygon_to_pixels(const Vector<Point2> &p_points);
 };
 
-#endif // GOOST_GEOMETRY_2D_H

--- a/core/math/geometry/2d/goost_geometry_2d_bind.h
+++ b/core/math/geometry/2d/goost_geometry_2d_bind.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_GEOMETRY_2D_BIND_H
-#define GOOST_GEOMETRY_2D_BIND_H
+#pragma once
 
 #include "core/object.h"
 
@@ -55,4 +54,3 @@ public:
 	_GoostGeometry2D();
 };
 
-#endif // GOOST_GEOMETRY_2D_BIND_H

--- a/core/math/geometry/2d/poly/boolean/clipper10/poly_boolean_clipper10.h
+++ b/core/math/geometry/2d/poly/boolean/clipper10/poly_boolean_clipper10.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_GEOMETRY_POLY_BOOLEAN_CLIPPER10
-#define GOOST_GEOMETRY_POLY_BOOLEAN_CLIPPER10
+#pragma once
 
 #include "../poly_boolean.h"
 #include "goost/thirdparty/clipper/clipper.h"
@@ -17,4 +16,3 @@ private:
 	bool subject_open;
 };
 
-#endif // GOOST_GEOMETRY_POLY_BOOLEAN_CLIPPER10

--- a/core/math/geometry/2d/poly/boolean/clipper6/poly_boolean_clipper6.h
+++ b/core/math/geometry/2d/poly/boolean/clipper6/poly_boolean_clipper6.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_GEOMETRY_POLY_BOOLEAN_CLIPPER6_H
-#define GOOST_GEOMETRY_POLY_BOOLEAN_CLIPPER6_H
+#pragma once
 
 #include "../poly_boolean.h"
 #include "thirdparty/misc/clipper.hpp"
@@ -17,4 +16,3 @@ private:
 	bool subject_open;
 };
 
-#endif // GOOST_GEOMETRY_POLY_BOOLEAN_CLIPPER6_H

--- a/core/math/geometry/2d/poly/boolean/poly_boolean.h
+++ b/core/math/geometry/2d/poly/boolean/poly_boolean.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_GEOMETRY_POLY_BOOLEAN_H
-#define GOOST_GEOMETRY_POLY_BOOLEAN_H
+#pragma once
 
 #include "core/resource.h"
 #include "../poly_node_2d.h"
@@ -164,4 +163,3 @@ public:
 
 VARIANT_ENUM_CAST(PolyBooleanParameters2D::FillRule);
 
-#endif // GOOST_GEOMETRY_POLY_BOOLEAN_H

--- a/core/math/geometry/2d/poly/decomp/clipper10/poly_decomp_clipper10.h
+++ b/core/math/geometry/2d/poly/decomp/clipper10/poly_decomp_clipper10.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_GEOMETRY_POLY_DECOMP_CLIPPER10
-#define GOOST_GEOMETRY_POLY_DECOMP_CLIPPER10
+#pragma once
 
 #include "../polypartition/poly_decomp_polypartition.h"
 #include "goost/thirdparty/clipper/clipper_triangulation.h"
@@ -13,4 +12,3 @@ private:
 	clipperlib::FillRule fill_rule;
 };
 
-#endif // GOOST_GEOMETRY_POLY_DECOMP_CLIPPER10

--- a/core/math/geometry/2d/poly/decomp/poly_decomp.h
+++ b/core/math/geometry/2d/poly/decomp/poly_decomp.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_GEOMETRY_POLY_DECOMP_H
-#define GOOST_GEOMETRY_POLY_DECOMP_H
+#pragma once
 
 #include "core/resource.h"
 
@@ -130,4 +129,3 @@ public:
 
 VARIANT_ENUM_CAST(PolyDecompParameters2D::FillRule);
 
-#endif // GOOST_GEOMETRY_POLY_DECOMP_H

--- a/core/math/geometry/2d/poly/decomp/polypartition/poly_decomp_polypartition.h
+++ b/core/math/geometry/2d/poly/decomp/polypartition/poly_decomp_polypartition.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_GEOMETRY_POLY_DECOMP_POLYPARTITION_H
-#define GOOST_GEOMETRY_POLY_DECOMP_POLYPARTITION_H
+#pragma once
 
 #include "../poly_decomp.h"
 #include "core/reference.h"
@@ -15,4 +14,3 @@ public:
 	virtual Vector<Vector<Point2>> decompose_convex_opt(const Vector<Vector<Point2>> &p_polygons);
 };
 
-#endif // GOOST_GEOMETRY_POLY_DECOMP_POLYPARTITION_H

--- a/core/math/geometry/2d/poly/offset/clipper10/poly_offset_clipper10.h
+++ b/core/math/geometry/2d/poly/offset/clipper10/poly_offset_clipper10.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_GEOMETRY_POLY_OFFSET_CLIPPER10
-#define GOOST_GEOMETRY_POLY_OFFSET_CLIPPER10
+#pragma once
 
 #include "../poly_offset.h"
 #include "goost/thirdparty/clipper/clipper_offset.h"
@@ -14,4 +13,3 @@ private:
 	clipperlib::EndType end_type;
 };
 
-#endif // GOOST_GEOMETRY_POLY_OFFSET_CLIPPER10

--- a/core/math/geometry/2d/poly/offset/clipper6/poly_offset_clipper6.h
+++ b/core/math/geometry/2d/poly/offset/clipper6/poly_offset_clipper6.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_GEOMETRY_POLY_OFFSET_CLIPPER6
-#define GOOST_GEOMETRY_POLY_OFFSET_CLIPPER6
+#pragma once
 
 #include "../poly_offset.h"
 #include "thirdparty/misc/clipper.hpp"
@@ -14,4 +13,3 @@ private:
 	ClipperLib::EndType end_type;
 };
 
-#endif // GOOST_GEOMETRY_POLY_OFFSET_CLIPPER6

--- a/core/math/geometry/2d/poly/offset/poly_offset.h
+++ b/core/math/geometry/2d/poly/offset/poly_offset.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_GEOMETRY_POLY_OFFSET_2D_H
-#define GOOST_GEOMETRY_POLY_OFFSET_2D_H
+#pragma once
 
 #include "core/resource.h"
 
@@ -122,4 +121,3 @@ public:
 VARIANT_ENUM_CAST(PolyOffsetParameters2D::JoinType);
 VARIANT_ENUM_CAST(PolyOffsetParameters2D::EndType);
 
-#endif // GOOST_GEOMETRY_POLY_OFFSET_2D_H

--- a/core/math/geometry/2d/poly/poly_backends.h
+++ b/core/math/geometry/2d/poly/poly_backends.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_POLY_BACKENDS_2D_H
-#define GOOST_POLY_BACKENDS_2D_H
+#pragma once
 
 #include "core/project_settings.h"
 
@@ -148,4 +147,3 @@ public:
 	}
 };
 
-#endif // GOOST_POLY_BACKENDS_2D_H

--- a/core/math/geometry/2d/poly/poly_node_2d.h
+++ b/core/math/geometry/2d/poly/poly_node_2d.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_POLY_NODE_2D_H
-#define GOOST_POLY_NODE_2D_H
+#pragma once
 
 #include "scene/2d/node_2d.h"
 
@@ -117,4 +116,3 @@ struct VariantCaster<PolyNode2D *> {
 	}
 };
 
-#endif // GOOST_POLY_NODE_2D_H

--- a/core/math/geometry/2d/poly/utils/godot_clipper10_path_convert.h
+++ b/core/math/geometry/2d/poly/utils/godot_clipper10_path_convert.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_CLIPPER10_PATH_CONVERT_H
-#define GOOST_CLIPPER10_PATH_CONVERT_H
+#pragma once
 
 #include "core/math/vector2.h"
 #include "core/vector.h"
@@ -16,4 +15,3 @@ void scale_down_polypath(const Path &p_polypath_in, Vector<Point2> &p_polypath_o
 
 } // namespace GodotClipperUtils
 
-#endif // GOOST_CLIPPER10_PATH_CONVERT_H

--- a/core/math/geometry/2d/poly/utils/godot_clipper6_path_convert.h
+++ b/core/math/geometry/2d/poly/utils/godot_clipper6_path_convert.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_CLIPPER6_PATH_CONVERT_H
-#define GOOST_CLIPPER6_PATH_CONVERT_H
+#pragma once
 
 #include "core/math/vector2.h"
 #include "core/vector.h"
@@ -26,4 +25,3 @@ void scale_down_polypath(const Path &p_polypath_in, Vector<Point2> &p_polypath_o
 
 } // namespace GodotClipperUtils
 
-#endif // GOOST_CLIPPER6_PATH_CONVERT_H

--- a/core/math/geometry/2d/random_2d.h
+++ b/core/math/geometry/2d/random_2d.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_RANDOM_2D_H
-#define GOOST_RANDOM_2D_H
+#pragma once
 
 #include "goost/core/math/random.h"
 
@@ -32,4 +31,3 @@ public:
 	}
 };
 
-#endif // GOOST_RANDOM_2D_H

--- a/core/math/random.h
+++ b/core/math/random.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_RANDOM_H
-#define GOOST_RANDOM_H
+#pragma once
 
 #include "core/math/random_number_generator.h"
 
@@ -37,4 +36,3 @@ public:
 	}
 };
 
-#endif // GOOST_RANDOM_H

--- a/core/script/mixin_script/editor/mixin_script_editor.h
+++ b/core/script/mixin_script/editor/mixin_script_editor.h
@@ -1,5 +1,4 @@
-#ifndef MIXIN_SCRIPT_EDITOR_H
-#define MIXIN_SCRIPT_EDITOR_H
+#pragma once
 
 #include "../mixin_script.h"
 
@@ -81,4 +80,3 @@ public:
 	~MixinScriptEditor();
 };
 
-#endif // MIXIN_SCRIPT_EDITOR_H

--- a/core/script/mixin_script/editor/mixin_script_editor_plugin.h
+++ b/core/script/mixin_script/editor/mixin_script_editor_plugin.h
@@ -1,5 +1,4 @@
-#ifndef MIXIN_SCRIPT_EDITOR_PLUGIN_H
-#define MIXIN_SCRIPT_EDITOR_PLUGIN_H
+#pragma once
 
 #include "../mixin_script.h"
 
@@ -30,4 +29,3 @@ public:
 	MixinScriptEditorPlugin(EditorNode *p_node);
 };
 
-#endif // MIXIN_SCRIPT_EDITOR_PLUGIN_H

--- a/core/script/mixin_script/mixin_script.h
+++ b/core/script/mixin_script/mixin_script.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_MULTISCRIPT_H
-#define GOOST_MULTISCRIPT_H
+#pragma once
 
 // Based on unreleased and subsequently removed MixinScript support
 // in previous versions of Godot: https://github.com/godotengine/godot/pull/8718
@@ -177,4 +176,3 @@ public:
 	int profiling_get_frame_data(ProfilingInfo *p_info_arr, int p_info_max) { return 0; }
 };
 
-#endif // GOOST_MULTISCRIPT_H

--- a/core/types/editor/variant_resource_preview.h
+++ b/core/types/editor/variant_resource_preview.h
@@ -1,5 +1,4 @@
-#ifndef VARIANT_RESOURCE_PREVIEW_H
-#define VARIANT_RESOURCE_PREVIEW_H
+#pragma once
 
 #include "editor/editor_resource_preview.h"
 #include "../variant_resource.h"
@@ -15,4 +14,3 @@ public:
 	virtual bool can_generate_small_preview() const { return true; };
 };
 
-#endif // VARIANT_RESOURCE_PREVIEW_H

--- a/core/types/linked_list.h
+++ b/core/types/linked_list.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_LIST_H
-#define GOOST_LIST_H
+#pragma once
 
 // Implementation based on Godot's `core/list.h`, which is mostly
 // an instantiation of the `List<Variant>` template class for performance,
@@ -192,4 +191,3 @@ struct VariantCaster<ListNode *> {
 	}
 };
 
-#endif // GOOST_LIST_H

--- a/core/types/variant_map.h
+++ b/core/types/variant_map.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_VARIANT_MAP_H
-#define GOOST_VARIANT_MAP_H
+#pragma once
 
 #include "core/resource.h"
 #include "core/variant.h"
@@ -51,4 +50,3 @@ public:
 	virtual String to_string();
 };
 
-#endif // GOOST_VARIANT_MAP_H

--- a/core/types/variant_resource.h
+++ b/core/types/variant_resource.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_VARIANT_RESOURCE_H
-#define GOOST_VARIANT_RESOURCE_H
+#pragma once
 
 #include "core/resource.h"
 #include "core/variant.h"
@@ -52,4 +51,3 @@ public:
 	}
 };
 
-#endif // GOOST_VARIANT_RESOURCE_H

--- a/editor/editor_about.h
+++ b/editor/editor_about.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_EDITOR_ABOUT_H
-#define GOOST_EDITOR_ABOUT_H
+#pragma once
 
 #include "scene/gui/control.h"
 #include "scene/gui/dialogs.h"
@@ -48,4 +47,3 @@ public:
 	GoostEditorAbout();
 };
 
-#endif // GOOST_EDITOR_ABOUT_H

--- a/goost.h
+++ b/goost.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_H
-#define GOOST_H
+#pragma once
 
 #include "core/goost_engine.h"
 #include "core/image/goost_image.h"
@@ -39,4 +38,3 @@ void register_class() {
 }
 } // namespace goost
 
-#endif // GOOST_H

--- a/modules/gdscript_transpiler/bind/gdscript_transpiler_bind.h
+++ b/modules/gdscript_transpiler/bind/gdscript_transpiler_bind.h
@@ -1,5 +1,4 @@
-#ifndef GDSCRIPT_TRANSPILER_BIND_H
-#define GDSCRIPT_TRANSPILER_BIND_H
+#pragma once
 
 #include "core/object.h"
 #include "gdscript_transpiler.h"
@@ -23,4 +22,3 @@ public:
 	_GDScriptTranspiler();
 };
 
-#endif // GDSCRIPT_TRANSPILER_H

--- a/modules/gdscript_transpiler/gdscript_transpiler.h
+++ b/modules/gdscript_transpiler/gdscript_transpiler.h
@@ -1,5 +1,4 @@
-#ifndef GDSCRIPT_TRANSPILER_H
-#define GDSCRIPT_TRANSPILER_H
+#pragma once
 
 #include "core/reference.h"
 
@@ -37,4 +36,3 @@ public:
 	virtual Variant transpile(const Ref<GDScript> &p_script) = 0;
 };
 
-#endif // GDSCRIPT_TRANSPILER_H

--- a/modules/gdscript_transpiler/gdscript_transpiler_utils.h
+++ b/modules/gdscript_transpiler/gdscript_transpiler_utils.h
@@ -1,5 +1,4 @@
-#ifndef GDSCRIPT_TRANSPILER_UTILS_H
-#define GDSCRIPT_TRANSPILER_UTILS_H
+#pragma once
 
 #include "core/string_builder.h"
 #include "core/ustring.h"
@@ -40,4 +39,3 @@ public:
 
 } // namespace GDScriptTranspilerUtils
 
-#endif // GDSCRIPT_TRANSPILER_UTILS_H

--- a/modules/gdscript_transpiler/languages/gdscript_transpiler_cxx.h
+++ b/modules/gdscript_transpiler/languages/gdscript_transpiler_cxx.h
@@ -1,5 +1,4 @@
-#ifndef GDSCRIPT_TRANSPILER_CPP_H
-#define GDSCRIPT_TRANSPILER_CPP_H
+#pragma once
 
 #include "gdscript_transpiler.h"
 
@@ -247,4 +246,3 @@ public:
 	~GDScriptTranspilerCpp();
 };
 
-#endif // GDSCRIPT_TRANSPILER_CPP_H

--- a/modules/gif/editor/import/resource_importer_animated_texture.h
+++ b/modules/gif/editor/import/resource_importer_animated_texture.h
@@ -1,5 +1,4 @@
-#ifndef RESOURCE_IMPORTER_ANIMATED_TEXTURE_H
-#define RESOURCE_IMPORTER_ANIMATED_TEXTURE_H
+#pragma once
 
 #include "core/io/resource_importer.h"
 
@@ -21,4 +20,3 @@ public:
 	virtual Error import(const String &p_source_file, const String &p_save_path, const Map<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr);
 };
 
-#endif // RESOURCE_IMPORTER_ANIMATED_TEXTURE_H

--- a/modules/gif/editor/import/resource_importer_sprite_frames.h
+++ b/modules/gif/editor/import/resource_importer_sprite_frames.h
@@ -1,5 +1,4 @@
-#ifndef RESOURCE_IMPORTER_SPRITE_FRAMES_H
-#define RESOURCE_IMPORTER_SPRITE_FRAMES_H
+#pragma once
 
 #include "core/io/resource_importer.h"
 
@@ -21,4 +20,3 @@ public:
 	virtual Error import(const String &p_source_file, const String &p_save_path, const Map<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr);
 };
 
-#endif // RESOURCE_IMPORTER_SPRITE_FRAMES_H

--- a/modules/gif/image_frames.h
+++ b/modules/gif/image_frames.h
@@ -1,5 +1,4 @@
-#ifndef IMAGE_FRAMES_H
-#define IMAGE_FRAMES_H
+#pragma once
 
 #include "core/image.h"
 
@@ -41,4 +40,3 @@ public:
 	void clear();
 };
 
-#endif // IMAGE_FRAMES_H

--- a/modules/gif/image_frames_loader.h
+++ b/modules/gif/image_frames_loader.h
@@ -1,5 +1,4 @@
-#ifndef IMAGE_FRAMES_LOADER_H
-#define IMAGE_FRAMES_LOADER_H
+#pragma once
 
 #include "image_frames.h"
 
@@ -55,4 +54,3 @@ public:
 	virtual String get_resource_type(const String &p_path) const;
 };
 
-#endif // IMAGE_FRAMES_LOADER_H  

--- a/modules/gif/image_frames_loader_gif.h
+++ b/modules/gif/image_frames_loader_gif.h
@@ -1,5 +1,4 @@
-#ifndef IMAGE_FRAMES_LOADER_GIF_H
-#define IMAGE_FRAMES_LOADER_GIF_H
+#pragma once
 
 #include "image_frames_loader.h"
 
@@ -32,4 +31,3 @@ public:
 	Error load_from_buffer(Ref<ImageFrames> &r_image_frames, const PoolByteArray &p_data, int max_frames = 0);
 };
 
-#endif // IMAGE_FRAMES_LOADER_GIF_H

--- a/modules/git/git_api.h
+++ b/modules/git/git_api.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_GIT_API_H
-#define GOOST_GIT_API_H
+#pragma once
 
 // Initial implementation based on Godot's GDNative version of the Git plugin
 // See https://github.com/godotengine/godot-git-plugin.
@@ -66,4 +65,3 @@ public:
 	PopupMenu *get_popup_menu(PopupMenu *p_popup) { return vcs_popup; }
 };
 
-#endif // GOOST_GIT_API_H

--- a/modules/git/git_common.h
+++ b/modules/git/git_common.h
@@ -1,5 +1,4 @@
-#ifndef GIT_COMMON_H
-#define GIT_COMMON_H
+#pragma once
 
 #include <git2.h>
 
@@ -9,4 +8,3 @@ extern "C" int diff_line_callback_function(const git_diff_delta *delta, const gi
 
 #define GIT2_CALL(function_call, m_error_msg, m_additional_msg) check_git2_errors(function_call, m_error_msg, m_additional_msg);
 
-#endif // !GIT_COMMON_H

--- a/register_types.h
+++ b/register_types.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_REGISTER_TYPES
-#define GOOST_REGISTER_TYPES
+#pragma once
 
 #include "core/engine.h"
 
@@ -11,4 +10,3 @@
 void register_goost_types();
 void unregister_goost_types();
 
-#endif // GOOST_REGISTER_TYPES

--- a/scene/2d/editor/poly_node_2d_editor_plugin.h
+++ b/scene/2d/editor/poly_node_2d_editor_plugin.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_POLY_NODE_2D_EDITOR_PLUGIN_H
-#define GOOST_POLY_NODE_2D_EDITOR_PLUGIN_H
+#pragma once
 
 #include "editor/plugins/abstract_polygon_2d_editor.h"
 #include "goost/core/math/geometry/2d/poly/poly_node_2d.h"
@@ -44,4 +43,3 @@ public:
 	PolyNode2DEditorPlugin(EditorNode *p_node);
 };
 
-#endif // GOOST_POLY_NODE_2D_EDITOR_PLUGIN_H

--- a/scene/2d/editor/visual_shape_2d_editor_plugin.h
+++ b/scene/2d/editor/visual_shape_2d_editor_plugin.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_VISUAL_SHAPE_2D_EDITOR_PLUGIN_H
-#define GOOST_VISUAL_SHAPE_2D_EDITOR_PLUGIN_H
+#pragma once
 
 #include "editor/plugins/abstract_polygon_2d_editor.h"
 #include "goost/scene/2d/visual_shape_2d.h"
@@ -36,4 +35,3 @@ public:
 	VisualShape2DEditorPlugin(EditorNode *p_node);
 };
 
-#endif // GOOST_VISUAL_SHAPE_2D_EDITOR_PLUGIN_H

--- a/scene/2d/poly_generators_2d.h
+++ b/scene/2d/poly_generators_2d.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_POLY_GENERATORS_2D_H
-#define GOOST_POLY_GENERATORS_2D_H
+#pragma once
 
 #include "goost/core/math/geometry/2d/poly/poly_node_2d.h"
 #include "goost/core/math/geometry/2d/poly/offset/poly_offset.h"
@@ -89,4 +88,3 @@ public:
 	}
 };
 
-#endif // GOOST_POLY_GENERATORS_2D_H

--- a/scene/2d/poly_shape_2d.h
+++ b/scene/2d/poly_shape_2d.h
@@ -1,5 +1,4 @@
-#ifndef POLY_SHAPE_2D_H
-#define POLY_SHAPE_2D_H
+#pragma once
 
 #include "goost/core/math/geometry/2d/poly/poly_node_2d.h"
 
@@ -47,4 +46,3 @@ public:
 
 VARIANT_ENUM_CAST(PolyShape2D::BuildMode);
 
-#endif // POLY_SHAPE_2D_H

--- a/scene/2d/visual_shape_2d.h
+++ b/scene/2d/visual_shape_2d.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_VISUAL_SHAPE_2D_H
-#define GOOST_VISUAL_SHAPE_2D_H
+#pragma once
 
 #include "scene/2d/node_2d.h"
 #include "scene/resources/concave_polygon_shape_2d.h"
@@ -49,4 +48,3 @@ public:
 	VisualShape2D(){};
 };
 
-#endif // GOOST_VISUAL_SHAPE_2D_H

--- a/scene/gui/grid_rect.h
+++ b/scene/gui/grid_rect.h
@@ -1,5 +1,4 @@
-#ifndef GRID_RECT_H
-#define GRID_RECT_H
+#pragma once
 
 #include "core/color.h"
 #include "scene/gui/control.h"
@@ -119,4 +118,3 @@ VARIANT_ENUM_CAST(GridRect::CellOrigin);
 VARIANT_ENUM_CAST(GridRect::Axis);
 VARIANT_ENUM_CAST(GridRect::Line);
 
-#endif // GRID_RECT_H

--- a/scene/main/stopwatch.h
+++ b/scene/main/stopwatch.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_STOPWATCH_H
-#define GOOST_STOPWATCH_H
+#pragma once
 
 #include "scene/main/node.h"
 
@@ -45,4 +44,3 @@ private:
 
 VARIANT_ENUM_CAST(Stopwatch::ProcessMode);
 
-#endif // GOOST_STOPWATCH_H

--- a/scene/physics/2d/poly_collision_shape_2d.h
+++ b/scene/physics/2d/poly_collision_shape_2d.h
@@ -1,5 +1,4 @@
-#ifndef POLY_COLLISION_SHAPE_2D_H
-#define POLY_COLLISION_SHAPE_2D_H
+#pragma once
 
 #include "scene/2d/collision_object_2d.h"
 #include "goost/scene/2d/poly_shape_2d.h"
@@ -34,4 +33,3 @@ public:
 	PolyCollisionShape2D();
 };
 
-#endif // POLY_COLLISION_SHAPE_2D_H

--- a/scene/physics/2d/shape_cast_2d.h
+++ b/scene/physics/2d/shape_cast_2d.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_SHAPE_CAST_2D_H
-#define GOOST_SHAPE_CAST_2D_H
+#pragma once
 
 #include "scene/2d/node_2d.h"
 #include "scene/resources/shape_2d.h"
@@ -93,4 +92,3 @@ public:
 	ShapeCast2D() {};
 };
 
-#endif // GOOST_SHAPE_CAST_2D_H

--- a/scene/resources/gradient_texture_2d.h
+++ b/scene/resources/gradient_texture_2d.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_GRADIENT_TEXTURE_2D
-#define GOOST_GRADIENT_TEXTURE_2D
+#pragma once
 
 #include "scene/resources/texture.h"
 
@@ -72,4 +71,3 @@ public:
 VARIANT_ENUM_CAST(GradientTexture2D::Fill);
 VARIANT_ENUM_CAST(GradientTexture2D::Repeat);
 
-#endif

--- a/scene/resources/light_texture.h
+++ b/scene/resources/light_texture.h
@@ -1,5 +1,4 @@
-#ifndef GOOST_LIGHT_TEXTURE
-#define GOOST_LIGHT_TEXTURE
+#pragma once
 
 #include "gradient_texture_2d.h"
 
@@ -9,4 +8,3 @@ class LightTexture : public GradientTexture2D {
 	LightTexture();
 };
 
-#endif // GOOST_LIGHT_TEXTURE


### PR DESCRIPTION
Similar to godotengine/godot#34143, except that this PR is going to be merged (given no issues arise from this change).

I've previously stumbled upon hard to debug issues due to old header include guards even in Goost, so even if Godot didn't decide to do this change, it's better to break the consistency in the interest of robustness.