### PR TITLE
Add `GoostMath` singleton

### DIFF
--- a/core/math/math.cpp
+++ b/core/math/math.cpp
@@ -1,0 +1,70 @@
+#include "math.h"
+
+GoostMath *GoostMath::singleton = nullptr;
+
+bool GoostMath::is_equal_approx(real_t a, real_t b, real_t tolerance) {
+    // Check for exact equality first, required to handle "infinity" values.
+    if (a == b) {
+        return true;
+    }
+    // Then check for approximate equality.
+    return abs(a - b) < tolerance;
+}
+
+bool GoostMath::is_zero_approx(real_t s, real_t tolerance) {
+    return abs(s) < tolerance;
+}
+
+Variant GoostMath::catmull_rom(const Variant &p0, const Variant &p1, const Variant &p2, const Variant &p3, float t) {
+#ifdef DEBUG_ENABLED
+    ERR_FAIL_COND_V(t < 0.0f, Variant());
+    ERR_FAIL_COND_V(t > 1.0f, Variant());
+#endif
+    switch (p0.get_type()) {
+        case Variant::INT:
+        case Variant::REAL: {
+            return goost::catmull_rom(p0.operator real_t(), p1.operator real_t(), p2.operator real_t(), p3.operator real_t(), t);
+        } break;
+        case Variant::VECTOR2: {
+            return goost::catmull_rom(p0.operator Vector2(), p1.operator Vector2(), p2.operator Vector2(), p3.operator Vector2(), t);
+        } break;
+        case Variant::VECTOR3: {
+            return goost::catmull_rom(p0.operator Vector3(), p1.operator Vector3(), p2.operator Vector3(), p3.operator Vector3(), t);
+        } break;
+        default: {
+            ERR_FAIL_V_MSG(Variant(), "Unsupported types.");
+        }
+    }
+    return Variant();
+}
+
+Variant GoostMath::bezier(const Variant &p0, const Variant &p1, const Variant &p2, const Variant &p3, float t) {
+#ifdef DEBUG_ENABLED
+    ERR_FAIL_COND_V(t < 0.0f, Variant());
+    ERR_FAIL_COND_V(t > 1.0f, Variant());
+#endif
+    switch (p0.get_type()) {
+        case Variant::INT:
+        case Variant::REAL: {
+            return goost::bezier(p0.operator real_t(), p1.operator real_t(), p2.operator real_t(), p3.operator real_t(), t);
+        } break;
+        case Variant::VECTOR2: {
+            return goost::bezier(p0.operator Vector2(), p1.operator Vector2(), p2.operator Vector2(), p3.operator Vector2(), t);
+        } break;
+        case Variant::VECTOR3: {
+            return goost::bezier(p0.operator Vector3(), p1.operator Vector3(), p2.operator Vector3(), p3.operator Vector3(), t);
+        } break;
+        default: {
+            ERR_FAIL_V_MSG(Variant(), "Unsupported types.");
+        }
+    }
+    return Variant();
+}
+
+void GoostMath::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("is_equal_approx", "a", "b", "tolerance"), &GoostMath::is_equal_approx, DEFVAL(GOOST_CMP_EPSILON));
+	ClassDB::bind_method(D_METHOD("is_zero_approx", "s", "tolerance"), &GoostMath::is_zero_approx, DEFVAL(GOOST_CMP_EPSILON));
+
+    ClassDB::bind_method(D_METHOD("catmull_rom", "ac", "a", "b", "bc", "weight"), &GoostMath::catmull_rom);
+    ClassDB::bind_method(D_METHOD("bezier", "a", "ac", "bc", "b", "weight"), &GoostMath::bezier);
+}

