### PR TITLE
Add logarithmic functions

### DIFF
--- a/core/math/math.cpp
+++ b/core/math/math.cpp
@@ -22,6 +22,16 @@ bool GoostMath::is_between(real_t s, real_t a, real_t b) {
 	return s >= a && s <= b;
 }
 
+real_t GoostMath::log(real_t x, real_t base) {
+	if (base == 1.0) {
+		return NAN;
+	}
+	if (x != 1.0 && (base == 0.0 || Math::is_inf(base))) {
+		return NAN;
+	}
+	return Math::log(x) / Math::log(base);
+}
+
 Variant GoostMath::catmull_rom(const Variant &p0, const Variant &p1, const Variant &p2, const Variant &p3, float t) {
 #ifdef DEBUG_ENABLED
 	ERR_FAIL_COND_V(t < 0.0f, Variant());
@@ -72,6 +82,10 @@ void GoostMath::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_equal_approx", "a", "b", "tolerance"), &GoostMath::is_equal_approx, DEFVAL(GOOST_CMP_EPSILON));
 	ClassDB::bind_method(D_METHOD("is_zero_approx", "s", "tolerance"), &GoostMath::is_zero_approx, DEFVAL(GOOST_CMP_EPSILON));
 	ClassDB::bind_method(D_METHOD("is_between", "s", "a", "b"), &GoostMath::is_between);
+
+	ClassDB::bind_method(D_METHOD("log", "x", "base"), &GoostMath::log, DEFVAL(Math_E));
+	ClassDB::bind_method(D_METHOD("log2", "x"), &GoostMath::log2);
+	ClassDB::bind_method(D_METHOD("log10", "x"), &GoostMath::log10);
 
 	ClassDB::bind_method(D_METHOD("catmull_rom", "ac", "a", "b", "bc", "weight"), &GoostMath::catmull_rom);
 	ClassDB::bind_method(D_METHOD("bezier", "a", "ac", "bc", "b", "weight"), &GoostMath::bezier);

--- a/core/math/math.h
+++ b/core/math/math.h
@@ -20,6 +20,10 @@ public:
 	bool is_zero_approx(real_t s, real_t tolerance = GOOST_CMP_EPSILON);
 	bool is_between(real_t s, real_t a, real_t b);
 
+	real_t log(real_t x, real_t base = Math_E);
+	real_t log2(real_t x) { return ::log2(x); }
+	real_t log10(real_t x) { return ::log10(x); }
+
 	Variant catmull_rom(const Variant &p0, const Variant &p1, const Variant &p2, const Variant &p3, float t);
 	Variant bezier(const Variant &p0, const Variant &p1, const Variant &p2, const Variant &p3, float t);
 

--- a/doc/GoostMath.xml
+++ b/doc/GoostMath.xml
@@ -4,7 +4,7 @@
 		Math functions.
 	</brief_description>
 	<description>
-		The singleton which provides various math functions such as interpolation.
+		The singleton which provides various mathematical functions.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -61,6 +61,28 @@
 			<description>
 				Returns [code]true[/code] if [code]s[/code] is zero or almost zero.
 				This method is faster than using [method is_equal_approx] with one value as zero.
+			</description>
+		</method>
+		<method name="log">
+			<return type="float" />
+			<argument index="0" name="x" type="float" />
+			<argument index="1" name="base" type="float" default="2.71828" />
+			<description>
+				Computes logarithm of [code]x[/code] with arbitrary base. If [code]base[/code] is not specified, returns natural logarithm of [code]x[/code].
+			</description>
+		</method>
+		<method name="log10">
+			<return type="float" />
+			<argument index="0" name="x" type="float" />
+			<description>
+				Computes common logarithm of [code]x[/code].
+			</description>
+		</method>
+		<method name="log2">
+			<return type="float" />
+			<argument index="0" name="x" type="float" />
+			<description>
+				Computes binary logarithm of [code]x[/code].
 			</description>
 		</method>
 	</methods>

--- a/tests/project/goost/core/math/test_math.gd
+++ b/tests/project/goost/core/math/test_math.gd
@@ -22,6 +22,16 @@ func test_is_between():
 	assert_true(GoostMath.is_between(s, 37, 37), "If a and b are the same, then s should be considered in range.")
 
 
+func test_log():
+	assert_almost_eq(GoostMath.log(0.99, 0.9), 0.095389964549, 0.000001)
+	assert_almost_eq(GoostMath.log(10), 2.302585092994046, 0.000001, "ln(10)")
+	assert_true(is_nan(GoostMath.log(-1, 10)))
+	assert_true(is_nan(GoostMath.log(-1, 10)))
+
+	assert_eq(GoostMath.log2(16), 4.0)
+	assert_eq(GoostMath.log10(1000), 3.0)
+
+
 func test_catmull_rom():
 	var r = GoostMath.catmull_rom(0, 1, 2, 3, 0.5)
 	assert_eq(r, 1.5)


### PR DESCRIPTION
Adds `log2`, `log10`, and `log` with ability to compute logarithm with arbitrary base.

For instance, I've come up with a way to calculate number of trials in order to achieve some success rate for some probability event via script, which requires finding `x` in:
* `1 - (1 - p)^x`:

```gdscript
func trials_until_success(event_probability, success_rate = 0.99):
    return GoostMath.log(1.0 - success_rate, 1.0 - event_probability)
```

