### PR TITLE
Refactor registration of disabled classes using `ClassDB` alone

### DIFF
--- a/builders.py
+++ b/builders.py
@@ -12,14 +12,12 @@ def make_classes_enabled(target, source, env):
     for c in env["goost_classes_enabled"]:
         h.write("#define GOOST_%s\n" % c)
     h.write("\n")
-    h.write("namespace goost {\n")
     for c in env["goost_classes_disabled"]:
         if c in goost.module_classes:
             # Modules are self-contained just like Goost,
             # we cannot disable individual classes from there.
             continue
-        h.write("template <> void register_class<%s>();\n" % c)
-    h.write("}\n")
+        h.write("template <> void ClassDB::register_class<%s>();\n" % c)
     h.close()
 
     # NOTE: it's not required to generate this file if there are no classes
@@ -29,14 +27,12 @@ def make_classes_enabled(target, source, env):
     cpp.write("// THIS FILE IS GENERATED, DO NOT EDIT!\n\n")
     cpp.write("#include \"classes_enabled.gen.h\"\n")
     cpp.write("\n")
-    cpp.write("namespace goost {\n")
     for c in env["goost_classes_disabled"]:
         if c in goost.module_classes:
             # Modules are self-contained just like Goost,
             # we cannot disable individual classes from there.
             continue
-        cpp.write("template <> void register_class<%s>() {}\n" % c)
-    cpp.write("}\n")
+        cpp.write("template <> void ClassDB::register_class<%s>() {}\n" % c)
     cpp.close()
 
 

