### PR TITLE
Fix `ImageFrames` accepting invalid `Image` when adding frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Moved `PolyCollisionShape2D` class to the `physics` component.
 - Converted `PolyBoolean/Offset/Decomp2D` classes into `Resource`s, as needed by `PolyPath2D`.
 - Updated third-party image libraries.
+- `ImageFrames.add_frame()` no longer accepts index to override existing frames.
 
 ### Removed
 - Redundant and buggy `ListNode.erase()` method. You can safely use `ListNode.free()` regardless of whether a node was instantiated manually or via `LinkedList.push_back()`.

--- a/modules/gif/doc_classes/ImageFrames.xml
+++ b/modules/gif/doc_classes/ImageFrames.xml
@@ -14,9 +14,7 @@
 			</return>
 			<argument index="0" name="image" type="Image">
 			</argument>
-			<argument index="1" name="delay" type="float">
-			</argument>
-			<argument index="2" name="idx" type="int" default="-1">
+			<argument index="1" name="delay" type="float" default="-1">
 			</argument>
 			<description>
 				Adds a new frame.
@@ -39,7 +37,7 @@
 		<method name="get_frame_delay" qualifiers="const">
 			<return type="float">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="index" type="int">
 			</argument>
 			<description>
 				Returns the delay of frame [code]idx[/code].
@@ -48,7 +46,7 @@
 		<method name="get_frame_image" qualifiers="const">
 			<return type="Image">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="index" type="int">
 			</argument>
 			<description>
 				Returns the [Image] of frame [code]idx[/code].
@@ -79,7 +77,7 @@
 		<method name="remove_frame">
 			<return type="void">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="index" type="int">
 			</argument>
 			<description>
 				Removes the frame [code]idx[/code].
@@ -103,7 +101,7 @@
 		<method name="set_frame_delay">
 			<return type="void">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="index" type="int">
 			</argument>
 			<argument index="1" name="delay" type="float">
 			</argument>
@@ -114,7 +112,7 @@
 		<method name="set_frame_image">
 			<return type="void">
 			</return>
-			<argument index="0" name="idx" type="int">
+			<argument index="0" name="index" type="int">
 			</argument>
 			<argument index="1" name="image" type="Image">
 			</argument>

