### PR TITLE
Add default grid to `Debug2D`

### DIFF
--- a/doc/Debug2D.xml
+++ b/doc/Debug2D.xml
@@ -209,6 +209,19 @@
 				Returns [DebugCapture] object to manage history of draw commands.
 			</description>
 		</method>
+		<method name="get_grid" qualifiers="const">
+			<return type="GridRect" />
+			<description>
+				Returns the default [GridRect] used to draw an infinite grid at run-time.
+				The grid drawing is disabled by default, so if you want to use it, you have to go into project settings and enable it manually. You can change the grid properties both by configuring project settings at [code]debug/draw/2d/grid[/code] and via code:
+				[codeblock]
+				func _ready():
+				    var grid: GridRect = Debug2D.get_grid()
+				    grid.show()
+				[/codeblock]
+				If you use [Camera2D] or change [member Viewport.canvas_transform], the grid's position and scale are going to be updated automatically to simulate an infinite grid. Note that [GridRect] doesn't currently support rotated grid lines.
+			</description>
+		</method>
 		<method name="update">
 			<return type="void" />
 			<description>

--- a/goost.py
+++ b/goost.py
@@ -221,7 +221,7 @@ classes = _classes
 # If so, define them here explicitly so that they're automatically enabled.
 class_dependencies = {
     "CommandLineParser": ["CommandLineOption", "CommandLineHelpFormat"],
-    "Debug2D": ["DebugCapture", "GoostGeometry2D"],
+    "Debug2D": ["DebugCapture", "GoostGeometry2D", "GridRect"],
     "GoostEngine" : "InvokeState",
     "GoostGeometry2D" : ["PolyBoolean2D", "PolyDecomp2D", "PolyOffset2D"],
     "LightTexture" : "GradientTexture2D",

--- a/scene/2d/debug_2d.cpp
+++ b/scene/2d/debug_2d.cpp
@@ -2,6 +2,7 @@
 
 #include "goost/core/math/geometry/2d/goost_geometry_2d.h"
 
+#include "scene/main/viewport.h"
 #include "scene/resources/theme.h"
 #include "scene/scene_string_names.h"
 
@@ -181,6 +182,23 @@ Variant Debug2D::_option_get_value(const String &p_option, const Variant &p_valu
 		ret = p_value;
 	}
 	return ret;
+}
+
+void Debug2D::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_PROCESS: {
+			if (grid_rect->is_visible()) {
+				const Transform2D &ct = get_viewport()->get_canvas_transform();
+
+				if (grid_rect->get_origin_offset() != ct.get_origin()) {
+					grid_rect->set_origin_offset(ct.get_origin());
+				}
+				if (grid_rect->get_origin_scale() != ct.get_scale()) {
+					grid_rect->set_origin_scale(ct.get_scale());
+				}
+			}
+		} break;
+	}
 }
 
 void Debug2D::_push_command(DrawCommand &p_command) {
@@ -449,12 +467,23 @@ Debug2D::Debug2D() {
 	ERR_FAIL_COND_MSG(singleton != nullptr, "Singleton already exists");
 	singleton = this;
 	state.instance();
+	set_process(true);
 
+	// Base for drawing.
 	base = memnew(Node2D);
 	set_canvas_item(base);
-
 	base->set_name("Canvas");
 	add_child(base);
+
+	// Grid layer.
+	grid_layer = memnew(CanvasLayer);
+	grid_layer->set_name("GridLayer");
+	grid_layer->set_layer(-1); // Do not show grid on top, since we have transparent grid by default.
+	add_child(grid_layer);
+
+	grid_rect = memnew(GridRect);
+	grid_layer->add_child(grid_rect);
+	grid_rect->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 
 	draw_reset();
 
@@ -479,6 +508,7 @@ void Debug2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_canvas_item", "canvas_item"), &Debug2D::set_canvas_item);
 	ClassDB::bind_method(D_METHOD("get_canvas_item"), &Debug2D::get_canvas_item);
 	ClassDB::bind_method(D_METHOD("get_base"), &Debug2D::get_base);
+	ClassDB::bind_method(D_METHOD("get_grid"), &Debug2D::get_grid);
 
 	ClassDB::bind_method(D_METHOD("draw", "method", "args"), &Debug2D::draw, DEFVAL(Variant()));
 

--- a/scene/2d/debug_2d.cpp
+++ b/scene/2d/debug_2d.cpp
@@ -482,6 +482,7 @@ Debug2D::Debug2D() {
 	add_child(grid_layer);
 
 	grid_rect = memnew(GridRect);
+	grid_rect->set_name("Grid");
 	grid_layer->add_child(grid_rect);
 	grid_rect->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 

--- a/scene/2d/debug_2d.cpp
+++ b/scene/2d/debug_2d.cpp
@@ -478,7 +478,7 @@ Debug2D::Debug2D() {
 	// Grid layer.
 	grid_layer = memnew(CanvasLayer);
 	grid_layer->set_name("GridLayer");
-	grid_layer->set_layer(-1); // Do not show grid on top, since we have transparent grid by default.
+	grid_layer->set_layer(GLOBAL_GET("debug/draw/2d/grid/layer"));
 	add_child(grid_layer);
 
 	grid_rect = memnew(GridRect);

--- a/scene/2d/debug_2d.h
+++ b/scene/2d/debug_2d.h
@@ -3,6 +3,9 @@
 #include "core/engine.h"
 #include "core/resource.h"
 #include "scene/2d/node_2d.h"
+#include "scene/main/canvas_layer.h"
+
+#include "scene/gui/grid_rect.h"
 
 class DebugCapture;
 
@@ -15,6 +18,10 @@ private:
 	bool enabled = true;
 
 	Node2D *base = nullptr;
+
+	CanvasLayer *grid_layer = nullptr;
+	GridRect *grid_rect = nullptr;
+
 	ObjectID canvas_item; // Currently used item passed to draw commands.
 
 	Dictionary draw_override;
@@ -48,6 +55,7 @@ private:
 
 protected:
 	static void _bind_methods();
+	void _notification(int p_what);
 
 	void _on_canvas_item_draw(Object *p_item);
 	void _push_command(DrawCommand &p_command);
@@ -66,6 +74,7 @@ public:
 	void set_canvas_item(Object *p_canvas_item);
 	Object *get_canvas_item() const;
 	Object *get_base() const { return base; } // The default canvas item.
+	GridRect *get_grid() const { return grid_rect; }
 
 	// Custom drawing using one of the `CanvasItem.draw_*` methods.
 	void draw(const StringName &p_method, const Array &p_args = Array());

--- a/scene/gui/grid_rect.h
+++ b/scene/gui/grid_rect.h
@@ -29,9 +29,9 @@ protected:
 	int divisions_horizontal = 8;
 	int divisions_vertical = 8;
 	float divisions_line_width = 1.0;
+
 	Vector2 origin_offset;
 	Vector2 origin_scale = Vector2(1, 1);
-
 	bool origin_centered = false;
 	bool origin_axes_visible = false;
 	float origin_axes_line_width = 1.0;

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -105,6 +105,7 @@ void register_scene_types() {
 	ClassDB::get_property_list("GridRect", &grid_props, true);
 
 	GLOBAL_DEF("debug/draw/2d/grid/visible", false);
+	GLOBAL_DEF("debug/draw/2d/grid/layer", 1); // Show on top by default.
 
 	auto g = memnew(GridRect);
 	for (List<PropertyInfo>::Element *E = grid_props.front(); E; E = E->next()) {

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -58,10 +58,10 @@ static void _debug_2d_add_to_scene_tree() {
 			}
 			grid->set(p.name, GLOBAL_GET("debug/draw/2d/grid/" + p.name));
 		}
-		grid->set("custom_colors/line_axis_x", GLOBAL_GET("debug/draw/2d/grid/axis_x_color"));
-		grid->set("custom_colors/line_axis_y", GLOBAL_GET("debug/draw/2d/grid/axis_y_color"));
-		grid->set("custom_colors/line_cell", GLOBAL_GET("debug/draw/2d/grid/line_cell_color"));
-		grid->set("custom_colors/line_division", GLOBAL_GET("debug/draw/2d/grid/line_division_color"));
+		grid->set("custom_colors/line_axis_x", GLOBAL_GET("debug/draw/2d/grid/origin_axis_x_color"));
+		grid->set("custom_colors/line_axis_y", GLOBAL_GET("debug/draw/2d/grid/origin_axis_y_color"));
+		grid->set("custom_colors/line_cell", GLOBAL_GET("debug/draw/2d/grid/cell_line_color"));
+		grid->set("custom_colors/line_division", GLOBAL_GET("debug/draw/2d/grid/divisions_line_color"));
 		grid->set("custom_colors/background", GLOBAL_GET("debug/draw/2d/grid/background_color"));
 	}
 	_debug_2d_added = true;
@@ -116,19 +116,29 @@ void register_scene_types() {
 			continue;
 		}
 		const String &setting = "debug/draw/2d/grid/" + p.name;
-		if (p.name == "origin_axes_visible") {
+	
+		if (p.name == "cell_line_width") {
+			GLOBAL_DEF(setting, g->get(p.name));
+			ProjectSettings::get_singleton()->set_custom_property_info(setting, p);
+			GLOBAL_DEF("debug/draw/2d/grid/cell_line_color", Color(1.0, 1.0, 1.0, 0.07)); // From GraphEdit in godot/editor/editor_themes.cpp
+
+		} else if (p.name == "divisions_line_width") {
+			GLOBAL_DEF(setting, g->get(p.name));
+			ProjectSettings::get_singleton()->set_custom_property_info(setting, p);
+			GLOBAL_DEF("debug/draw/2d/grid/divisions_line_color", Color(1.0, 1.0, 1.0, 0.15)); // From GraphEdit in godot/editor/editor_themes.cpp
+
+		} else if (p.name == "origin_axes_visible") {
 			GLOBAL_DEF(setting, true);
+			GLOBAL_DEF("debug/draw/2d/grid/origin_axis_x_color", Color(0.96, 0.20, 0.32)); // From godot/editor/editor_themes.cpp
+			GLOBAL_DEF("debug/draw/2d/grid/origin_axis_y_color", Color(0.53, 0.84, 0.01)); // From godot/editor/editor_themes.cpp
+		} else {
+			GLOBAL_DEF(setting, g->get(p.name));
+			ProjectSettings::get_singleton()->set_custom_property_info(setting, p);
 		}
-		GLOBAL_DEF(setting, g->get(p.name));
-		ProjectSettings::get_singleton()->set_custom_property_info(setting, p);
 	}
+	GLOBAL_DEF("debug/draw/2d/grid/background_color", Color(0, 0, 0, 0));
 	memdelete(g);
 
-	GLOBAL_DEF("debug/draw/2d/grid/axis_x_color", Color(0.96, 0.20, 0.32)); // From godot/editor/editor_themes.cpp
-	GLOBAL_DEF("debug/draw/2d/grid/axis_y_color", Color(0.53, 0.84, 0.01)); // From godot/editor/editor_themes.cpp
-	GLOBAL_DEF("debug/draw/2d/grid/line_cell_color", Color(1.0, 1.0, 1.0, 0.07)); // From GraphEdit in godot/editor/editor_themes.cpp
-	GLOBAL_DEF("debug/draw/2d/grid/line_division_color", Color(1.0, 1.0, 1.0, 0.15)); // From GraphEdit in godot/editor/editor_themes.cpp
-	GLOBAL_DEF("debug/draw/2d/grid/background_color", Color(0, 0, 0, 0));
 	// End grid setup.
 
 	ClassDB::register_virtual_class<Debug2D>();

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -27,20 +27,43 @@ static void _debug_2d_add_to_scene_tree() {
 	if (_debug_2d_added) {
 		return;
 	}
-	Debug2D::get_singleton()->set_name("Debug2D");
+	auto debug_2d = Debug2D::get_singleton();
+	bool editor = Engine::get_singleton()->is_editor_hint();
+	debug_2d->set_name("Debug2D");
+	debug_2d->set_enabled(GLOBAL_GET("debug/draw/2d/enabled"));
 
-	if (Engine::get_singleton()->is_editor_hint()) {
+	if (editor) {
 #ifdef TOOLS_ENABLED
-		EditorNode::get_singleton()->get_scene_root()->add_child(Debug2D::get_singleton());
+		EditorNode::get_singleton()->get_scene_root()->add_child(debug_2d);
+		debug_2d->get_grid()->hide();
 #endif
 	} else {
 		if (!SceneTree::get_singleton()) {
 			return;
 		}
-		SceneTree::get_singleton()->get_root()->add_child(Debug2D::get_singleton());
-	}
-	Debug2D::get_singleton()->set_enabled(GLOBAL_GET("debug/draw/2d/enabled"));
+		SceneTree::get_singleton()->get_root()->add_child(debug_2d);
 
+		GridRect *grid = debug_2d->get_grid();
+		grid->set_visible(GLOBAL_GET("debug/draw/2d/grid/visible"));
+
+		List<PropertyInfo> grid_props;
+		ClassDB::get_property_list("GridRect", &grid_props, true);
+		for (List<PropertyInfo>::Element *E = grid_props.front(); E; E = E->next()) {
+			const PropertyInfo &p = E->get();
+			if (p.usage & PROPERTY_USAGE_GROUP) {
+				continue;
+			}
+			if (p.name == "origin_offset" || p.name == "origin_scale" || p.name == "origin_centered") {
+				continue;
+			}
+			grid->set(p.name, GLOBAL_GET("debug/draw/2d/grid/" + p.name));
+		}
+		grid->set("custom_colors/line_axis_x", GLOBAL_GET("debug/draw/2d/grid/axis_x_color"));
+		grid->set("custom_colors/line_axis_y", GLOBAL_GET("debug/draw/2d/grid/axis_y_color"));
+		grid->set("custom_colors/line_cell", GLOBAL_GET("debug/draw/2d/grid/line_cell_color"));
+		grid->set("custom_colors/line_division", GLOBAL_GET("debug/draw/2d/grid/line_division_color"));
+		grid->set("custom_colors/background", GLOBAL_GET("debug/draw/2d/grid/background_color"));
+	}
 	_debug_2d_added = true;
 }
 #endif
@@ -62,14 +85,51 @@ void register_scene_types() {
 	ClassDB::register_class<GradientTexture2D>();
 	ClassDB::register_class<LightTexture>();
 
+#ifdef GOOST_GUI_ENABLED
+	// Before Debug2D, need to access default values, property hints etc.
+	ClassDB::register_class<GridRect>(); 
+#endif
+
 #if defined(GOOST_GEOMETRY_ENABLED) && defined(GOOST_Debug2D)
 	// Define project settings before registering classes.
 	GLOBAL_DEF("debug/draw/2d/enabled", true);
 	GLOBAL_DEF("debug/draw/2d/color", Color(0.0, 0.6, 0.7, 1));
 	GLOBAL_DEF("debug/draw/2d/filled", true);
 	GLOBAL_DEF("debug/draw/2d/line_width", 1.0);
-	ProjectSettings::get_singleton()->set_custom_property_info("debug/draw/2d/line_width", PropertyInfo(Variant::REAL, "debug/draw/2d/line_width", PROPERTY_HINT_RANGE, "0.1,5.0,0.1,or_greater"));
+	ProjectSettings::get_singleton()->set_custom_property_info("debug/draw/2d/line_width",
+			PropertyInfo(Variant::REAL, "debug/draw/2d/line_width", PROPERTY_HINT_RANGE, "0.1,5.0,0.1,or_greater"));
 	GLOBAL_DEF("debug/draw/2d/antialiased", false);
+
+	// Grid layer.
+	List<PropertyInfo> grid_props;
+	ClassDB::get_property_list("GridRect", &grid_props, true);
+
+	GLOBAL_DEF("debug/draw/2d/grid/visible", false);
+
+	auto g = memnew(GridRect);
+	for (List<PropertyInfo>::Element *E = grid_props.front(); E; E = E->next()) {
+		const PropertyInfo &p = E->get();
+		if (p.usage & PROPERTY_USAGE_GROUP) {
+			continue;
+		}
+		if (p.name == "origin_offset" || p.name == "origin_scale" || p.name == "origin_centered") {
+			continue;
+		}
+		const String &setting = "debug/draw/2d/grid/" + p.name;
+		if (p.name == "origin_axes_visible") {
+			GLOBAL_DEF(setting, true);
+		}
+		GLOBAL_DEF(setting, g->get(p.name));
+		ProjectSettings::get_singleton()->set_custom_property_info(setting, p);
+	}
+	memdelete(g);
+
+	GLOBAL_DEF("debug/draw/2d/grid/axis_x_color", Color(0.96, 0.20, 0.32)); // From godot/editor/editor_themes.cpp
+	GLOBAL_DEF("debug/draw/2d/grid/axis_y_color", Color(0.53, 0.84, 0.01)); // From godot/editor/editor_themes.cpp
+	GLOBAL_DEF("debug/draw/2d/grid/line_cell_color", Color(1.0, 1.0, 1.0, 0.07)); // From GraphEdit in godot/editor/editor_themes.cpp
+	GLOBAL_DEF("debug/draw/2d/grid/line_division_color", Color(1.0, 1.0, 1.0, 0.15)); // From GraphEdit in godot/editor/editor_themes.cpp
+	GLOBAL_DEF("debug/draw/2d/grid/background_color", Color(0, 0, 0, 0));
+	// End grid setup.
 
 	ClassDB::register_virtual_class<Debug2D>();
 	ClassDB::register_virtual_class<DebugCapture>();
@@ -77,14 +137,9 @@ void register_scene_types() {
 	_debug_2d = memnew(Debug2D);
 	Engine::get_singleton()->add_singleton(Engine::Singleton("Debug2D", Debug2D::get_singleton()));
 	SceneTree::add_idle_callback(&_debug_2d_add_to_scene_tree);
-
 #endif
 #ifdef GOOST_AUDIO_ENABLED
 	register_audio_types();
-#endif
-
-#ifdef GOOST_GUI_ENABLED
-	ClassDB::register_class<GridRect>();
 #endif
 
 #if defined(TOOLS_ENABLED) && defined(GOOST_EDITOR_ENABLED)


### PR DESCRIPTION
This adds ability to draw an infinite grid at run-time (while the game is running):

![image](https://user-images.githubusercontent.com/17108460/146646837-4912bf4c-51e5-45ee-bdf6-e1ecc3960804.png)

This uses `GridRect` class previously added in #80. The grid drawing is disabled by default, so if you want to use it, you have to go into project settings and enable it manually:

![image](https://user-images.githubusercontent.com/17108460/146646842-0e452ade-6690-49a0-80f5-5bb848976391.png)

The grid settings more or less match `GridRect` ones. Additionally, you can access the grid via code and be able to customize everything that way:

```gdscript
func _ready():
    var grid: GridRect = Debug2D.get_grid()
```

If you use `Camera2D` or change the canvas transform, the grid's position and scale are going to be updated automatically to simulate an infinite grid. The only thing which does not work correctly is when you set `Camera2D` to `rotating`. `GridRect` doesn't currently support rotated grid lines, but hopefully updating origin+scale should be enough for debugging purposes.