### PR TITLE
Fix `CommandLineParser` crash with `find_option()`

### DIFF
--- a/core/command_line_parser.cpp
+++ b/core/command_line_parser.cpp
@@ -695,6 +695,13 @@ Error CommandLineParser::parse(const PoolStringArray &p_args) {
 
 void CommandLineParser::append_option(const Ref<CommandLineOption> &p_option) {
 	ERR_FAIL_COND(p_option.is_null());
+	ERR_FAIL_COND_MSG(p_option->get_names().empty(), "Option does not have any names.");
+
+	const String &opt_name = p_option->get_names()[0];
+	const Ref<CommandLineOption> &existing_option = find_option(opt_name);
+	ERR_FAIL_COND_MSG(existing_option.is_valid(),
+			"Found existing option with the same name which is already added to the parser.");
+
 	_options.push_back(p_option);
 }
 
@@ -708,6 +715,7 @@ Ref<CommandLineOption> CommandLineParser::get_option(int p_idx) const {
 }
 
 void CommandLineParser::set_option(int p_idx, const Ref<CommandLineOption> &p_option) {
+	ERR_FAIL_COND(p_option.is_null());
 	ERR_FAIL_INDEX(p_idx, _options.size());
 	_options.set(p_idx, p_option);
 }
@@ -719,8 +727,10 @@ void CommandLineParser::remove_option(int p_idx) {
 
 Ref<CommandLineOption> CommandLineParser::find_option(const String &p_name) const {
 	for (int i = 0; i < _options.size(); ++i) {
-		if (has_arg(_options[i]->get_names(), p_name)) {
-			return _options[i];
+		const Ref<CommandLineOption> &opt = _options[i];
+		ERR_CONTINUE(opt.is_null());
+		if (has_arg(opt->get_names(), p_name)) {
+			return opt;
 		}
 	}
 	return Ref<CommandLineOption>();
@@ -739,7 +749,7 @@ Ref<CommandLineOption> CommandLineParser::add_option(const String &p_name, const
 	if (!p_allowed_values.empty()) {
 		option->set_allowed_args(p_allowed_values);
 	}
-	_options.push_back(option);
+	append_option(option);
 
 	return option;
 }

--- a/tests/project/goost/core/test_command_line_parser.gd
+++ b/tests/project/goost/core/test_command_line_parser.gd
@@ -58,14 +58,14 @@ func test_parse_multiple_options():
 
 
 func test_same_options():
+    Engine.print_error_messages = false
+
     var _opt
     _opt = cmd.add_option("verbose")
     _opt = cmd.add_option("verbose")
 
-    Engine.print_error_messages = false
-
     var err = cmd.parse(["--verbose=yes"])
-    assert_eq(err, ERR_PARSE_ERROR)
+    assert_eq(err, OK)
 
     Engine.print_error_messages = true
 
@@ -169,7 +169,6 @@ func test_several_positional_options():
     for i in 10:
         args.append("%s.txt" % i)
 
-    print(cmd.get_help_text())
     assert_eq(cmd.parse(args), OK)
 
     for i in 10:
@@ -177,6 +176,14 @@ func test_several_positional_options():
 
     assert_eq(cmd.parse(["0.txt", "1.txt", "--input-2", "2.txt"]), OK)
     assert_eq(cmd.get_value(opts[2]), "2.txt")
+
+
+func test_find_non_existing_option():
+    var _version = cmd.add_version_option()
+    Engine.print_error_messages = false
+    cmd.set_option(0, null)
+    Engine.print_error_messages = true
+    assert_null(cmd.find_option("help"))
 
 
 func add_test_option(arg_count):
@@ -244,10 +251,6 @@ func test_validation():
     opt.required = not required
     assert_eq(cmd.parse([]), ERR_PARSE_ERROR, "Required and have default arguments, should fail.")
     opt.required = required
-
-    cmd.append_option(opt)
-    assert_eq(cmd.parse([]), ERR_PARSE_ERROR, "Same name, should fail.")
-    cmd.remove_option(1)
 
     Engine.print_error_messages = true
 


### PR DESCRIPTION
It was possible to set existing option to `null`, which could cause `find_option()` to crash upon `null` value.

This patch also makes sure that options with the same name are not added.

Bug found via fuzzer 🐛: https://github.com/goostengine/goost-fuzzer/runs/3326725665.