--- a/modules/gif/image_frames.cpp
+++ b/modules/gif/image_frames.cpp
@@ -63,6 +63,7 @@ Error ImageFrames::save_gif(const String &p_filepath, int p_color_count) {
 
 	// Using dimensions of the first image as the base.
 	const Ref<Image> &first = get_frame_image(0);
+	ERR_FAIL_COND_V(first.is_null(), ERR_CANT_CREATE);
 
 	gif->SWidth = first->get_width();
 	gif->SHeight = first->get_height();
@@ -170,45 +171,37 @@ Error ImageFrames::save_gif(const String &p_filepath, int p_color_count) {
 }
 #endif // GOOST_ImageIndexed
 
-void ImageFrames::add_frame(const Ref<Image> &p_image, float p_delay, int p_idx) {
-	ERR_FAIL_COND(p_idx > get_frame_count() - 1);
+void ImageFrames::add_frame(const Ref<Image> &p_image, float p_delay) {
+	ERR_FAIL_COND(p_image.is_null());
+
 	Frame frame;
 	frame.image = p_image;
 	frame.delay = p_delay;
-	if (p_idx < 0) {
-		frames.push_back(frame);
-	} else {
-		frames.set(p_idx, frame);
-	}
+	frames.push_back(frame);
 }
 
 void ImageFrames::remove_frame(int p_idx) {
-	ERR_FAIL_COND(p_idx < 0);
-	ERR_FAIL_COND(p_idx > get_frame_count() - 1);
+	ERR_FAIL_INDEX(p_idx, frames.size());
 	frames.remove(p_idx);
 }
 
 void ImageFrames::set_frame_image(int p_idx, const Ref<Image> &p_image) {
-	ERR_FAIL_COND(p_idx < 0);
-	ERR_FAIL_COND(p_idx > get_frame_count() - 1);
+	ERR_FAIL_INDEX(p_idx, frames.size());
 	frames.write[p_idx].image = p_image;
 }
 
 Ref<Image> ImageFrames::get_frame_image(int p_idx) const {
-	ERR_FAIL_COND_V(p_idx < 0, Ref<Image>());
-	ERR_FAIL_COND_V(p_idx > get_frame_count() - 1, Ref<Image>());
+	ERR_FAIL_INDEX_V(p_idx, frames.size(), Ref<Image>());
 	return frames[p_idx].image;
 }
 
 void ImageFrames::set_frame_delay(int p_idx, float p_delay) {
-	ERR_FAIL_COND(p_idx < 0);
-	ERR_FAIL_COND(p_idx > get_frame_count() - 1);
+	ERR_FAIL_INDEX(p_idx, frames.size());
 	frames.write[p_idx].delay = p_delay;
 }
 
 float ImageFrames::get_frame_delay(int p_idx) const {
-	ERR_FAIL_COND_V(p_idx < 0, 0);
-	ERR_FAIL_COND_V(p_idx > get_frame_count() - 1, 0);
+	ERR_FAIL_INDEX_V(p_idx, frames.size(), 0);
 	return frames[p_idx].delay;
 }
 
@@ -226,14 +219,14 @@ void ImageFrames::_bind_methods() {
 #ifdef GOOST_ImageIndexed
 	ClassDB::bind_method(D_METHOD("save_gif", "filepath", "color_count"), &ImageFrames::save_gif, DEFVAL(256));
 #endif
-	ClassDB::bind_method(D_METHOD("add_frame", "image", "delay", "idx"), &ImageFrames::add_frame, DEFVAL(-1));
-	ClassDB::bind_method(D_METHOD("remove_frame", "idx"), &ImageFrames::remove_frame);
+	ClassDB::bind_method(D_METHOD("add_frame", "image", "delay"), &ImageFrames::add_frame, DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("remove_frame", "index"), &ImageFrames::remove_frame);
 
-	ClassDB::bind_method(D_METHOD("set_frame_image", "idx", "image"), &ImageFrames::set_frame_image);
-	ClassDB::bind_method(D_METHOD("get_frame_image", "idx"), &ImageFrames::get_frame_image);
+	ClassDB::bind_method(D_METHOD("set_frame_image", "index", "image"), &ImageFrames::set_frame_image);
+	ClassDB::bind_method(D_METHOD("get_frame_image", "index"), &ImageFrames::get_frame_image);
 
-	ClassDB::bind_method(D_METHOD("set_frame_delay", "idx", "delay"), &ImageFrames::set_frame_delay);
-	ClassDB::bind_method(D_METHOD("get_frame_delay", "idx"), &ImageFrames::get_frame_delay);
+	ClassDB::bind_method(D_METHOD("set_frame_delay", "index", "delay"), &ImageFrames::set_frame_delay);
+	ClassDB::bind_method(D_METHOD("get_frame_delay", "index"), &ImageFrames::get_frame_delay);
 
 	ClassDB::bind_method(D_METHOD("get_frame_count"), &ImageFrames::get_frame_count);
 

--- a/modules/gif/image_frames.h
+++ b/modules/gif/image_frames.h
@@ -26,7 +26,7 @@ public:
 
 	Error save_gif(const String &p_path, int p_color_count = 256);
 
-	void add_frame(const Ref<Image> &p_image, float p_delay, int p_idx = -1);
+	void add_frame(const Ref<Image> &p_image, float p_delay);
 	void remove_frame(int p_idx);
 
 	void set_frame_image(int p_idx, const Ref<Image> &p_image);

--- a/tests/project/goost/core/image/test_image_frames.gd
+++ b/tests/project/goost/core/image/test_image_frames.gd
@@ -101,4 +101,8 @@ func test_image_frames_invalid_data():
 	frames.load_gif_from_buffer(PoolByteArray([]), -31)
 	assert_eq(frames.get_frame_count(), 0)
 
+	frames = ImageFrames.new()
+	frames.add_frame(null, -46.891228)
+	frames.save_gif("res://out/3857695334", -28)
+
 	Engine.print_error_messages = true


### PR DESCRIPTION
`ImageFrames.add_frame()` no longer accepts index to override existing frames, which could lead to hard to debug errors.

Part of #120.
