### PR TITLE
Git plugin: Allow to customize path to repository

### DIFF
--- a/modules/git/git_api.h
+++ b/modules/git/git_api.h
@@ -63,5 +63,7 @@ public:
 	};
 	void set_popup_menu(PopupMenu *p_popup) { vcs_popup = p_popup; }
 	PopupMenu *get_popup_menu(PopupMenu *p_popup) { return vcs_popup; }
+	
+	static bool repository_exists();
 };
 

--- a/modules/git/git_common.cpp
+++ b/modules/git/git_common.cpp
@@ -29,7 +29,6 @@ extern "C" int diff_line_callback_function(const git_diff_delta *delta, const gi
 
 	String prefix = "";
 	switch (line->origin) {
-
 		case GIT_DIFF_LINE_DEL_EOFNL:
 		case GIT_DIFF_LINE_DELETION:
 			prefix = "-"; break;
@@ -40,6 +39,7 @@ extern "C" int diff_line_callback_function(const git_diff_delta *delta, const gi
 	}
 
 	String content_str = content;
+	delete[] content;
 
 	Dictionary result;
 	result["content"] = prefix + content_str;


### PR DESCRIPTION
This adds `version_control/git/repository_path` project setting which allows to configure a path to existing Git repository (other than `res://` path, which was a previously hardcoded default).

This is useful in cases when you create prototypes as separate Godot projects, but wish to track changes in main project, or when repository is not initialized directly in Godot project.

The `version_control/git/repository_path` setting supports both relative and absolute paths, but using relative paths is recommended if you work on a project with others.