### PR TITLE
Add support for transparency while saving GIFs

### DIFF
--- a/modules/gif/doc/ImageFrames.xml
+++ b/modules/gif/doc/ImageFrames.xml
@@ -76,6 +76,7 @@
 				Frames can have different sizes. Dimensions of the first frame is taken as the base canvas size.
 				Note that GIF animation timing is measured in hundredths of a second, and delay values below [code]0.02[/code] may fallback to [code]1.0[/code] second when rendered on screen, which depends on application displaying such a GIF.
 				This method depends on [ImageIndexed] used to generate image palette required to write GIF files. By default, indexed images will be created from all images in [ImageFrames]. If [ImageFrames] already contains [ImageIndexed], then you must ensure that [ImageIndexed] has color palette already generated with [method ImageIndexed.generate_palette] prior to calling this method.
+				Saving animated image as transparent is also supported, given all frames are provided in [constant Image.FORMAT_RGBA8] format, but note that transparency is not consistently supported across GIF decoders.
 			</description>
 		</method>
 		<method name="set_frame_delay">

--- a/tests/project/goost/core/image/test_image_frames.gd
+++ b/tests/project/goost/core/image/test_image_frames.gd
@@ -37,26 +37,67 @@ func test_save_gif_animated():
 	# Different image sizes are tested here.
 
 	var frame = Image.new()
-	frame.create(90, 90, false, Image.FORMAT_RGBA8)
+	frame.create(90, 90, false, Image.FORMAT_RGB8)
 	frame.fill(Color.white)
 	image_frames.add_frame(frame, 1.0)
 
 	frame = Image.new()
-	frame.create(90, 90, false, Image.FORMAT_RGBA8)
+	frame.create(90, 90, false, Image.FORMAT_RGB8)
 	frame.fill(Color.red)
 	image_frames.add_frame(frame, 1.0)
 
 	frame = Image.new()
-	frame.create(60, 60, false, Image.FORMAT_RGBA8)
+	frame.create(60, 60, false, Image.FORMAT_RGB8)
 	frame.fill(Color.green)
 	image_frames.add_frame(frame, 1.0)
 
 	frame = Image.new()
-	frame.create(30, 30, false, Image.FORMAT_RGBA8)
+	frame.create(30, 30, false, Image.FORMAT_RGB8)
 	frame.fill(Color.blue)
 	image_frames.add_frame(frame, 1.0)
 
 	var err = image_frames.save_gif("res://out/animated.gif")
+	assert_eq(err, OK)
+
+
+func test_save_gif_animated_transparency():
+	var image_frames = ImageFrames.new()
+
+	var a = Image.new()
+	a.create(50, 50, false, Image.FORMAT_RGBA8)
+	a.fill(Color.orange)
+
+	var b = Image.new()
+	b.create(50, 50, false, Image.FORMAT_RGBA8)
+	b.fill(Color.blue)
+
+	var frame_a = Image.new()
+	frame_a.create(100, 100, false, Image.FORMAT_RGBA8)
+	frame_a.blit_rect(a, Rect2(0, 0, 49, 49), Vector2(0, 0))
+	image_frames.add_frame(frame_a, 1.0)
+
+	var frame_b = Image.new()
+	frame_b.create(100, 100, false, Image.FORMAT_RGBA8)
+	frame_b.blit_rect(b, Rect2(0, 0, 50, 50), Vector2(50, 50))
+	image_frames.add_frame(frame_b, 1.0)
+
+	var err = image_frames.save_gif("res://out/animated_transparency.gif")
+	assert_eq(err, OK)
+
+
+func test_save_gif_static_transparency():
+	var image_frames = ImageFrames.new()
+
+	var a = Image.new()
+	a.create(25, 25, false, Image.FORMAT_RGBA8)
+	a.fill(Color.orange)
+
+	var frame_a = Image.new()
+	frame_a.create(100, 100, false, Image.FORMAT_RGBA8)
+	frame_a.blit_rect(a, Rect2(0, 0, 24, 24), Vector2(25, 25))
+	image_frames.add_frame(frame_a, 1.0)
+
+	var err = image_frames.save_gif("res://out/animated_static_transparency.gif")
 	assert_eq(err, OK)
 
 
@@ -67,6 +108,7 @@ func test_save_gif_animated_rotation():
 	for i in 8:
 		var frame = TestUtils.image_load(SAMPLES.icon)
 		GoostImage.rotate(frame, angle, false)
+		frame.convert(Image.FORMAT_RGB8)
 		image_frames.add_frame(frame, 0.02)
 		angle += TAU / 8.0
 


### PR DESCRIPTION
![animated_rotation](https://user-images.githubusercontent.com/17108460/130326191-e9aa1626-4f07-41b1-9d41-b69c9879701c.gif)

---

All you have to do is to add frames in `FORMAT_RGBA8` format to `ImageFrames` before saving with `save_gif()`.

Note that transparency may not be supported in some GIF decoders/renderers.