### PR TITLE
Fix erase/remove behavior in `LinkedList` and `ListNode`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Converted `PolyBoolean/Offset/Decomp2D` classes into `Resource`s, as needed by `PolyPath2D`.
 - Updated third-party image libraries.
 
+### Removed
+- Redundant and buggy `ListNode.erase()` method. You can safely use `ListNode.free()` regardless of whether a node was instantiated manually or via `LinkedList.push_back()`.
+- No longer relevant `LinkedList.remove(ListNode)` method due to the above.
+
 ### Fixed
 - Crashes with `LinkedList` when dealing with invalid data.
   - `insert_before/after(null, value)` no longer pushes front/back an element.

--- a/core/types/linked_list.h
+++ b/core/types/linked_list.h
@@ -13,13 +13,14 @@ struct ListData {
 	ListNode *first = nullptr;
 	ListNode *last = nullptr;
 	int size_cache = 0;
-	bool erase(ListNode *p_node);
+	bool remove(ListNode *p_node);
 };
 
 class ListNode : public Object {
 	GDCLASS(ListNode, Object);
 
 protected:
+	void _notification(int p_what);
 	static void _bind_methods();
 
 private:
@@ -37,8 +38,6 @@ public:
 
 	Variant get_value() { return value; }
 	void set_value(const Variant &p_value) { value = p_value; }
-
-	void erase();
 
 	virtual String to_string() { return String(value); }
 
@@ -80,7 +79,6 @@ public:
 
 	ListNode *find(const Variant &p_value);
 
-	bool remove(ListNode *p_node);
 	bool erase(const Variant &value);
 	bool empty() const { return !_data || !_data->size_cache; }
 	void clear();

--- a/doc/LinkedList.xml
+++ b/doc/LinkedList.xml
@@ -192,15 +192,6 @@
 				Constructs a new [ListNode] and pushes it at the [i]beginning[/i] of the list.
 			</description>
 		</method>
-		<method name="remove">
-			<return type="bool">
-			</return>
-			<argument index="0" name="node" type="ListNode">
-			</argument>
-			<description>
-				Removes (and deletes) an existing node from the list.
-			</description>
-		</method>
 		<method name="size" qualifiers="const">
 			<return type="int">
 			</return>

--- a/doc/ListNode.xml
+++ b/doc/ListNode.xml
@@ -5,18 +5,11 @@
 	</brief_description>
 	<description>
 		The list node is an elemental building block which represent the entire structure of [LinkedList]s. It has [member next] and [member prev] properties which are assigned whenever a new element is inserted into the list, such as using [method LinkedList.push_back].
-		[b]Warning:[/b] do not use [method Object.free] to remove this node from the list it belongs to (unless it is instantiated manually with [code]ListNode.new()[/code]), call [method erase] instead which allows the list to update neighbor node references as well.
+		You can call [method Object.free] to remove this node from the list it belongs to.
 	</description>
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="erase">
-			<return type="void">
-			</return>
-			<description>
-				Erases this node from the [LinkedList] it originates from.
-			</description>
-		</method>
 	</methods>
 	<members>
 		<member name="next" type="ListNode" setter="" getter="get_next">

--- a/tests/project/goost/core/types/test_linked_list.gd
+++ b/tests/project/goost/core/types/test_linked_list.gd
@@ -163,21 +163,12 @@ func test_erase():
 	assert_false(erased)
 
 
-func test_remove():
-	var nodes = populate_test_data(list)
-	var original_size = nodes.size()
-	var removed = list.remove(list.find("Goost"))
-	assert_true(removed)
-	assert_eq(list.size(), original_size - 1)
-	assert_null(list.find("Goost"))
-
-
 func test_empty():
 	populate_test_data(list)
 	var n: ListNode = list.front
 	while n:
-		var removed = list.remove(n)
-		assert_true(removed)
+		n.free()
+		assert_freed(n, "Freed")
 		n = list.front
 	assert_eq(list.size(), 0)
 
@@ -550,24 +541,20 @@ func test_create_from_dictionary():
 	assert_eq(list.back.get_meta("value"), Color.blue)
 
 
-# TODO: Disabled `ListNode.erase()` tests for now in order to enable address
-# and memory leak sanitizer checks for other test cases in CI.
-# See https://github.com/goostengine/goost/issues/112
-#
-# func test_list_node_erase():
-# 	var nodes = populate_test_data(list)
-# 	assert_not_null(nodes[0])
-# 	assert_not_null(list.find("Goost"))
-# 	nodes[0].erase()
-# 	assert_freed(nodes[0], "List node")
-# 	assert_null(list.find("Goost"))
-#
-#
-# func test_list_node_erase_orphan():
-# 	var n = ListNode.new()
-# 	n.value = "Goost"
-# 	n.erase() # Should not crash.
-# 	assert_freed(n, "List node")
+func test_list_node_free():
+	var nodes = populate_test_data(list)
+	assert_not_null(nodes[0])
+	assert_not_null(list.find("Goost"))
+	nodes[0].free()
+	assert_freed(nodes[0], "List node")
+	assert_null(list.find("Goost"))
+
+
+func test_list_node_free_orphan():
+	var n = ListNode.new()
+	n.value = "Goost"
+	n.free() # Should not crash.
+	assert_freed(n, "List node")
 
 
 # Sorry, this doesn't work, use `ListNode.erase()` instead.


### PR DESCRIPTION
Updating references in `NOTIFICATION_PREDELETE` resolves #112.

Due to this, removed redundant and buggy `ListNode.erase()` method. You can safely use `ListNode.free()` regardless of whether a node was instantiated manually or via `LinkedList.push_back()`.

Removed no longer relevant `LinkedList.remove(ListNode)` method due to the above.