### PR TITLE
Add `is_between()` method

### DIFF
--- a/core/math/math.cpp
+++ b/core/math/math.cpp
@@ -3,68 +3,76 @@
 GoostMath *GoostMath::singleton = nullptr;
 
 bool GoostMath::is_equal_approx(real_t a, real_t b, real_t tolerance) {
-    // Check for exact equality first, required to handle "infinity" values.
-    if (a == b) {
-        return true;
-    }
-    // Then check for approximate equality.
-    return abs(a - b) < tolerance;
+	// Check for exact equality first, required to handle "infinity" values.
+	if (a == b) {
+		return true;
+	}
+	// Then check for approximate equality.
+	return abs(a - b) < tolerance;
 }
 
 bool GoostMath::is_zero_approx(real_t s, real_t tolerance) {
-    return abs(s) < tolerance;
+	return abs(s) < tolerance;
+}
+
+bool GoostMath::is_between(real_t s, real_t a, real_t b) {
+	if (a > b) {
+		SWAP(a, b);
+	}
+	return s >= a && s <= b;
 }
 
 Variant GoostMath::catmull_rom(const Variant &p0, const Variant &p1, const Variant &p2, const Variant &p3, float t) {
 #ifdef DEBUG_ENABLED
-    ERR_FAIL_COND_V(t < 0.0f, Variant());
-    ERR_FAIL_COND_V(t > 1.0f, Variant());
+	ERR_FAIL_COND_V(t < 0.0f, Variant());
+	ERR_FAIL_COND_V(t > 1.0f, Variant());
 #endif
-    switch (p0.get_type()) {
-        case Variant::INT:
-        case Variant::REAL: {
-            return goost::math::catmull_rom(p0.operator real_t(), p1.operator real_t(), p2.operator real_t(), p3.operator real_t(), t);
-        } break;
-        case Variant::VECTOR2: {
-            return goost::math::catmull_rom(p0.operator Vector2(), p1.operator Vector2(), p2.operator Vector2(), p3.operator Vector2(), t);
-        } break;
-        case Variant::VECTOR3: {
-            return goost::math::catmull_rom(p0.operator Vector3(), p1.operator Vector3(), p2.operator Vector3(), p3.operator Vector3(), t);
-        } break;
-        default: {
-            ERR_FAIL_V_MSG(Variant(), "Unsupported types.");
-        }
-    }
-    return Variant();
+	switch (p0.get_type()) {
+		case Variant::INT:
+		case Variant::REAL: {
+			return goost::math::catmull_rom(p0.operator real_t(), p1.operator real_t(), p2.operator real_t(), p3.operator real_t(), t);
+		} break;
+		case Variant::VECTOR2: {
+			return goost::math::catmull_rom(p0.operator Vector2(), p1.operator Vector2(), p2.operator Vector2(), p3.operator Vector2(), t);
+		} break;
+		case Variant::VECTOR3: {
+			return goost::math::catmull_rom(p0.operator Vector3(), p1.operator Vector3(), p2.operator Vector3(), p3.operator Vector3(), t);
+		} break;
+		default: {
+			ERR_FAIL_V_MSG(Variant(), "Unsupported types.");
+		}
+	}
+	return Variant();
 }
 
 Variant GoostMath::bezier(const Variant &p0, const Variant &p1, const Variant &p2, const Variant &p3, float t) {
 #ifdef DEBUG_ENABLED
-    ERR_FAIL_COND_V(t < 0.0f, Variant());
-    ERR_FAIL_COND_V(t > 1.0f, Variant());
+	ERR_FAIL_COND_V(t < 0.0f, Variant());
+	ERR_FAIL_COND_V(t > 1.0f, Variant());
 #endif
-    switch (p0.get_type()) {
-        case Variant::INT:
-        case Variant::REAL: {
-            return goost::math::bezier(p0.operator real_t(), p1.operator real_t(), p2.operator real_t(), p3.operator real_t(), t);
-        } break;
-        case Variant::VECTOR2: {
-            return goost::math::bezier(p0.operator Vector2(), p1.operator Vector2(), p2.operator Vector2(), p3.operator Vector2(), t);
-        } break;
-        case Variant::VECTOR3: {
-            return goost::math::bezier(p0.operator Vector3(), p1.operator Vector3(), p2.operator Vector3(), p3.operator Vector3(), t);
-        } break;
-        default: {
-            ERR_FAIL_V_MSG(Variant(), "Unsupported types.");
-        }
-    }
-    return Variant();
+	switch (p0.get_type()) {
+		case Variant::INT:
+		case Variant::REAL: {
+			return goost::math::bezier(p0.operator real_t(), p1.operator real_t(), p2.operator real_t(), p3.operator real_t(), t);
+		} break;
+		case Variant::VECTOR2: {
+			return goost::math::bezier(p0.operator Vector2(), p1.operator Vector2(), p2.operator Vector2(), p3.operator Vector2(), t);
+		} break;
+		case Variant::VECTOR3: {
+			return goost::math::bezier(p0.operator Vector3(), p1.operator Vector3(), p2.operator Vector3(), p3.operator Vector3(), t);
+		} break;
+		default: {
+			ERR_FAIL_V_MSG(Variant(), "Unsupported types.");
+		}
+	}
+	return Variant();
 }
 
 void GoostMath::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_equal_approx", "a", "b", "tolerance"), &GoostMath::is_equal_approx, DEFVAL(GOOST_CMP_EPSILON));
 	ClassDB::bind_method(D_METHOD("is_zero_approx", "s", "tolerance"), &GoostMath::is_zero_approx, DEFVAL(GOOST_CMP_EPSILON));
