### PR TITLE
Fix vertices generation order in `GoostGeometry2D.regular_polygon()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Crashes while decomposing empty polygons with `PolyDecomp2D` when using `polypartition` geometry backend.
 - Crash when attempting to load invalid GIF data from buffer using `ImageFrames.load_gif_from_buffer()`.
 - Memory leaks in the image component.
+- Vertex generation order in `GoostGeometry2D.regular_polygon()`.
 
 ## [1.0] - 2021-05-24
 


### PR DESCRIPTION
Makes it "mathematically correct", the first vertex starts at `Vector2.RIGHT` direction. This also removes the need to generate points reverse to fix orientation.

The maximum number of points in `GoostGeometry2D.circle()` is unlimited now. The limit was hardcoded according to Godot's polygon vertex count limit for rendering, but it can be configured in fact (via `rendering/limits` project settings).