--- a/core/math/math.h
+++ b/core/math/math.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "core/object.h"
+
+#define GOOST_CMP_EPSILON 0.000001
+
+class GoostMath : public Object {
+	GDCLASS(GoostMath, Object);
+
+private:
+	static GoostMath *singleton;
+
+protected:
+	static void _bind_methods();
+
+public:
+	static GoostMath *get_singleton() { return singleton; }
+
+    bool is_equal_approx(real_t a, real_t b, real_t tolerance = GOOST_CMP_EPSILON);
+    bool is_zero_approx(real_t s, real_t tolerance = GOOST_CMP_EPSILON);
+
+	Variant catmull_rom(const Variant &p0, const Variant &p1, const Variant &p2, const Variant &p3, float t);
+	Variant bezier(const Variant &p0, const Variant &p1, const Variant &p2, const Variant &p3, float t);
+
+	GoostMath() {
+		ERR_FAIL_COND_MSG(singleton != nullptr, "Singleton already exists");
+		singleton = this;
+	}
+};
+
+namespace goost {
+
+template <class T>
+T catmull_rom(const T &p0, const T &p1, const T &p2, const T &p3, float t) {
+	float t2 = t * t;
+	float t3 = t2 * t;
+
+	return 0.5f * ((2.0f * p1) + (-p0 + p2) * t + (2.0f * p0 - 5.0f * p1 + 4 * p2 - p3) * t2 + (-p0 + 3.0f * p1 - 3.0f * p2 + p3) * t3);
+}
+
+template <class T>
+T bezier(T start, T control_1, T control_2, T end, float t) {
+	real_t it = (1.0 - t);
+	real_t it2 = it * it;
+	real_t it3 = it2 * it;
+	real_t t2 = t * t;
+	real_t t3 = t2 * t;
+
+	return start * it3 + control_1 * it2 * t * 3.0 + control_2 * it * t2 * 3.0 + end * t3;
+}
+
+} // namespace goost

--- a/core/math/register_math_types.cpp
+++ b/core/math/register_math_types.cpp
@@ -1,13 +1,22 @@
 #include "register_math_types.h"
 
 #include "geometry/register_geometry_types.h"
-#include "goost/classes_enabled.gen.h"
+#include "math.h"
+#include "random.h"
 