+	ClassDB::bind_method(D_METHOD("is_between", "s", "a", "b"), &GoostMath::is_between);
 
-    ClassDB::bind_method(D_METHOD("catmull_rom", "ac", "a", "b", "bc", "weight"), &GoostMath::catmull_rom);
-    ClassDB::bind_method(D_METHOD("bezier", "a", "ac", "bc", "b", "weight"), &GoostMath::bezier);
+	ClassDB::bind_method(D_METHOD("catmull_rom", "ac", "a", "b", "bc", "weight"), &GoostMath::catmull_rom);
+	ClassDB::bind_method(D_METHOD("bezier", "a", "ac", "bc", "b", "weight"), &GoostMath::bezier);
 }

--- a/core/math/math.h
+++ b/core/math/math.h
@@ -16,8 +16,9 @@ protected:
 public:
 	static GoostMath *get_singleton() { return singleton; }
 
-    bool is_equal_approx(real_t a, real_t b, real_t tolerance = GOOST_CMP_EPSILON);
-    bool is_zero_approx(real_t s, real_t tolerance = GOOST_CMP_EPSILON);
+	bool is_equal_approx(real_t a, real_t b, real_t tolerance = GOOST_CMP_EPSILON);
+	bool is_zero_approx(real_t s, real_t tolerance = GOOST_CMP_EPSILON);
+	bool is_between(real_t s, real_t a, real_t b);
 
 	Variant catmull_rom(const Variant &p0, const Variant &p1, const Variant &p2, const Variant &p3, float t);
 	Variant bezier(const Variant &p0, const Variant &p1, const Variant &p2, const Variant &p3, float t);

--- a/doc/GoostMath.xml
+++ b/doc/GoostMath.xml
@@ -33,6 +33,16 @@
 				The following types are supported: [float], [Vector2], [Vector3].
 			</description>
 		</method>
+		<method name="is_between">
+			<return type="bool" />
+			<argument index="0" name="s" type="float" />
+			<argument index="1" name="a" type="float" />
+			<argument index="2" name="b" type="float" />
+			<description>
+				Returns [code]true[/code] if [code]s[/code] lies between [code]a[/code] and [code]b[/code] values. Here, "between" means that [code]s[/code] lies within the range of [code][a, b][/code] [b]or[/b] [code][b, a][/code] ranges, so [code]a[/code] and [code]b[/code] should not be seen as min and max values, but rather as two extremes of the range.
+				Values are compared using non-strict inequality. If [code]a[/code] and [code]b[/code] are the same, then [code]s[/code] will still return [code]true[/code] if [code]s[/code] equals to [code]a[/code] and [code]b[/code].
+			</description>
+		</method>
 		<method name="is_equal_approx">
 			<return type="bool" />
 			<argument index="0" name="a" type="float" />

--- a/tests/project/goost/core/math/test_math.gd
+++ b/tests/project/goost/core/math/test_math.gd
@@ -9,6 +9,19 @@ func test_is_zero_approx():
 	assert_true(GoostMath.is_zero_approx(0.0000001))
 
 
+func test_is_between():
+	var s = 37
+
+	assert_true(GoostMath.is_between(s, 0, 100))
+	assert_true(GoostMath.is_between(s, -100, 100), "Must handle negative values.")
+	assert_true(GoostMath.is_between(s, 100, -100), "Min and max values should be determined automatically.")
+
+	assert_false(GoostMath.is_between(s, 0, 10))
+	assert_false(GoostMath.is_between(s, 10, 0), "Min and max values should be determined automatically.")
+
+	assert_true(GoostMath.is_between(s, 37, 37), "If a and b are the same, then s should be considered in range.")
+
+
 func test_catmull_rom():
 	var r = GoostMath.catmull_rom(0, 1, 2, 3, 0.5)
 	assert_eq(r, 1.5)


### PR DESCRIPTION
Closes godotengine/godot#31639.

1. Removes the need to use `x >= a and x <= b`, so improves readability and/or usability.
2. Will work the same both for  `a > b` or `b > a`, so this makes comparisons work regardless of order, in cases where you cannot be sure which value is min or max.