### PR TITLE
Add `is_in_range()` function

### DIFF
--- a/core/math/math.cpp
+++ b/core/math/math.cpp
@@ -22,6 +22,11 @@ bool GoostMath::is_between(real_t s, real_t a, real_t b) {
 	return s >= a && s <= b;
 }
 
+bool GoostMath::is_in_range(real_t s, real_t min, real_t max) {
+	ERR_FAIL_COND_V_MSG(min > max, false, "Invalid range");
+	return s >= min && s <= max;
+}
+
 real_t GoostMath::log(real_t x, real_t base) {
 	if (base == 1.0) {
 		return NAN;
@@ -81,7 +86,9 @@ Variant GoostMath::bezier(const Variant &p0, const Variant &p1, const Variant &p
 void GoostMath::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_equal_approx", "a", "b", "tolerance"), &GoostMath::is_equal_approx, DEFVAL(GOOST_CMP_EPSILON));
 	ClassDB::bind_method(D_METHOD("is_zero_approx", "s", "tolerance"), &GoostMath::is_zero_approx, DEFVAL(GOOST_CMP_EPSILON));
+
 	ClassDB::bind_method(D_METHOD("is_between", "s", "a", "b"), &GoostMath::is_between);
+	ClassDB::bind_method(D_METHOD("is_in_range", "s", "min", "max"), &GoostMath::is_in_range);
 
 	ClassDB::bind_method(D_METHOD("log", "x", "base"), &GoostMath::log, DEFVAL(Math_E));
 	ClassDB::bind_method(D_METHOD("log2", "x"), &GoostMath::log2);

--- a/core/math/math.h
+++ b/core/math/math.h
@@ -18,7 +18,9 @@ public:
 
 	bool is_equal_approx(real_t a, real_t b, real_t tolerance = GOOST_CMP_EPSILON);
 	bool is_zero_approx(real_t s, real_t tolerance = GOOST_CMP_EPSILON);
+
 	bool is_between(real_t s, real_t a, real_t b);
+	bool is_in_range(real_t s, real_t min, real_t max);
 
 	real_t log(real_t x, real_t base = Math_E);
 	real_t log2(real_t x) { return ::log2(x); }

--- a/doc/GoostMath.xml
+++ b/doc/GoostMath.xml
@@ -39,7 +39,7 @@
 			<argument index="1" name="a" type="float" />
 			<argument index="2" name="b" type="float" />
 			<description>
-				Returns [code]true[/code] if [code]s[/code] lies between [code]a[/code] and [code]b[/code] values. Here, "between" means that [code]s[/code] lies within the range of [code][a, b][/code] [b]or[/b] [code][b, a][/code] ranges, so [code]a[/code] and [code]b[/code] should not be seen as min and max values, but rather as two extremes of the range.
+				Returns [code]true[/code] if [code]s[/code] lies between [code]a[/code] and [code]b[/code] values. Here, "between" means that [code]s[/code] lies within the range of [code][a, b][/code] [b]or[/b] [code][b, a][/code] ranges, so [code]a[/code] and [code]b[/code] should not be seen as min and max values, but rather as two extremes of the range. To prevent this, use [method is_in_range] instead.
 				Values are compared using non-strict inequality. If [code]a[/code] and [code]b[/code] are the same, then [code]s[/code] will still return [code]true[/code] if [code]s[/code] equals to [code]a[/code] and [code]b[/code].
 			</description>
 		</method>
@@ -52,6 +52,16 @@
 				Returns [code]true[/code] if [code]a[/code] and [code]b[/code] are approximately equal to each other.
 				Here, approximately equal means that [code]a[/code] and [code]b[/code] are within [code]tolerance[/code] of each other.
 				Infinity values of the same sign are considered equal.
+			</description>
+		</method>
+		<method name="is_in_range">
+			<return type="bool" />
+			<argument index="0" name="s" type="float" />
+			<argument index="1" name="min" type="float" />
+			<argument index="2" name="max" type="float" />
+			<description>
+				Returns [code]true[/code] if [code]s[/code] is in the range of [code]min[/code] and [code]max[/code] values. If [code]min > max[/code], the range is considered invalid and an error is printed. To prevent this, use [method is_between] instead.
+				Values are compared using non-strict inequality. If [code]min[/code] and [code]max[/code] are the same, then [code]s[/code] will still return [code]true[/code] if [code]s[/code] equals to [code]min[/code] and [code]max[/code].
 			</description>
 		</method>
 		<method name="is_zero_approx">

--- a/tests/project/goost/core/math/test_math.gd
+++ b/tests/project/goost/core/math/test_math.gd
@@ -19,7 +19,21 @@ func test_is_between():
 	assert_false(GoostMath.is_between(s, 0, 10))
 	assert_false(GoostMath.is_between(s, 10, 0), "Min and max values should be determined automatically.")
 
-	assert_true(GoostMath.is_between(s, 37, 37), "If a and b are the same, then s should be considered in range.")
+	assert_true(GoostMath.is_between(s, 37, 37), "If a and b are the same, then `s` should be considered in range.")
+
+
+func test_is_in_range():
+	var s = 37
+
+	assert_true(GoostMath.is_in_range(s, 0, 100))
+	assert_true(GoostMath.is_in_range(s, -100, 100), "Must handle negative values.")
+
+	Engine.print_error_messages = false
+	assert_false(GoostMath.is_in_range(s, 100, -100), "Invalid range should be detected.")
+	Engine.print_error_messages = true
+
+	assert_false(GoostMath.is_in_range(s, 0, 10))
+	assert_true(GoostMath.is_in_range(s, 37, 37), "If `min` and `max` are the same, then `s` should be considered in range.")
 
 
 func test_log():


### PR DESCRIPTION
Allows to check whether a value is in the range of min and max values, and unlike `is_between()`, will print an error if the range is invalid (when `min > max`).

Complements #154.

See also rationale in https://github.com/godotengine/godot-proposals/issues/889#issuecomment-980580919.