-static Ref<Random> _random;
+#include "goost/classes_enabled.gen.h"
 
 namespace goost {
 
+static Ref<Random> _random;
+static GoostMath *_math = nullptr;
+
 void register_math_types() {
+#ifdef GOOST_GoostMath
+	_math = memnew(GoostMath);
+	ClassDB::register_class<GoostMath>();
+	Engine::get_singleton()->add_singleton(Engine::Singleton("GoostMath", GoostMath::get_singleton()));
+#endif
 #ifdef GOOST_Random
 	_random.instance();
 	ClassDB::register_class<Random>();
@@ -21,10 +30,14 @@ void register_math_types() {
 }
 
 void unregister_math_types() {
+#ifdef GOOST_GoostMath
+	if (_math) {
+		memdelete(_math);
+	}
+#endif
 #ifdef GOOST_Random
 	_random.unref();
 #endif
-
 #ifdef GOOST_GEOMETRY_ENABLED
 	goost::unregister_geometry_types();
 #endif

--- a/doc/GoostMath.xml
+++ b/doc/GoostMath.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GoostMath" inherits="Object" version="3.4">
+	<brief_description>
+		Math functions.
+	</brief_description>
+	<description>
+		The singleton which provides various math functions such as interpolation.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="bezier">
+			<return type="Variant" />
+			<argument index="0" name="a" type="Variant" />
+			<argument index="1" name="ac" type="Variant" />
+			<argument index="2" name="bc" type="Variant" />
+			<argument index="3" name="b" type="Variant" />
+			<argument index="4" name="weight" type="float" />
+			<description>
+				Interpolates a cubic Bézier curve between the four control points [code]a[/code], [code]ac[/code], [code]bc[/code], [code]b[/code]. Points [code]ac[/code] and [code]bc[/code] provide directional information, and the distance between these points determines how fast the curve moves towards [code]ac[/code] before turning towards [code]bc[/code].
+				The following types are supported: [float], [Vector2], [Vector3].
+			</description>
+		</method>
+		<method name="catmull_rom">
+			<return type="Variant" />
+			<argument index="0" name="ac" type="Variant" />
+			<argument index="1" name="a" type="Variant" />
+			<argument index="2" name="b" type="Variant" />
+			<argument index="3" name="bc" type="Variant" />
+			<argument index="4" name="weight" type="float" />
+			<description>
+				Interpolates a centripetal Catmull–Rom spline between the four control points [code]ac[/code], [code]a[/code], [code]b[/code], [code]bc[/code].  Points [code]ac[/code] and [code]bc[/code] provide directional information, and the interpolated values lie between [code]a[/code] and [code]b[/code] points.
+				The following types are supported: [float], [Vector2], [Vector3].
+			</description>
+		</method>
+		<method name="is_equal_approx">
+			<return type="bool" />
+			<argument index="0" name="a" type="float" />
+			<argument index="1" name="b" type="float" />
+			<argument index="2" name="tolerance" type="float" default="1e-06" />
+			<description>
+				Returns [code]true[/code] if [code]a[/code] and [code]b[/code] are approximately equal to each other.
+				Here, approximately equal means that [code]a[/code] and [code]b[/code] are within [code]tolerance[/code] of each other.
+				Infinity values of the same sign are considered equal.
+			</description>
+		</method>
+		<method name="is_zero_approx">
+			<return type="bool" />
+			<argument index="0" name="s" type="float" />
+			<argument index="1" name="tolerance" type="float" default="1e-06" />
+			<description>
+				Returns [code]true[/code] if [code]s[/code] is zero or almost zero.
+				This method is faster than using [method is_equal_approx] with one value as zero.
+			</description>
+		</method>
+	</methods>
+	<constants>
+	</constants>
+</class>

--- a/goost.py
+++ b/goost.py
@@ -21,6 +21,7 @@ website = "https://goostengine.github.io/"
 components = [
     "core/script",
     "core/image",
+    "core/math",
     "core/math/geometry",
     "scene/physics",
     "scene/gui",
@@ -31,6 +32,7 @@ def get_component_readable_name(component):
     name = {
         "script": "Scripting",
         "image": "Image Processing",
+        "math": "Mathematics",
         "geometry": "Geometry",
         "physics": "Physics",
         "gui": "User Interface",
@@ -151,6 +153,7 @@ classes = {
     "CommandLineOption": "core",
 	"CommandLineParser": "core",
     "GoostEngine": "core",
+    "GoostMath": "math",
     "GoostGeometry2D": "geometry",
     "GoostImage": "image",
     "GradientTexture2D": "scene",

--- a/tests/project/goost/core/math/test_math.gd
+++ b/tests/project/goost/core/math/test_math.gd
@@ -1,0 +1,19 @@
+extends "res://addons/gut/test.gd"
+
+
+func test_is_equal_approx():
+	assert_true(GoostMath.is_equal_approx(0.05, 0.050001))
+	
+
+func test_is_zero_approx():
+	assert_true(GoostMath.is_zero_approx(0.0000001))
+
+
+func test_catmull_rom():
+	var r = GoostMath.catmull_rom(0, 1, 2, 3, 0.5)
+	assert_eq(r, 1.5)
+
+
+func test_bezier():
+	var r = GoostMath.bezier(10, 0.1, -0.1, 20, 0.5)
+	assert_eq(r, 3.75)


### PR DESCRIPTION
This will be the home for math functions in Goost, see #151.

Implemented Bezier interpolation:

![image](https://user-images.githubusercontent.com/17108460/143482108-c05a6730-f040-4a4c-b0a7-12d2093f3970.png)

and Catmull-Rom interpolation functions which is similar to #77.

Both support `float`, `Vector2` and `Vector3`.

Added `is_equal_approx()` and `is_zero_approx()` with configurable tolerance which is impossible to configure in Godot's `is_equal_approx()`. `CMP_EPSILON` is not exposed either, see godotengine/godot-proposals#3565, unfortunately there's no way to bind float-based constants even via modules.