--- a/core/image/register_image_types.cpp
+++ b/core/image/register_image_types.cpp
@@ -16,11 +16,11 @@ namespace goost {
 void register_image_types() {
 #ifdef GOOST_GoostImage
 	_goost_image = memnew(_GoostImage);
-	goost::register_class<_GoostImage>();
+	ClassDB::register_class<_GoostImage>();
 	Engine::get_singleton()->add_singleton(Engine::Singleton("GoostImage", _GoostImage::get_singleton()));
 #endif
 #ifdef GOOST_ImageIndexed
-	goost::register_class<ImageIndexed>();
+	ClassDB::register_class<ImageIndexed>();
 
 	image_loader_indexed_png = memnew(ImageLoaderIndexedPNG);
 	ImageLoader::add_image_format_loader(image_loader_indexed_png);
@@ -28,7 +28,7 @@ void register_image_types() {
 	resource_saver_indexed_png.instance();
 	ResourceSaver::add_resource_format_saver(resource_saver_indexed_png);
 #endif
-	goost::register_class<ImageBlender>();
+	ClassDB::register_class<ImageBlender>();
 }
 
 void unregister_image_types() {

--- a/core/math/geometry/register_geometry_types.cpp
+++ b/core/math/geometry/register_geometry_types.cpp
@@ -14,7 +14,7 @@ namespace goost {
 void register_geometry_types() {
 #ifdef GOOST_GoostGeometry2D
 	_goost_geometry_2d = memnew(_GoostGeometry2D);
-	goost::register_class<_GoostGeometry2D>();
+	ClassDB::register_class<_GoostGeometry2D>();
 	Engine::get_singleton()->add_singleton(Engine::Singleton("GoostGeometry2D", _GoostGeometry2D::get_singleton()));
 #endif
 #ifdef GOOST_PolyNode2D
@@ -22,32 +22,32 @@ void register_geometry_types() {
 #endif
 #ifdef GOOST_PolyBoolean2D
 	_poly_boolean_2d.instance();
-	goost::register_class<_PolyBoolean2D>();
+	ClassDB::register_class<_PolyBoolean2D>();
 	Object *poly_boolean_2d = Object::cast_to<Object>(_PolyBoolean2D::get_singleton());
 	Engine::get_singleton()->add_singleton(Engine::Singleton("PolyBoolean2D", poly_boolean_2d));
 #endif
-	goost::register_class<PolyBooleanParameters2D>();
-	goost::register_class<PolyNode2D>();
+	ClassDB::register_class<PolyBooleanParameters2D>();
+	ClassDB::register_class<PolyNode2D>();
 
 #ifdef GOOST_PolyOffset2D
 	_poly_offset_2d.instance();
-	goost::register_class<_PolyOffset2D>();
+	ClassDB::register_class<_PolyOffset2D>();
 	Object *poly_offset_2d = Object::cast_to<Object>(_PolyOffset2D::get_singleton());
 	Engine::get_singleton()->add_singleton(Engine::Singleton("PolyOffset2D", poly_offset_2d));
 #endif
-	goost::register_class<PolyOffsetParameters2D>();
+	ClassDB::register_class<PolyOffsetParameters2D>();
 
 #ifdef GOOST_PolyDecomp2D
 	_poly_decomp_2d.instance();
-	goost::register_class<_PolyDecomp2D>();
+	ClassDB::register_class<_PolyDecomp2D>();
 	Object *poly_decomp_2d = Object::cast_to<Object>(_PolyDecomp2D::get_singleton());
 	Engine::get_singleton()->add_singleton(Engine::Singleton("PolyDecomp2D", poly_decomp_2d));
 #endif
-	goost::register_class<PolyDecompParameters2D>();
+	ClassDB::register_class<PolyDecompParameters2D>();
 
 #ifdef GOOST_Random2D
 	_random_2d.instance();
-	goost::register_class<Random2D>();
+	ClassDB::register_class<Random2D>();
 	Object *random_2d = Object::cast_to<Object>(Random2D::get_singleton());
 	Engine::get_singleton()->add_singleton(Engine::Singleton("Random2D", random_2d));
 #endif

--- a/core/math/register_math_types.cpp
+++ b/core/math/register_math_types.cpp
@@ -10,7 +10,7 @@ namespace goost {
 void register_math_types() {
 #ifdef GOOST_Random
 	_random.instance();
-	goost::register_class<Random>();
+	ClassDB::register_class<Random>();
 	Object *random = Object::cast_to<Object>(Random::get_singleton());
 	Engine::get_singleton()->add_singleton(Engine::Singleton("Random", random));
 #endif

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -26,18 +26,18 @@ static void _variant_resource_preview_init();
 void register_core_types() {
 #ifdef GOOST_GoostEngine
 	_goost = memnew(GoostEngine);
-	goost::register_class<GoostEngine>();
+	ClassDB::register_class<GoostEngine>();
 	Engine::get_singleton()->add_singleton(
 			Engine::Singleton("GoostEngine", GoostEngine::get_singleton()));
 	SceneTree::add_idle_callback(&GoostEngine::flush_calls);
 #endif
-	goost::register_class<InvokeState>();
+	ClassDB::register_class<InvokeState>();
 
-	goost::register_class<ListNode>();
-	goost::register_class<LinkedList>();
+	ClassDB::register_class<ListNode>();
+	ClassDB::register_class<LinkedList>();
 
-	goost::register_class<VariantMap>();
-	goost::register_class<VariantResource>();
+	ClassDB::register_class<VariantMap>();
+	ClassDB::register_class<VariantResource>();
 #if defined(TOOLS_ENABLED) && defined(GOOST_VariantResource)
 	EditorNode::add_init_callback(_variant_resource_preview_init);
 #endif

--- a/goost.h
+++ b/goost.h
@@ -30,11 +30,3 @@
 #include "scene/physics/2d/shape_cast_2d.h"
 #include "scene/resources/gradient_texture_2d.h"
 #include "scene/resources/light_texture.h"
-
-namespace goost {
-template <typename T>
-void register_class() {
-	ClassDB::register_class<T>();
-}
-} // namespace goost
-

--- a/scene/physics/register_physics_types.cpp
+++ b/scene/physics/register_physics_types.cpp
@@ -5,10 +5,10 @@
 namespace goost {
 
 void register_physics_types() {
-	goost::register_class<ShapeCast2D>();
+	ClassDB::register_class<ShapeCast2D>();
 
 #if defined(GOOST_GEOMETRY_ENABLED) && defined(GOOST_PolyNode2D) && defined(GOOST_PolyShape2D)
-	goost::register_class<PolyCollisionShape2D>();
+	ClassDB::register_class<PolyCollisionShape2D>();
 #endif
 }
 

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -7,18 +7,18 @@ namespace goost {
 
 void register_scene_types() {
 #if defined(GOOST_GEOMETRY_ENABLED) && defined(GOOST_PolyNode2D)
-	goost::register_class<PolyCircle2D>();
-	goost::register_class<PolyRectangle2D>();
-	goost::register_class<PolyPath2D>();
-	goost::register_class<PolyShape2D>();
+	ClassDB::register_class<PolyCircle2D>();
+	ClassDB::register_class<PolyRectangle2D>();
+	ClassDB::register_class<PolyPath2D>();
+	ClassDB::register_class<PolyShape2D>();
 #endif
-	goost::register_class<Stopwatch>();
-	goost::register_class<VisualShape2D>();
-	goost::register_class<GradientTexture2D>();
-	goost::register_class<LightTexture>();
+	ClassDB::register_class<Stopwatch>();
+	ClassDB::register_class<VisualShape2D>();
+	ClassDB::register_class<GradientTexture2D>();
+	ClassDB::register_class<LightTexture>();
 
 #ifdef GOOST_GUI_ENABLED
-	goost::register_class<GridRect>();
+	ClassDB::register_class<GridRect>();
 #endif
 
 #if defined(TOOLS_ENABLED) && defined(GOOST_EDITOR_ENABLED)


### PR DESCRIPTION
Makes it consistent with Godot source, slightly simplifies implementation because we no longer have to deal with namespaces.

This change also makes it forward compatible with Godot's own way to disable individual classes in Godot 4.0, which is in development: godotengine/godot#50381. But unlike Godot, Goost have a notion of dependency of classes, individual components, so current mechanism is still necessary to retain in Goost, especially when we have to deal with handling software bloat in the future, so everything must be properly organized and modularized.