### PR TITLE
Support dictionaries for `Random.choice()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - A `geometry` option/component, which is separate from `math` now.
 - Numerous `GoostEngine` methods to retrieve copyright/license information, such as `get_license_text()`.
 - "About Goost" editor dialog, which lists Goost authors, Goost license, and third-party licenses.
+- Support for `Dictionary` for choosing a random value with `Random.choice()`.
 
 ### Changed
 - Refactor the process of configuring components and classes. You can use `python goost.py config` to configure components and individual classes now.

--- a/core/math/random.cpp
+++ b/core/math/random.cpp
@@ -64,10 +64,10 @@ Color Random::color_rgb(float r_min, float r_max, float g_min, float g_max, floa
 			randf_range(a_min, a_max));
 }
 
-Variant Random::choice(const Variant &p_sequence) {
-	switch (p_sequence.get_type()) {
+Variant Random::choice(const Variant &p_from) {
+	switch (p_from.get_type()) {
 		case Variant::STRING: {
-			String str = p_sequence;
+			String str = p_from;
 			ERR_FAIL_COND_V_MSG(str.empty(), Variant(), "String is empty.");
 			return str.substr(randi() % str.length(), 1); // Not size().
 		} break;
@@ -79,12 +79,17 @@ Variant Random::choice(const Variant &p_sequence) {
 		case Variant::POOL_VECTOR3_ARRAY:
 		case Variant::POOL_COLOR_ARRAY:
 		case Variant::ARRAY: {
-			Array arr = p_sequence;
+			Array arr = p_from;
 			ERR_FAIL_COND_V_MSG(arr.empty(), Variant(), "Array is empty.");
 			return arr[randi() % arr.size()];
 		} break;
+		case Variant::DICTIONARY: {
+			Dictionary dict = p_from;
+			ERR_FAIL_COND_V_MSG(dict.empty(), Variant(), "Dictionary is empty.");
+			return dict.get_value_at_index(randi() % dict.size());
+		} break;
 		default: {
-			ERR_FAIL_V_MSG(Variant(), "Unsupported type: the sequence must be indexable.");
+			ERR_FAIL_V_MSG(Variant(), "Unsupported: the type must be indexable.");
 		}
 	}
 	return Variant();
@@ -120,7 +125,7 @@ void Random::_bind_methods() {
 			&Random::color_rgb, DEFVAL(0.0), DEFVAL(1.0), DEFVAL(0.0), DEFVAL(1.0), DEFVAL(0.0), DEFVAL(1.0), DEFVAL(1.0), DEFVAL(1.0));
 
 	ClassDB::bind_method(D_METHOD("range", "from", "to"), &Random::range);
-	ClassDB::bind_method(D_METHOD("choice", "from_sequence"), &Random::choice);
+	ClassDB::bind_method(D_METHOD("choice", "from"), &Random::choice);
 	ClassDB::bind_method(D_METHOD("shuffle", "array"), &Random::shuffle);
 	ClassDB::bind_method(D_METHOD("decision", "probability"), &Random::decision);
 

--- a/doc/Random.xml
+++ b/doc/Random.xml
@@ -21,9 +21,9 @@
 	<methods>
 		<method name="choice">
 			<return type="Variant" />
-			<argument index="0" name="from_sequence" type="Variant" />
+			<argument index="0" name="from" type="Variant" />
 			<description>
-				Returns a random element from indexable sequence-based types, such as [Array] or [String]. If the sequence is empty, prints an error and returns [code]null[/code].
+				Returns a random element from a container or indexable sequence, such as [Array], [Dictionary], [String]. If container is empty, prints an error and returns [code]null[/code].
 			</description>
 		</method>
 		<method name="color_hsv">

--- a/tests/project/goost/core/math/test_random.gd
+++ b/tests/project/goost/core/math/test_random.gd
@@ -143,8 +143,12 @@ func test_choice():
 	assert_eq(element, "Goost")
 
 	rng.seed = 222
-	var ch = rng.choice("Goost")
-	assert_eq(ch, "G")
+	element = rng.choice("Goost")
+	assert_eq(element, "G")
+
+	rng.seed = 335
+	element = rng.choice({0 : "Godot", 1 : "Goost", 2 : "Godex"})
+	assert_eq(element, "Goost")
 
 	Engine.print_error_messages = false
 


### PR DESCRIPTION
Since `Dictionary` is indexable by key and is a container similarly to `Array`, it makes sense to return a random value from dictionary.