### PR TITLE
Clear `Debug2D` canvas when switching scenes in the editor

### DIFF
--- a/SCsub
+++ b/SCsub
@@ -52,7 +52,7 @@ env_goost.Prepend(CPPDEFINES={"SCALE_FACTOR" : env["goost_scale_factor"]})
 # modifying each and every SCSub file, making it work everywhere in Goost.
 godot_add_source_files = env_goost.__class__.add_source_files
 
-def goost_add_source_files(self, sources, files, warn_duplicates=True):
+def goost_add_source_files(self, sources, files):
     from compat import isbasestring
     # Convert string to list of absolute paths (including expanding wildcard)
     if isbasestring(files):
@@ -63,8 +63,13 @@ def goost_add_source_files(self, sources, files, warn_duplicates=True):
                 return
             files = [files]
         else:
+            # Exclude .gen.cpp files from globbing, to avoid including obsolete ones.
+            # They should instead be added manually.
+            skip_gen_cpp = "*" in files
             dir_path = self.Dir(".").abspath
             files = sorted(glob.glob(dir_path + "/" + files))
+            if skip_gen_cpp:
+                files = [f for f in files if not f.endswith(".gen.cpp")]
     # Flatten.
     _files = []
     for path in files:
@@ -94,10 +99,8 @@ def goost_add_source_files(self, sources, files, warn_duplicates=True):
             continue
         obj = self.Object(path)
         if obj in sources:
-            if warn_duplicates:
-                print('WARNING: Object "{}" already included in environment sources.'.format(obj))
-            else:
-                continue
+            print('WARNING: Object "{}" already included in environment sources.'.format(obj))
+            continue
         sources.append(obj)
 
 # Inject now!
@@ -117,7 +120,8 @@ if env["goost_editor_enabled"]:
 
 SConscript("thirdparty/SCsub")
 
-env_goost.add_source_files(env.modules_sources, "*.cpp")
+env_goost.add_source_files(env.modules_sources, "register_types.cpp")
+env_goost.add_source_files(env.modules_sources, "classes_enabled.gen.cpp")
 
 # Restore the method back (not sure if needed, but good for consistency).
 env_goost.__class__.add_source_files = godot_add_source_files

--- a/editor/goost_editor_plugin.cpp
+++ b/editor/goost_editor_plugin.cpp
@@ -1,7 +1,6 @@
 #include "goost_editor_plugin.h"
 
 #include "scene/2d/debug_2d.h"
-
 #include "goost/classes_enabled.gen.h"
 
 void GoostEditorPlugin::_bind_methods() {
@@ -9,7 +8,7 @@ void GoostEditorPlugin::_bind_methods() {
 }
 
 void GoostEditorPlugin::_on_editor_scene_changed(Node *p_scene_root) {
-#if defined(GOOST_GEOMETRY_ENABLED) && defined(GOOST_Debug2D)
+#if defined(GOOST_SCENE_ENABLED) && defined(GOOST_GEOMETRY_ENABLED) && defined(GOOST_Debug2D)
     if (Debug2D::get_singleton()) {
         Debug2D::get_singleton()->clear();
     }

--- a/editor/goost_editor_plugin.cpp
+++ b/editor/goost_editor_plugin.cpp
@@ -1,0 +1,22 @@
+#include "goost_editor_plugin.h"
+
+#include "scene/2d/debug_2d.h"
+
+#include "goost/classes_enabled.gen.h"
+
+void GoostEditorPlugin::_bind_methods() {
+    ClassDB::bind_method(D_METHOD("_on_editor_scene_changed"), &GoostEditorPlugin::_on_editor_scene_changed);
+}
+
+void GoostEditorPlugin::_on_editor_scene_changed(Node *p_scene_root) {
+#if defined(GOOST_GEOMETRY_ENABLED) && defined(GOOST_Debug2D)
+    if (Debug2D::get_singleton()) {
+        Debug2D::get_singleton()->clear();
+    }
+#endif
+}
+
+GoostEditorPlugin::GoostEditorPlugin(EditorNode *p_editor) {
+    // Signals are added during `EditorPlugin::_bind_methods()`, so calling deferred.
+    call_deferred("connect", "scene_changed", this, "_on_editor_scene_changed");
+}

--- a/editor/goost_editor_plugin.h
+++ b/editor/goost_editor_plugin.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "editor/editor_plugin.h"
+
+// General-purpose plugin to handle global events.
+
+class GoostEditorPlugin : public EditorPlugin {
+	GDCLASS(GoostEditorPlugin, EditorPlugin);
+	
+protected:
+	static void _bind_methods();
+	
+	void _on_editor_scene_changed(Node *p_scene_root);
+
+public:
+	GoostEditorPlugin(EditorNode *p_editor);
+};

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -3,6 +3,8 @@
 #include "editor/editor_node.h"
 #include "editor_about.h"
 
+#include "goost_editor_plugin.h"
+
 namespace goost {
 
 void editor_init() {
@@ -38,6 +40,7 @@ void editor_init() {
 
 void register_editor_types() {
 	EditorNode::add_init_callback(editor_init);
+	EditorPlugins::add_by_type<GoostEditorPlugin>();
 }
 
 void unregister_editor_types() {


### PR DESCRIPTION
This adds `GoostEditorPlugin` created specifically for this purpose. More things could be added to such a plugin that pertain to Godot's global editor state in general.

Resolves limitation described in https://github.com/goostengine/goost/issues/163#issuecomment-987382852.