### PR TITLE
Add `Graph` class

### DIFF
--- a/core/image/goost_image.cpp
+++ b/core/image/goost_image.cpp
@@ -30,6 +30,7 @@ void GoostImage::replace_color(Ref<Image> p_image, const Color &p_color, const C
 	p_image->unlock();
 }
 
+// TODO: replace by `core/types/templates/queue.h`
 struct BucketFillQueue {
 	LocalVector<Vector2> array;
 	uint32_t front = 0;

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -3,6 +3,8 @@
 #include "core/engine.h"
 #include "scene/main/scene_tree.h"
 
+#include "string_names.h"
+
 #include "image/register_image_types.h"
 #include "math/register_math_types.h"
 #include "script/register_script_types.h"
@@ -24,6 +26,8 @@ static void _variant_resource_preview_init();
 #endif
 
 void register_core_types() {
+	StringNames::create();
+
 	ClassDB::register_class<CommandLineOption>();
 	ClassDB::register_class<CommandLineHelpFormat>();
 	ClassDB::register_class<CommandLineParser>();
@@ -74,6 +78,7 @@ void unregister_core_types() {
 #ifdef GOOST_SCRIPT_ENABLED
 	unregister_script_types();
 #endif
+	StringNames::free();
 }
 
 #if defined(TOOLS_ENABLED) && defined(GOOST_VariantResource)

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -39,6 +39,10 @@ void register_core_types() {
 	ClassDB::register_class<ListNode>();
 	ClassDB::register_class<LinkedList>();
 
+	ClassDB::register_class<Graph>();
+	ClassDB::register_class<GraphVertex>();
+	ClassDB::register_class<GraphEdge>();
+
 	ClassDB::register_class<VariantMap>();
 	ClassDB::register_class<VariantResource>();
 

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -46,6 +46,7 @@ void register_core_types() {
 	ClassDB::register_class<Graph>();
 	ClassDB::register_class<GraphVertex>();
 	ClassDB::register_class<GraphEdge>();
+	ClassDB::register_class<GraphIterator>();
 
 	ClassDB::register_class<VariantMap>();
 	ClassDB::register_class<VariantResource>();

--- a/core/string_names.cpp
+++ b/core/string_names.cpp
@@ -4,5 +4,8 @@ StringNames *StringNames::singleton = nullptr;
 
 StringNames::StringNames() :
 		_create_vertex(StaticCString::create("_create_vertex")),
-		_create_edge(StaticCString::create("_create_edge"))
+		_create_edge(StaticCString::create("_create_edge")),
+		initialize(StaticCString::create("initialize")),
+    	has_next(StaticCString::create("has_next")),
+    	next(StaticCString::create("next"))
 {}

--- a/core/string_names.cpp
+++ b/core/string_names.cpp
@@ -1,0 +1,8 @@
+#include "string_names.h"
+
+StringNames *StringNames::singleton = nullptr;
+
+StringNames::StringNames() :
+		_create_vertex(StaticCString::create("_create_vertex")),
+		_create_edge(StaticCString::create("_create_edge"))
+{}

--- a/core/string_names.h
+++ b/core/string_names.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "core/string_name.h"
+
+namespace goost {
+    void register_core_types();
+	void unregister_core_types();
+}
+
+class StringNames {
+	friend void goost::register_core_types();
+	friend void goost::unregister_core_types();
+
+	static void create() { singleton = memnew(StringNames); }
+	static void free() {
+		memdelete(singleton);
+		singleton = nullptr;
+	}
+	StringNames();
+
+public:
+	_FORCE_INLINE_ static StringNames *get_singleton() { return singleton; }
+	static StringNames *singleton;
+
+    StringName _create_vertex;
+    StringName _create_edge;
+};

--- a/core/string_names.h
+++ b/core/string_names.h
@@ -24,4 +24,7 @@ public:
 
     StringName _create_vertex;
     StringName _create_edge;
+    StringName initialize;
+    StringName has_next;
+    StringName next;
 };

--- a/core/types/graph.cpp
+++ b/core/types/graph.cpp
@@ -294,12 +294,8 @@ Array Graph::get_edge_list(GraphVertex *p_a, GraphVertex *p_b) const {
 Array Graph::find_connected_component(GraphVertex *p_vertex) const {
 	Array component;
 
-	GraphDFS dfs(p_vertex);
-	while (dfs.has_next()) {
-		GraphVertex *v = dfs.next();
-		if (v) {
-			component.push_back(v);
-		}
+	for (GraphDFS dfs(p_vertex); dfs.has_next();) {
+		component.push_back(dfs.next());
 	}
 	return component;
 }
@@ -317,13 +313,8 @@ bool Graph::is_strongly_connected() const {
 	GraphVertex *root = graph->vertices[*k];
 
 	uint32_t count = 0;
-
-	GraphDFS dfs(root);
-	while (dfs.has_next()) {
-		GraphVertex *v = dfs.next();
-		if (v) {
-			count++;
-		}
+	for (GraphDFS dfs(root); dfs.has_next(); dfs.next()) {
+		count++;
 	}
 	return count == graph->vertices.size();
 }
@@ -456,19 +447,24 @@ GraphVertex *GraphDFS::next() {
 	if (stack.is_empty()) {
 		return nullptr;
 	}
-	GraphVertex *v = stack.pop();
-	if (visited.has(v->id)) {
-		return nullptr;
-	}
-	visited.insert(v->id);
-
-	const uint32_t *k = nullptr;
-	while ((k = v->neighbors.next(k))) {
-		GraphVertex *vn = graph->vertices[*k];
-		if (!visited.has(vn->id)) {
-			stack.push(vn);
+	GraphVertex *v = nullptr;
+	do {
+		v = stack.pop();
+		if (visited.has(v->id)) {
+			continue;
 		}
-	}
+		visited.insert(v->id);
+
+		const uint32_t *k = nullptr;
+		while ((k = v->neighbors.next(k))) {
+			GraphVertex *vn = graph->vertices[*k];
+			if (!visited.has(vn->id)) {
+				stack.push(vn);
+			}
+		}
+	} while (!v);
+
+	ERR_FAIL_NULL_V(v, nullptr);
 	return v;
 }
 

--- a/core/types/graph.cpp
+++ b/core/types/graph.cpp
@@ -5,24 +5,24 @@
 #ifdef DEBUG_ENABLED
 
 #define ERR_INVALID_VERTEX(m_v) \
-	ERR_FAIL_NULL(v);           \
-	ERR_FAIL_COND(!graph->data.has(v));
+	ERR_FAIL_NULL(m_v);           \
+	ERR_FAIL_COND(!graph->data.has(m_v));
 
 #define ERR_INVALID_VERTEX_V(m_v, m_ret) \
-	ERR_FAIL_NULL_V(v, m_ret);           \
-	ERR_FAIL_COND_V(!graph->data.has(v), m_ret);
+	ERR_FAIL_NULL_V(m_v, m_ret);           \
+	ERR_FAIL_COND_V(!graph->data.has(m_v), m_ret);
 
 #define ERR_INVALID_VERTICES(m_a, m_b)  \
-	ERR_FAIL_NULL(a);                   \
-	ERR_FAIL_NULL(b);                   \
-	ERR_FAIL_COND(!graph->data.has(a)); \
-	ERR_FAIL_COND(!graph->data.has(b));
+	ERR_FAIL_NULL(m_a);                   \
+	ERR_FAIL_NULL(m_b);                   \
+	ERR_FAIL_COND(!graph->data.has(m_a)); \
+	ERR_FAIL_COND(!graph->data.has(m_b));
 
 #define ERR_INVALID_VERTICES_V(m_a, m_b, m_ret)  \
-	ERR_FAIL_NULL_V(a, m_ret);                   \
-	ERR_FAIL_NULL_V(b, m_ret);                   \
-	ERR_FAIL_COND_V(!graph->data.has(a), m_ret); \
-	ERR_FAIL_COND_V(!graph->data.has(b), m_ret);
+	ERR_FAIL_NULL_V(m_a, m_ret);                   \
+	ERR_FAIL_NULL_V(m_b, m_ret);                   \
+	ERR_FAIL_COND_V(!graph->data.has(m_a), m_ret); \
+	ERR_FAIL_COND_V(!graph->data.has(m_b), m_ret);
 #else
 
 #define ERR_INVALID_VERTEX(m_v)
@@ -187,6 +187,26 @@ GraphEdge *Graph::add_directed_edge(const Variant &p_a, const Variant &p_b, real
 	return _add_edge(p_a, p_b, p_weight, true);
 }
 
+void Graph::remove_edge(GraphEdge *e) {
+	ERR_FAIL_NULL(e);
+	ERR_INVALID_VERTEX(e->a);
+	ERR_INVALID_VERTEX(e->b);
+
+	GraphVertex *v[2] = {e->a, e->b};
+
+	for (int i = 0; i < 2; ++i) {
+		List<GraphEdge *> &list = graph->data[v[i]];
+
+		for (List<GraphEdge *>::Element *E = list.front(); E; E = E->next()) {
+			GraphEdge *edge = E->get();
+			if (e == edge) {
+				list.erase(E);
+			}
+		}
+	}
+	memdelete(e);
+}
+
 GraphEdge *Graph::find_edge(GraphVertex *a, GraphVertex *b) const {
 	ERR_INVALID_VERTICES_V(a, b, nullptr);
 
@@ -289,6 +309,7 @@ void Graph::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("add_edge", "a", "b", "weight"), &Graph::add_edge, DEFVAL(1.0));
 	ClassDB::bind_method(D_METHOD("add_directed_edge", "from", "to", "weight"), &Graph::add_directed_edge, DEFVAL(1.0));
+	ClassDB::bind_method(D_METHOD("remove_edge", "edge"), &Graph::remove_edge);
 	ClassDB::bind_method(D_METHOD("find_edge", "a", "b"), &Graph::find_edge);
 	ClassDB::bind_method(D_METHOD("has_edge", "a", "b"), &Graph::has_edge);
 	ClassDB::bind_method(D_METHOD("get_edge_list", "a", "b"), &Graph::get_edge_list, DEFVAL(Variant()), DEFVAL(Variant()));

--- a/core/types/graph.cpp
+++ b/core/types/graph.cpp
@@ -209,14 +209,14 @@ bool Graph::has_vertex(GraphVertex *p_vertex) const {
 	return graph->vertices.has(p_vertex->id);
 }
 
-Array Graph::get_vertex_list() const {
-	Array vertex_list;
+Array Graph::get_vertices() const {
+	Array vertices;
 
 	const uint32_t *k = nullptr;
 	while ((k = graph->vertices.next(k))) {
-		vertex_list.push_back(graph->vertices[*k]);
+		vertices.push_back(graph->vertices[*k]);
 	}
-	return vertex_list;
+	return vertices;
 }
 
 Ref<Graph> GraphVertex::get_graph() const {
@@ -410,11 +410,11 @@ bool Graph::has_edge(GraphVertex *p_a, GraphVertex *p_b) const {
 	return find_edge(p_a, p_b) != nullptr;
 }
 
-Array Graph::get_edge_list(GraphVertex *p_a, GraphVertex *p_b) const {
+Array Graph::get_edges(GraphVertex *p_a, GraphVertex *p_b) const {
 	ERR_FAIL_COND_V_MSG(!p_a && p_b, Array(), "Parameter 'a' is not a valid GraphVertex");
 	ERR_FAIL_COND_V_MSG(p_a && !p_b, Array(), "Parameter 'b' is not a valid GraphVertex");
 
-	Array edge_list;
+	Array edges;
 
 	const bool fetch_all = !p_a || !p_b;
 
@@ -425,17 +425,17 @@ Array Graph::get_edge_list(GraphVertex *p_a, GraphVertex *p_b) const {
 		for (int i = 0; i < list.size(); ++i) {
 			GraphEdge *edge = list[i];
 			if (fetch_all) { // Get all edges in the graph.
-				edge_list.push_back(edge);
+				edges.push_back(edge);
 			} else { // Get all edges between vertices.
 				if (p_a == edge->a && p_b == edge->b) {
-					edge_list.push_back(edge);
+					edges.push_back(edge);
 				} else if (!edge->directed && p_a == edge->b && p_b == edge->a) {
-					edge_list.push_back(edge);
+					edges.push_back(edge);
 				}
 			}
 		}
 	}
-	return edge_list;
+	return edges;
 }
 
 Array Graph::find_connected_component(GraphVertex *p_vertex) {
@@ -718,7 +718,7 @@ void Graph::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_vertex", "vertex"), &Graph::remove_vertex);
 	ClassDB::bind_method(D_METHOD("find_vertex", "value"), &Graph::find_vertex);
 	ClassDB::bind_method(D_METHOD("has_vertex", "vertex"), &Graph::has_vertex);
-	ClassDB::bind_method(D_METHOD("get_vertex_list"), &Graph::get_vertex_list);
+	ClassDB::bind_method(D_METHOD("get_vertices"), &Graph::get_vertices);
 	ClassDB::bind_method(D_METHOD("get_vertex_count"), &Graph::get_vertex_count);
 
 	ClassDB::bind_method(D_METHOD("add_edge", "a", "b", "value"), &Graph::add_edge, DEFVAL(1.0));
@@ -726,7 +726,7 @@ void Graph::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_edge", "edge"), &Graph::remove_edge);
 	ClassDB::bind_method(D_METHOD("find_edge", "a", "b"), &Graph::find_edge);
 	ClassDB::bind_method(D_METHOD("has_edge", "a", "b"), &Graph::has_edge);
-	ClassDB::bind_method(D_METHOD("get_edge_list", "a", "b"), &Graph::get_edge_list, DEFVAL(Variant()), DEFVAL(Variant()));
+	ClassDB::bind_method(D_METHOD("get_edges", "a", "b"), &Graph::get_edges, DEFVAL(Variant()), DEFVAL(Variant()));
 	ClassDB::bind_method(D_METHOD("get_edge_count"), &Graph::get_edge_count);
 
 	ClassDB::bind_method(D_METHOD("find_connected_component", "vertex"), &Graph::find_connected_component);

--- a/core/types/graph.cpp
+++ b/core/types/graph.cpp
@@ -5,7 +5,7 @@
 
 #include "core/types/templates/union_find.h"
 
-using EdgeKey = Pair<uint32_t, uint32_t>;
+using EdgeKey = GraphData::EdgeKey;
 using EdgeList = LocalVector<GraphEdge *, int>;
 
 void GraphData::remove_vertex(GraphVertex *p_vertex) {
@@ -304,7 +304,7 @@ GraphEdge *Graph::_add_edge(const Variant &p_a, const Variant &p_b, const Varian
 	const auto &key = EdgeKey(a->id, b->id);
 	if (!graph->edges.has(key)) {
 		EdgeList list;
-		list.reserve(4); // Slight optimization for directed or multi-edges.
+		list.reserve(2); // Slight optimization for directed or multi-edges.
 		list.push_back(edge);
 		graph->edges[key] = list;
 	} else {

--- a/core/types/graph.cpp
+++ b/core/types/graph.cpp
@@ -5,20 +5,20 @@
 #ifdef DEBUG_ENABLED
 
 #define ERR_INVALID_VERTEX(m_v) \
-	ERR_FAIL_NULL(m_v);           \
+	ERR_FAIL_NULL(m_v);         \
 	ERR_FAIL_COND(!graph->data.has(m_v));
 
 #define ERR_INVALID_VERTEX_V(m_v, m_ret) \
-	ERR_FAIL_NULL_V(m_v, m_ret);           \
+	ERR_FAIL_NULL_V(m_v, m_ret);         \
 	ERR_FAIL_COND_V(!graph->data.has(m_v), m_ret);
 
-#define ERR_INVALID_VERTICES(m_a, m_b)  \
+#define ERR_INVALID_VERTICES(m_a, m_b)    \
 	ERR_FAIL_NULL(m_a);                   \
 	ERR_FAIL_NULL(m_b);                   \
 	ERR_FAIL_COND(!graph->data.has(m_a)); \
 	ERR_FAIL_COND(!graph->data.has(m_b));
 
-#define ERR_INVALID_VERTICES_V(m_a, m_b, m_ret)  \
+#define ERR_INVALID_VERTICES_V(m_a, m_b, m_ret)    \
 	ERR_FAIL_NULL_V(m_a, m_ret);                   \
 	ERR_FAIL_NULL_V(m_b, m_ret);                   \
 	ERR_FAIL_COND_V(!graph->data.has(m_a), m_ret); \
@@ -69,12 +69,15 @@ void GraphData::remove_vertex(GraphVertex *v) {
 		GraphVertex *n = closed_neighborhood[i];
 		List<GraphEdge *> &list_n = data[n];
 
-		for (List<GraphEdge *>::Element *E = list_n.front(); E; E = E->next()) {
+		for (List<GraphEdge *>::Element *E = list_n.front(); E;) {
+			auto N = E->next();
 			GraphEdge *edge = E->get();
+	
 			if (v == edge->a || v == edge->b) {
 				edges_to_delete.insert(edge);
 				list_n.erase(E);
 			}
+			E = N;
 		}
 	}
 	// Delete all edges associated with the vertex.
@@ -192,16 +195,18 @@ void Graph::remove_edge(GraphEdge *e) {
 	ERR_INVALID_VERTEX(e->a);
 	ERR_INVALID_VERTEX(e->b);
 
-	GraphVertex *v[2] = {e->a, e->b};
+	GraphVertex *v[2] = { e->a, e->b };
 
 	for (int i = 0; i < 2; ++i) {
 		List<GraphEdge *> &list = graph->data[v[i]];
 
-		for (List<GraphEdge *>::Element *E = list.front(); E; E = E->next()) {
+		for (List<GraphEdge *>::Element *E = list.front(); E;) {
+			auto N = E->next();
 			GraphEdge *edge = E->get();
 			if (e == edge) {
 				list.erase(E);
 			}
+			E = N;
 		}
 	}
 	memdelete(e);
@@ -287,13 +292,15 @@ void Graph::clear_edges() {
 
 	for (Map<GraphVertex *, List<GraphEdge *>>::Element *E = graph->data.front(); E; E = E->next()) {
 		List<GraphEdge *> &list = E->get();
-		for (List<GraphEdge *>::Element *I = list.front(); I; I = I->next()) {
+		for (List<GraphEdge *>::Element *I = list.front(); I;) {
+			auto N = I->next();
 			edge_set.insert(I->get());
 			list.erase(I);
+			I = N;
 		}
 	}
-	for (const Set<GraphEdge *>::Element *I = edge_set.front(); I; I = I->next()) {
-		memdelete(I->get());
+	for (const Set<GraphEdge *>::Element *E = edge_set.front(); E; E = E->next()) {
+		memdelete(E->get());
 	}
 }
 
@@ -360,6 +367,8 @@ void GraphEdge::_notification(int p_what) {
 void GraphEdge::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_vertex_a"), &GraphEdge::get_vertex_a);
 	ClassDB::bind_method(D_METHOD("get_vertex_b"), &GraphEdge::get_vertex_b);
+
+	ClassDB::bind_method(D_METHOD("is_loop"), &GraphEdge::is_loop);
 
 	ClassDB::bind_method(D_METHOD("set_weight", "weight"), &GraphEdge::set_weight);
 	ClassDB::bind_method(D_METHOD("get_weight"), &GraphEdge::get_weight);

--- a/core/types/graph.cpp
+++ b/core/types/graph.cpp
@@ -100,6 +100,17 @@ void Graph::remove_vertex(GraphVertex *p_vertex) {
 	memdelete(p_vertex);
 }
 
+GraphVertex *Graph::find_vertex(const Variant &p_value) {
+	const uint32_t *k = nullptr;
+	while ((k = graph->vertices.next(k))) {
+		GraphVertex *v = graph->vertices[*k];
+		if (v->value == p_value) {
+			return v;
+		}
+	}
+	return nullptr;
+}
+
 bool Graph::has_vertex(GraphVertex *p_vertex) const {
 	return graph->vertices.has(p_vertex->id);
 }
@@ -318,6 +329,7 @@ void Graph::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("add_vertex", "value"), &Graph::add_vertex);
 	ClassDB::bind_method(D_METHOD("remove_vertex", "vertex"), &Graph::remove_vertex);
+	ClassDB::bind_method(D_METHOD("find_vertex", "value"), &Graph::find_vertex);
 	ClassDB::bind_method(D_METHOD("has_vertex", "vertex"), &Graph::has_vertex);
 	ClassDB::bind_method(D_METHOD("get_vertex_list"), &Graph::get_vertex_list);
 	ClassDB::bind_method(D_METHOD("get_vertex_count"), &Graph::get_vertex_count);

--- a/core/types/graph.cpp
+++ b/core/types/graph.cpp
@@ -454,23 +454,19 @@ bool GraphDFS::has_next() {
 }
 
 GraphVertex *GraphDFS::next() {
-	discovered = false;
-
 	if (stack.is_empty()) {
 		return nullptr;
 	}
 	GraphVertex *v = stack.pop_back();
-	if (visited.lookup(v->id, discovered)) {
+	if (visited.has(v->id)) {
 		return nullptr;
 	}
-	visited.insert(v->id, true);
-	discovered = true;
+	visited.insert(v->id);
 
 	const uint32_t *k = nullptr;
 	while ((k = v->neighbors.next(k))) {
 		GraphVertex *vn = graph->vertices[*k];
-		bool has;
-		if (!visited.lookup(vn->id, has)) {
+		if (!visited.has(vn->id)) {
 			stack.push_back(vn);
 		}
 	}

--- a/core/types/graph.cpp
+++ b/core/types/graph.cpp
@@ -214,6 +214,10 @@ GraphEdge *Graph::find_edge(GraphVertex *a, GraphVertex *b) const {
 	return nullptr;
 }
 
+bool Graph::has_edge(GraphVertex *a, GraphVertex *b) const {
+	return find_edge(a, b) != nullptr;
+}
+
 Array Graph::get_edge_list(GraphVertex *a, GraphVertex *b) const {
 	Array edge_list;
 
@@ -269,6 +273,21 @@ void Graph::clear() {
 	}
 }
 
+void Graph::clear_edges() {
+	Set<GraphEdge *> edge_set;
+
+	for (Map<GraphVertex *, List<GraphEdge *>>::Element *E = graph->data.front(); E; E = E->next()) {
+		List<GraphEdge *> &list = E->get();
+		for (List<GraphEdge *>::Element *I = list.front(); I; I = I->next()) {
+			edge_set.insert(I->get());
+			list.erase(I);
+		}
+	}
+	for (const Set<GraphEdge *>::Element *I = edge_set.front(); I; I = I->next()) {
+		memdelete(I->get());
+	}
+}
+
 void Graph::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_vertex", "value"), &Graph::add_vertex);
 	ClassDB::bind_method(D_METHOD("remove_vertex", "vertex"), &Graph::remove_vertex);
@@ -282,8 +301,12 @@ void Graph::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_edge", "a", "b", "weight"), &Graph::add_edge, DEFVAL(1.0));
 	ClassDB::bind_method(D_METHOD("add_directed_edge", "from", "to", "weight"), &Graph::add_directed_edge, DEFVAL(1.0));
 	ClassDB::bind_method(D_METHOD("find_edge", "a", "b"), &Graph::find_edge);
+	ClassDB::bind_method(D_METHOD("has_edge", "a", "b"), &Graph::has_edge);
 	ClassDB::bind_method(D_METHOD("get_edge_list", "a", "b"), &Graph::get_edge_list, DEFVAL(Variant()), DEFVAL(Variant()));
 	ClassDB::bind_method(D_METHOD("get_edge_count"), &Graph::get_edge_count);
+
+	ClassDB::bind_method(D_METHOD("clear"), &Graph::clear);
+	ClassDB::bind_method(D_METHOD("clear_edges"), &Graph::clear_edges);
 }
 
 Graph::Graph() {

--- a/core/types/graph.cpp
+++ b/core/types/graph.cpp
@@ -315,9 +315,12 @@ GraphEdge *Graph::_add_edge(const Variant &p_a, const Variant &p_b, const Varian
 			b = add_vertex(p_b);
 		}
 	}
+#ifdef DEBUG_ENABLED
 	ERR_FAIL_NULL_V(a, nullptr);
 	ERR_FAIL_NULL_V(b, nullptr);
-
+	ERR_FAIL_COND_V_MSG(a->graph != graph, nullptr, "A vertex is not owned by this graph");
+	ERR_FAIL_COND_V_MSG(b->graph != graph, nullptr, "B vertex is not owned by this graph");
+#endif
 	a->neighbors[b->id] = b;
 	b->neighbors[a->id] = a;
 

--- a/core/types/graph.cpp
+++ b/core/types/graph.cpp
@@ -667,7 +667,7 @@ void Graph::clear() {
 
 void Graph::clear_edges() {
 	graph->iterating = false;
-	
+
 	EdgeList to_delete;
 
 	const EdgeKey *k = nullptr;
@@ -696,6 +696,7 @@ Variant Graph::_iter_init(const Array &p_iter) {
 }
 
 Variant Graph::_iter_next(const Array &p_iter) {
+	ERR_FAIL_COND_V(!graph->iterating, false);
 	_iter_current = graph->vertices.next(_iter_current);
 	graph->iterating = _iter_current != nullptr;
 	return graph->iterating;

--- a/core/types/graph.cpp
+++ b/core/types/graph.cpp
@@ -213,6 +213,15 @@ Array Graph::get_vertex_list() const {
 	return vertex_list;
 }
 
+Ref<Graph> GraphVertex::get_graph() const {
+	ERR_FAIL_NULL_V(graph, Ref<Graph>());
+
+	Object *obj = ObjectDB::get_instance(graph->id);
+	Ref<Graph> graph_ref(Object::cast_to<Graph>(obj));
+
+	return graph_ref;
+}
+
 Array GraphVertex::get_neighbors() const {
 	Array ret;
 
@@ -700,6 +709,9 @@ void Graph::_bind_methods() {
 
 Graph::Graph() {
 	graph = memnew(GraphData);
+	graph->id = get_instance_id();
+	ERR_FAIL_COND(graph->id == 0);
+
 	G_dfs.instance();
 	G_bfs.instance();
 	G = G_dfs; // Set depth-first search iterator by default.
@@ -723,6 +735,8 @@ void GraphVertex::_notification(int p_what) {
 }
 
 void GraphVertex::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_graph"), &GraphVertex::get_graph);
+
 	ClassDB::bind_method(D_METHOD("get_neighbors"), &GraphVertex::get_neighbors);
 	ClassDB::bind_method(D_METHOD("get_neighbor_count"), &GraphVertex::get_neighbor_count);
 

--- a/core/types/graph.cpp
+++ b/core/types/graph.cpp
@@ -45,8 +45,9 @@ GraphVertex *Graph::add_vertex(const Variant &p_value) {
 Array Graph::get_vertex_list() const {
 	Array vertex_list;
 
-	for (Map<GraphVertex *, List<GraphEdge *>>::Element *E = graph->data.front(); E; E = E->next()) {
-		vertex_list.push_back(E->key());
+	GraphVertex *const *k = nullptr;
+	while ((k = graph->data.next(k))) {
+		vertex_list.push_back(*k);
 	}
 	return vertex_list;
 }
@@ -81,7 +82,7 @@ void GraphData::remove_vertex(GraphVertex *v) {
 		for (List<GraphEdge *>::Element *E = list_n.front(); E;) {
 			auto N = E->next();
 			GraphEdge *edge = E->get();
-	
+
 			if (v == edge->a || v == edge->b) {
 				edges_to_delete.insert(edge);
 				list_n.erase(E);
@@ -248,16 +249,18 @@ Array Graph::get_edge_list(GraphVertex *a, GraphVertex *b) const {
 
 	if (!a && !b) {
 		// Get all edges in the graph.
-		for (Map<GraphVertex *, List<GraphEdge *>>::Element *E = graph->data.front(); E; E = E->next()) {
-			const List<GraphEdge *> &list = E->get();
+		GraphVertex *const *k = nullptr;
+		while ((k = graph->data.next(k))) {
+			const List<GraphEdge *> &list = graph->data[*k];
 			for (const List<GraphEdge *>::Element *I = list.front(); I; I = I->next()) {
 				edge_set.insert(I->get());
 			}
 		}
 	} else {
 		// Get all edges between vertices.
-		for (Map<GraphVertex *, List<GraphEdge *>>::Element *E = graph->data.front(); E; E = E->next()) {
-			const List<GraphEdge *> &list = E->get();
+		GraphVertex *const *k = nullptr;
+		while ((k = graph->data.next(k))) {
+			const List<GraphEdge *> &list = graph->data[*k];
 			for (const List<GraphEdge *>::Element *I = list.front(); I; I = I->next()) {
 				GraphEdge *edge = I->get();
 				if (a == edge->a && b == edge->b) {
@@ -277,8 +280,9 @@ Array Graph::get_edge_list(GraphVertex *a, GraphVertex *b) const {
 int Graph::get_edge_count() const {
 	Set<GraphEdge *> edge_set;
 
-	for (const Map<GraphVertex *, List<GraphEdge *>>::Element *E = graph->data.front(); E; E = E->next()) {
-		const List<GraphEdge *> &list = E->get();
+	GraphVertex *const *k = nullptr;
+	while ((k = graph->data.next(k))) {
+		const List<GraphEdge *> &list = graph->data[*k];
 		for (const List<GraphEdge *>::Element *I = list.front(); I; I = I->next()) {
 			edge_set.insert(I->get());
 		}
@@ -288,8 +292,9 @@ int Graph::get_edge_count() const {
 
 void Graph::clear() {
 	Vector<GraphVertex *> to_remove;
-	for (Map<GraphVertex *, List<GraphEdge *>>::Element *E = graph->data.front(); E; E = E->next()) {
-		to_remove.push_back(E->key());
+	GraphVertex *const *k = nullptr;
+	while ((k = graph->data.next(k))) {
+		to_remove.push_back(*k);
 	}
 	for (int i = 0; i < to_remove.size(); ++i) {
 		memdelete(to_remove[i]); // This will also delete associated edges.
@@ -299,8 +304,9 @@ void Graph::clear() {
 void Graph::clear_edges() {
 	Set<GraphEdge *> edge_set;
 
-	for (Map<GraphVertex *, List<GraphEdge *>>::Element *E = graph->data.front(); E; E = E->next()) {
-		List<GraphEdge *> &list = E->get();
+	GraphVertex *const *k = nullptr;
+	while ((k = graph->data.next(k))) {
+		List<GraphEdge *> &list = graph->data[*k];
 		for (List<GraphEdge *>::Element *I = list.front(); I;) {
 			auto N = I->next();
 			edge_set.insert(I->get());

--- a/core/types/graph.cpp
+++ b/core/types/graph.cpp
@@ -294,21 +294,30 @@ GraphEdge *Graph::_add_edge(const Variant &p_a, const Variant &p_b, const Varian
 	ERR_FAIL_COND_V(p_a.get_type() == Variant::NIL, nullptr);
 	ERR_FAIL_COND_V(p_b.get_type() == Variant::NIL, nullptr);
 
-	GraphVertex *a;
-	GraphVertex *b;
+	GraphVertex *a = nullptr;
+	GraphVertex *b = nullptr;
 
 	if (p_a.get_type() == Variant::OBJECT) {
 		a = Object::cast_to<GraphVertex>(p_a);
-		ERR_FAIL_NULL_V_MSG(a, nullptr, "The object is not a valid GraphVertex");
-	} else {
-		a = add_vertex(p_a);
+	}
+	if (!a) {
+		a = find_vertex(p_a);
+		if (!a) {
+			a = add_vertex(p_a);
+		}
 	}
 	if (p_b.get_type() == Variant::OBJECT) {
 		b = Object::cast_to<GraphVertex>(p_b);
-		ERR_FAIL_NULL_V_MSG(b, nullptr, "The object is not a valid GraphVertex");
-	} else {
-		b = add_vertex(p_b);
 	}
+	if (!b) {
+		b = find_vertex(p_b);
+		if (!b) {
+			b = add_vertex(p_b);
+		}
+	}
+	ERR_FAIL_NULL_V(a, nullptr);
+	ERR_FAIL_NULL_V(b, nullptr);
+
 	a->neighbors[b->id] = b;
 	b->neighbors[a->id] = a;
 

--- a/core/types/graph.cpp
+++ b/core/types/graph.cpp
@@ -1,0 +1,112 @@
+#include "graph.h"
+
+#ifdef DEBUG_ENABLED
+
+#define ERR_INVALID_VERTICES(m_a, m_b) \
+	ERR_FAIL_NULL(a);               \
+	ERR_FAIL_NULL(b);               \
+	ERR_FAIL_COND(!graph.has(a));   \
+	ERR_FAIL_COND(!graph.has(b));
+
+#define ERR_INVALID_VERTICES_V(m_a, m_b, m_ret) \
+	ERR_FAIL_NULL_V(a, m_ret);               \
+	ERR_FAIL_NULL_V(b, m_ret);               \
+	ERR_FAIL_COND_V(!graph.has(a), m_ret);   \
+	ERR_FAIL_COND_V(!graph.has(b), m_ret);   
+#else
+
+#define ERR_INVALID_VERTICES(m_a, m_b)
+#define ERR_INVALID_VERTICES_V(m_a, m_b, m_ret)
+
+#endif // DEBUG_ENABLED
+
+GraphVertex *Graph::add_vertex(const Variant &p_value) {
+	GraphVertex *v = memnew(GraphVertex);
+
+	v->value = p_value;
+	graph[v] = List<GraphEdge *>();
+
+	return v;
+}
+
+GraphEdge *Graph::_add_edge(const Variant &p_a, const Variant &p_b, real_t p_weight, bool p_bidirectional) {
+	ERR_FAIL_COND_V(p_a.get_type() == Variant::NIL, nullptr);
+	ERR_FAIL_COND_V(p_b.get_type() == Variant::NIL, nullptr);
+
+	GraphVertex *a;
+	GraphVertex *b;
+
+	if (p_a.get_type() == Variant::OBJECT) {
+		a = Object::cast_to<GraphVertex>(p_a);
+		ERR_FAIL_NULL_V(a, nullptr);
+	} else {
+		a = add_vertex(p_a);
+	}
+	if (p_b.get_type() == Variant::OBJECT) {
+		b = Object::cast_to<GraphVertex>(p_b);
+		ERR_FAIL_NULL_V(b, nullptr);
+	} else {
+		b = add_vertex(p_b);
+	}
+	GraphEdge *edge = memnew(GraphEdge);
+	edge->a = a;
+	edge->b = b;
+	edge->weight = p_weight;
+	edge->bidirectional = p_bidirectional;
+
+	graph[a].push_back(edge);
+	graph[b].push_back(edge);
+
+	return edge;
+}
+
+GraphEdge *Graph::add_edge(const Variant &p_a, const Variant &p_b, real_t p_weight) {
+	return _add_edge(p_a, p_b, p_weight, true);
+}
+
+GraphEdge *Graph::add_directed_edge(const Variant &p_a, const Variant &p_b, real_t p_weight) {
+	return _add_edge(p_a, p_b, p_weight, false);
+}
+
+GraphEdge *Graph::find_edge(GraphVertex *a, GraphVertex *b) const {
+	ERR_INVALID_VERTICES_V(a, b, nullptr);
+
+	const List<GraphEdge *> &list = graph[a];
+	for (const List<GraphEdge *>::Element *E = list.front(); E; E = E->next()) {
+		GraphEdge *edge = E->get();
+		if (a == edge->a && b == edge->b) {
+			return edge;
+		}
+		if (edge->bidirectional && a == edge->b && b == edge->a) {
+			return edge;
+		}
+	}
+	return nullptr;
+}
+
+void Graph::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("add_vertex", "value"), &Graph::add_vertex);
+
+	ClassDB::bind_method(D_METHOD("add_edge", "a", "b", "weight"), &Graph::add_edge, DEFVAL(1.0));
+	ClassDB::bind_method(D_METHOD("add_directed_edge", "a", "b", "weight"), &Graph::add_directed_edge, DEFVAL(1.0));
+	ClassDB::bind_method(D_METHOD("find_edge", "a", "b"), &Graph::find_edge);
+}
+
+void GraphVertex::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_value", "value"), &GraphVertex::set_value);
+	ClassDB::bind_method(D_METHOD("get_value"), &GraphVertex::get_value);
+
+	ADD_PROPERTY(PropertyInfo(Variant::NIL, "value", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT), "set_value", "get_value");
+}
+
+void GraphEdge::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_vertex_a"), &GraphEdge::get_vertex_a);
+	ClassDB::bind_method(D_METHOD("get_vertex_b"), &GraphEdge::get_vertex_b);
+
+	ClassDB::bind_method(D_METHOD("set_weight", "weight"), &GraphEdge::set_weight);
+	ClassDB::bind_method(D_METHOD("get_weight"), &GraphEdge::get_weight);
+
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "vertex_a"), "", "get_vertex_a");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "vertex_b"), "", "get_vertex_b");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "weight"), "set_weight", "get_weight");
+}

--- a/core/types/graph.cpp
+++ b/core/types/graph.cpp
@@ -260,7 +260,7 @@ void Graph::clear() {
 
 void Graph::clear_edges() {
 	Vector<GraphEdge *> to_delete;
-	
+
 	const Pair<uint32_t, uint32_t> *k = nullptr;
 	while ((k = graph->edges.next(k))) {
 		List<GraphEdge *> &list = graph->edges[*k];
@@ -337,8 +337,8 @@ void GraphEdge::_notification(int p_what) {
 }
 
 void GraphEdge::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("get_vertex_a"), &GraphEdge::get_vertex_a);
-	ClassDB::bind_method(D_METHOD("get_vertex_b"), &GraphEdge::get_vertex_b);
+	ClassDB::bind_method(D_METHOD("get_a"), &GraphEdge::get_a);
+	ClassDB::bind_method(D_METHOD("get_b"), &GraphEdge::get_b);
 
 	ClassDB::bind_method(D_METHOD("is_loop"), &GraphEdge::is_loop);
 	ClassDB::bind_method(D_METHOD("is_directed"), &GraphEdge::is_directed);
@@ -346,7 +346,7 @@ void GraphEdge::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_value", "value"), &GraphEdge::set_value);
 	ClassDB::bind_method(D_METHOD("get_value"), &GraphEdge::get_value);
 
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "vertex_a"), "", "get_vertex_a");
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "vertex_b"), "", "get_vertex_b");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "a"), "", "get_a");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "b"), "", "get_b");
 	ADD_PROPERTY(PropertyInfo(Variant::NIL, "value", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT), "set_value", "get_value");
 }

--- a/core/types/graph.cpp
+++ b/core/types/graph.cpp
@@ -1,20 +1,32 @@
 #include "graph.h"
 
+#include "core/set.h"
+
 #ifdef DEBUG_ENABLED
 
-#define ERR_INVALID_VERTICES(m_a, m_b) \
-	ERR_FAIL_NULL(a);               \
-	ERR_FAIL_NULL(b);               \
-	ERR_FAIL_COND(!graph.has(a));   \
-	ERR_FAIL_COND(!graph.has(b));
+#define ERR_INVALID_VERTEX(m_v) \
+	ERR_FAIL_NULL(v);           \
+	ERR_FAIL_COND(!graph->data.has(v));
 
-#define ERR_INVALID_VERTICES_V(m_a, m_b, m_ret) \
-	ERR_FAIL_NULL_V(a, m_ret);               \
-	ERR_FAIL_NULL_V(b, m_ret);               \
-	ERR_FAIL_COND_V(!graph.has(a), m_ret);   \
-	ERR_FAIL_COND_V(!graph.has(b), m_ret);   
+#define ERR_INVALID_VERTEX_V(m_v, m_ret) \
+	ERR_FAIL_NULL_V(v, m_ret);           \
+	ERR_FAIL_COND_V(!graph->data.has(v), m_ret);
+
+#define ERR_INVALID_VERTICES(m_a, m_b)  \
+	ERR_FAIL_NULL(a);                   \
+	ERR_FAIL_NULL(b);                   \
+	ERR_FAIL_COND(!graph->data.has(a)); \
+	ERR_FAIL_COND(!graph->data.has(b));
+
+#define ERR_INVALID_VERTICES_V(m_a, m_b, m_ret)  \
+	ERR_FAIL_NULL_V(a, m_ret);                   \
+	ERR_FAIL_NULL_V(b, m_ret);                   \
+	ERR_FAIL_COND_V(!graph->data.has(a), m_ret); \
+	ERR_FAIL_COND_V(!graph->data.has(b), m_ret);
 #else
 
+#define ERR_INVALID_VERTEX(m_v)
+#define ERR_INVALID_VERTEX_V(m_v, m_ret)
 #define ERR_INVALID_VERTICES(m_a, m_b)
 #define ERR_INVALID_VERTICES_V(m_a, m_b, m_ret)
 
@@ -24,9 +36,121 @@ GraphVertex *Graph::add_vertex(const Variant &p_value) {
 	GraphVertex *v = memnew(GraphVertex);
 
 	v->value = p_value;
-	graph[v] = List<GraphEdge *>();
+	graph->data[v] = List<GraphEdge *>();
+	v->graph = graph;
 
 	return v;
+}
+
+void Graph::remove_vertex(GraphVertex *v) {
+	ERR_INVALID_VERTEX(v);
+	// Calls into GraphData::remove_vertex() during NOTIFICATION_PREDELETE
+	memdelete(v);
+}
+
+void GraphData::remove_vertex(GraphVertex *v) {
+	using EdgeItem = List<GraphEdge *>::Element *;
+	using EdgeList = List<GraphEdge *> *;
+
+	Map<EdgeItem, EdgeList> edges_to_remove;
+
+	// Find all vertices connected to this one, including the vertex to be removed.
+	Vector<GraphVertex *> closed_neighborhood;
+	closed_neighborhood.push_back(v);
+
+	List<GraphEdge *> &list_v = data[v];
+	for (EdgeItem E = list_v.front(); E; E = E->next()) {
+		GraphEdge *edge = E->get();
+		if (v == edge->a) {
+			closed_neighborhood.push_back(edge->b);
+		} else {
+			closed_neighborhood.push_back(edge->a);
+		}
+	}
+	// Find edges that are associated with the vertices above.
+	for (int i = 0; i < closed_neighborhood.size(); ++i) {
+		GraphVertex *n = closed_neighborhood[i];
+		List<GraphEdge *> &list_n = data[n];
+
+		for (EdgeItem E = list_n.front(); E; E = E->next()) {
+			GraphEdge *edge = E->get();
+			if (v == edge->a || v == edge->b) {
+				edges_to_remove[E] = &list_n;
+			}
+		}
+	}
+	// Delete all edges associated with the vertex.
+	Set<GraphEdge *> edges_to_delete;
+
+	for (Map<EdgeItem, EdgeList>::Element *E = edges_to_remove.front(); E; E = E->next()) {
+		EdgeItem item = E->key();
+		GraphEdge *edge = item->get();
+		edges_to_delete.insert(edge);
+
+		EdgeList list = E->get();
+		list->erase(item);
+	}
+	for (Set<GraphEdge *>::Element *E = edges_to_delete.front(); E; E = E->next()) {
+		memdelete(E->get());
+	}
+	v->graph = nullptr;
+	bool erased = data.erase(v);
+	ERR_FAIL_COND(!erased);
+}
+
+Array Graph::get_neighbors(GraphVertex *v) {
+	ERR_INVALID_VERTEX_V(v, Array());
+
+	Array neighborhood;
+	const List<GraphEdge *> &list = graph->data[v];
+
+	for (const List<GraphEdge *>::Element *E = list.front(); E; E = E->next()) {
+		GraphEdge *edge = E->get();
+		if (edge->bidirectional) {
+			if (v == edge->a) {
+				neighborhood.push_back(edge->b);
+			} else {
+				neighborhood.push_back(edge->a);
+			}
+		}
+	}
+	return neighborhood;
+}
+
+Array Graph::get_successors(GraphVertex *v) {
+	ERR_INVALID_VERTEX_V(v, Array());
+
+	Array successors;
+	const List<GraphEdge *> &list = graph->data[v];
+
+	for (const List<GraphEdge *>::Element *E = list.front(); E; E = E->next()) {
+		GraphEdge *edge = E->get();
+		if (edge->bidirectional) {
+			continue;
+		}
+		if (v == edge->a) {
+			successors.push_back(edge->b);
+		}
+	}
+	return successors;
+}
+
+Array Graph::get_predecessors(GraphVertex *v) {
+	ERR_INVALID_VERTEX_V(v, Array());
+
+	Array predecessors;
+	const List<GraphEdge *> &list = graph->data[v];
+
+	for (const List<GraphEdge *>::Element *E = list.front(); E; E = E->next()) {
+		GraphEdge *edge = E->get();
+		if (edge->bidirectional) {
+			continue;
+		}
+		if (v == edge->b) {
+			predecessors.push_back(edge->a);
+		}
+	}
+	return predecessors;
 }
 
 GraphEdge *Graph::_add_edge(const Variant &p_a, const Variant &p_b, real_t p_weight, bool p_bidirectional) {
@@ -54,14 +178,19 @@ GraphEdge *Graph::_add_edge(const Variant &p_a, const Variant &p_b, real_t p_wei
 	edge->weight = p_weight;
 	edge->bidirectional = p_bidirectional;
 
-	graph[a].push_back(edge);
-	graph[b].push_back(edge);
+	graph->data[a].push_back(edge);
+	graph->data[b].push_back(edge);
+	edge->graph = graph;
 
 	return edge;
 }
 
 GraphEdge *Graph::add_edge(const Variant &p_a, const Variant &p_b, real_t p_weight) {
 	return _add_edge(p_a, p_b, p_weight, true);
+}
+
+void GraphData::remove_edge(GraphEdge *e) {
+	e->graph = nullptr;
 }
 
 GraphEdge *Graph::add_directed_edge(const Variant &p_a, const Variant &p_b, real_t p_weight) {
@@ -71,7 +200,7 @@ GraphEdge *Graph::add_directed_edge(const Variant &p_a, const Variant &p_b, real
 GraphEdge *Graph::find_edge(GraphVertex *a, GraphVertex *b) const {
 	ERR_INVALID_VERTICES_V(a, b, nullptr);
 
-	const List<GraphEdge *> &list = graph[a];
+	const List<GraphEdge *> &list = graph->data[a];
 	for (const List<GraphEdge *>::Element *E = list.front(); E; E = E->next()) {
 		GraphEdge *edge = E->get();
 		if (a == edge->a && b == edge->b) {
@@ -84,12 +213,98 @@ GraphEdge *Graph::find_edge(GraphVertex *a, GraphVertex *b) const {
 	return nullptr;
 }
 
+Array Graph::get_edge_list(GraphVertex *a, GraphVertex *b) const {
+	Array edge_list;
+
+	Set<GraphEdge *> edge_set;
+
+	if (!a && !b) {
+		// Get all edges in the graph.
+		for (Map<GraphVertex *, List<GraphEdge *>>::Element *E = graph->data.front(); E; E = E->next()) {
+			const List<GraphEdge *> &list = E->get();
+			for (const List<GraphEdge *>::Element *I = list.front(); I; I = I->next()) {
+				edge_set.insert(I->get());
+			}
+		}
+	} else {
+		// Get all edges between vertices.
+		for (Map<GraphVertex *, List<GraphEdge *>>::Element *E = graph->data.front(); E; E = E->next()) {
+			const List<GraphEdge *> &list = E->get();
+			for (const List<GraphEdge *>::Element *I = list.front(); I; I = I->next()) {
+				GraphEdge *edge = I->get();
+				if (a == edge->a && b == edge->b) {
+					edge_set.insert(edge);
+				}
+				if (edge->bidirectional && a == edge->b && b == edge->a) {
+					edge_set.insert(edge);
+				}
+			}
+		}
+	}
+	for (const Set<GraphEdge *>::Element *I = edge_set.front(); I; I = I->next()) {
+		edge_list.push_back(I->get());
+	}
+	return edge_list;
+}
+
+int Graph::get_edge_count() const {
+	Set<GraphEdge *> edge_set;
+
+	for (const Map<GraphVertex *, List<GraphEdge *>>::Element *E = graph->data.front(); E; E = E->next()) {
+		const List<GraphEdge *> &list = E->get();
+		for (const List<GraphEdge *>::Element *I = list.front(); I; I = I->next()) {
+			edge_set.insert(I->get());
+		}
+	}
+	return edge_set.size();
+}
+
+void Graph::clear() {
+	Vector<GraphVertex *> to_remove;
+	for (Map<GraphVertex *, List<GraphEdge *>>::Element *E = graph->data.front(); E; E = E->next()) {
+		to_remove.push_back(E->key());
+	}
+	for (int i = 0; i < to_remove.size(); ++i) {
+		memdelete(to_remove[i]); // This will also delete associated edges.
+	}
+}
+
 void Graph::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_vertex", "value"), &Graph::add_vertex);
+	ClassDB::bind_method(D_METHOD("remove_vertex", "vertex"), &Graph::remove_vertex);
+	ClassDB::bind_method(D_METHOD("has_vertex", "vertex"), &Graph::has_vertex);
+	ClassDB::bind_method(D_METHOD("get_vertex_count"), &Graph::get_vertex_count);
+
+	ClassDB::bind_method(D_METHOD("get_neighbors", "vertex"), &Graph::get_neighbors);
+	ClassDB::bind_method(D_METHOD("get_successors", "vertex"), &Graph::get_successors);
+	ClassDB::bind_method(D_METHOD("get_predecessors", "vertex"), &Graph::get_predecessors);
 
 	ClassDB::bind_method(D_METHOD("add_edge", "a", "b", "weight"), &Graph::add_edge, DEFVAL(1.0));
-	ClassDB::bind_method(D_METHOD("add_directed_edge", "a", "b", "weight"), &Graph::add_directed_edge, DEFVAL(1.0));
+	ClassDB::bind_method(D_METHOD("add_directed_edge", "from", "to", "weight"), &Graph::add_directed_edge, DEFVAL(1.0));
 	ClassDB::bind_method(D_METHOD("find_edge", "a", "b"), &Graph::find_edge);
+	ClassDB::bind_method(D_METHOD("get_edge_list", "a", "b"), &Graph::get_edge_list, DEFVAL(Variant()), DEFVAL(Variant()));
+	ClassDB::bind_method(D_METHOD("get_edge_count"), &Graph::get_edge_count);
+}
+
+Graph::Graph() {
+	graph = memnew(GraphData);
+}
+
+Graph::~Graph() {
+	clear();
+	if (graph) {
+		memdelete(graph);
+	}
+}
+
+void GraphVertex::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_PREDELETE: {
+			if (graph) {
+				graph->remove_vertex(this);
+			}
+		} break;
+	}
 }
 
 void GraphVertex::_bind_methods() {
@@ -97,6 +312,16 @@ void GraphVertex::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_value"), &GraphVertex::get_value);
 
 	ADD_PROPERTY(PropertyInfo(Variant::NIL, "value", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT), "set_value", "get_value");
+}
+
+void GraphEdge::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_PREDELETE: {
+			if (graph) {
+				graph->remove_edge(this);
+			}
+		} break;
+	}
 }
 
 void GraphEdge::_bind_methods() {

--- a/core/types/graph.cpp
+++ b/core/types/graph.cpp
@@ -122,6 +122,10 @@ Array GraphVertex::get_successors() const {
 	return ret;
 }
 
+int GraphVertex::get_successor_count() const {
+	return get_successors().size(); // TODO: can be optimized.
+}
+
 Array GraphVertex::get_predecessors() const {
 	Array ret;
 
@@ -145,6 +149,10 @@ Array GraphVertex::get_predecessors() const {
 		}
 	}
 	return ret;
+}
+
+int GraphVertex::get_predecessor_count() const {
+	return get_predecessors().size(); // TODO: can be optimized.
 }
 
 GraphEdge *Graph::_add_edge(const Variant &p_a, const Variant &p_b, const Variant &p_value, bool p_directed) {
@@ -177,7 +185,7 @@ GraphEdge *Graph::_add_edge(const Variant &p_a, const Variant &p_b, const Varian
 	edge->id = next_edge_id++;
 	edge->graph = graph;
 
-	auto &key = EdgeKey(a->id, b->id);
+	const auto &key = EdgeKey(a->id, b->id);
 	if (!graph->edges.has(key)) {
 		List<GraphEdge *> list;
 		list.push_back(edge);
@@ -319,8 +327,13 @@ void GraphVertex::_notification(int p_what) {
 
 void GraphVertex::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_neighbors"), &GraphVertex::get_neighbors);
+	ClassDB::bind_method(D_METHOD("get_neighbor_count"), &GraphVertex::get_neighbor_count);
+
 	ClassDB::bind_method(D_METHOD("get_successors"), &GraphVertex::get_successors);
+	ClassDB::bind_method(D_METHOD("get_successor_count"), &GraphVertex::get_successor_count);
+
 	ClassDB::bind_method(D_METHOD("get_predecessors"), &GraphVertex::get_predecessors);
+	ClassDB::bind_method(D_METHOD("get_predecessor_count"), &GraphVertex::get_predecessor_count);
 
 	ClassDB::bind_method(D_METHOD("set_value", "value"), &GraphVertex::set_value);
 	ClassDB::bind_method(D_METHOD("get_value"), &GraphVertex::get_value);

--- a/core/types/graph.cpp
+++ b/core/types/graph.cpp
@@ -744,8 +744,6 @@ void GraphVertex::_notification(int p_what) {
 }
 
 void GraphVertex::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("get_graph"), &GraphVertex::get_graph);
-
 	ClassDB::bind_method(D_METHOD("get_neighbors"), &GraphVertex::get_neighbors);
 	ClassDB::bind_method(D_METHOD("get_neighbor_count"), &GraphVertex::get_neighbor_count);
 
@@ -758,7 +756,18 @@ void GraphVertex::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_value", "value"), &GraphVertex::set_value);
 	ClassDB::bind_method(D_METHOD("get_value"), &GraphVertex::get_value);
 
+	ClassDB::bind_method(D_METHOD("get_graph"), &GraphVertex::get_graph);
+
 	ADD_PROPERTY(PropertyInfo(Variant::NIL, "value", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT), "set_value", "get_value");
+}
+
+Ref<Graph> GraphEdge::get_graph() const {
+	ERR_FAIL_NULL_V(graph, Ref<Graph>());
+
+	Object *obj = ObjectDB::get_instance(graph->id);
+	Ref<Graph> graph_ref(Object::cast_to<Graph>(obj));
+
+	return graph_ref;
 }
 
 void GraphEdge::_notification(int p_what) {
@@ -780,6 +789,8 @@ void GraphEdge::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_value", "value"), &GraphEdge::set_value);
 	ClassDB::bind_method(D_METHOD("get_value"), &GraphEdge::get_value);
+
+	ClassDB::bind_method(D_METHOD("get_graph"), &GraphEdge::get_graph);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "a"), "", "get_a");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "b"), "", "get_b");

--- a/core/types/graph.cpp
+++ b/core/types/graph.cpp
@@ -294,10 +294,9 @@ Array Graph::get_edge_list(GraphVertex *p_a, GraphVertex *p_b) const {
 Array Graph::find_connected_component(GraphVertex *p_vertex) const {
 	Array component;
 
-	GraphDFS state(p_vertex);
-
-	while (state.has_next()) {
-		GraphVertex *v = state.next();
+	GraphDFS dfs(p_vertex);
+	while (dfs.has_next()) {
+		GraphVertex *v = dfs.next();
 		if (v) {
 			component.push_back(v);
 		}
@@ -319,9 +318,9 @@ bool Graph::is_strongly_connected() const {
 
 	uint32_t count = 0;
 
-	GraphDFS state(root);
-	while (state.has_next()) {
-		GraphVertex *v = state.next();
+	GraphDFS dfs(root);
+	while (dfs.has_next()) {
+		GraphVertex *v = dfs.next();
 		if (v) {
 			count++;
 		}
@@ -457,7 +456,7 @@ GraphVertex *GraphDFS::next() {
 	if (stack.is_empty()) {
 		return nullptr;
 	}
-	GraphVertex *v = stack.pop_back();
+	GraphVertex *v = stack.pop();
 	if (visited.has(v->id)) {
 		return nullptr;
 	}
@@ -467,7 +466,7 @@ GraphVertex *GraphDFS::next() {
 	while ((k = v->neighbors.next(k))) {
 		GraphVertex *vn = graph->vertices[*k];
 		if (!visited.has(vn->id)) {
-			stack.push_back(vn);
+			stack.push(vn);
 		}
 	}
 	return v;
@@ -475,6 +474,6 @@ GraphVertex *GraphDFS::next() {
 
 GraphDFS::GraphDFS(GraphVertex *p_root) {
 	ERR_FAIL_NULL(p_root);
-	stack.push_back(p_root);
+	stack.push(p_root);
 	graph = p_root->graph;
 }

--- a/core/types/graph.cpp
+++ b/core/types/graph.cpp
@@ -4,15 +4,16 @@
 #include "core/string_names.h"
 
 using EdgeKey = Pair<uint32_t, uint32_t>;
+using EdgeList = LocalVector<GraphEdge *, int>;
 
 void GraphData::remove_vertex(GraphVertex *p_vertex) {
-	LocalVector<GraphEdge *> edges_to_delete;
+	EdgeList edges_to_delete;
 
 	const uint32_t *n = nullptr;
 	while ((n = p_vertex->neighbors.next(n))) {
 		GraphVertex *n_vertex = p_vertex->neighbors[*n];
 
-		LocalVector<GraphEdge *> &list = get_edges(p_vertex->id, n_vertex->id);
+		EdgeList &list = get_edges(p_vertex->id, n_vertex->id);
 
 		for (int i = 0; i < list.size(); ++i) {
 			// Removing edges updates neighbors as well, but doing so here
@@ -37,7 +38,7 @@ void GraphData::remove_edge(GraphEdge *p_edge) {
 	GraphVertex *&a = p_edge->a;
 	GraphVertex *&b = p_edge->b;
 
-	LocalVector<GraphEdge *> &list = get_edges(a->id, b->id);
+	EdgeList &list = get_edges(a->id, b->id);
 
 	for (int i = 0; i < list.size(); ++i) {
 		if (p_edge == list[i]) {
@@ -141,7 +142,7 @@ Array GraphVertex::get_successors() const {
 		const GraphVertex *a = this;
 		const GraphVertex *b = neighbors[*n];
 
-		const LocalVector<GraphEdge *> &list = graph->get_edges(a->id, b->id);
+		const EdgeList &list = graph->get_edges(a->id, b->id);
 
 		for (int i = 0; i < list.size(); ++i) {
 			GraphEdge *edge = list[i];
@@ -170,7 +171,7 @@ Array GraphVertex::get_predecessors() const {
 		const GraphVertex *a = this;
 		const GraphVertex *b = neighbors[*n];
 
-		const LocalVector<GraphEdge *> &list = graph->get_edges(a->id, b->id);
+		const EdgeList &list = graph->get_edges(a->id, b->id);
 
 		for (int i = 0; i < list.size(); ++i) {
 			GraphEdge *edge = list[i];
@@ -223,12 +224,12 @@ GraphEdge *Graph::_add_edge(const Variant &p_a, const Variant &p_b, const Varian
 
 	const auto &key = EdgeKey(a->id, b->id);
 	if (!graph->edges.has(key)) {
-		LocalVector<GraphEdge *> list;
+		EdgeList list;
 		list.reserve(4); // Slight optimization for directed or multi-edges.
 		list.push_back(edge);
 		graph->edges[key] = list;
 	} else {
-		LocalVector<GraphEdge *> &list = graph->edges[key];
+		EdgeList &list = graph->edges[key];
 		list.push_back(edge);
 	}
 	return edge;
@@ -242,12 +243,12 @@ GraphEdge *Graph::add_directed_edge(const Variant &p_a, const Variant &p_b, cons
 	return _add_edge(p_a, p_b, p_value, true);
 }
 
-LocalVector<GraphEdge *> &GraphData::get_edges(uint32_t a_id, uint32_t b_id) {
+EdgeList &GraphData::get_edges(uint32_t a_id, uint32_t b_id) {
 	return edges[EdgeKey(a_id, b_id)];
 }
 
 GraphEdge *Graph::find_edge(GraphVertex *p_a, GraphVertex *p_b) const {
-	const LocalVector<GraphEdge *> &list = graph->get_edges(p_a->id, p_b->id);
+	const EdgeList &list = graph->get_edges(p_a->id, p_b->id);
 
 	for (int i = 0; i < list.size(); ++i) {
 		GraphEdge *edge = list[i];
@@ -272,7 +273,7 @@ Array Graph::get_edge_list(GraphVertex *p_a, GraphVertex *p_b) const {
 
 	const EdgeKey *k = nullptr;
 	while ((k = graph->edges.next(k))) {
-		LocalVector<GraphEdge *> &list = graph->edges[*k];
+		EdgeList &list = graph->edges[*k];
 
 		for (int i = 0; i < list.size(); ++i) {
 			GraphEdge *edge = list[i];
@@ -306,11 +307,11 @@ void Graph::clear() {
 }
 
 void Graph::clear_edges() {
-	LocalVector<GraphEdge *> to_delete;
+	EdgeList to_delete;
 
 	const EdgeKey *k = nullptr;
 	while ((k = graph->edges.next(k))) {
-		LocalVector<GraphEdge *> &list = graph->edges[*k];
+		EdgeList &list = graph->edges[*k];
 
 		for (int i = 0; i < list.size(); ++i) {
 			to_delete.push_back(list[i]);

--- a/core/types/graph.cpp
+++ b/core/types/graph.cpp
@@ -87,64 +87,64 @@ Array Graph::get_vertex_list() const {
 	return vertex_list;
 }
 
-Array Graph::get_neighbors(GraphVertex *p_vertex) {
-	Array neighbors;
+Array GraphVertex::get_neighbors() const {
+	Array ret;
 
 	const uint32_t *n = nullptr;
-	while ((n = p_vertex->neighbors.next(n))) {
-		neighbors.push_back(p_vertex->neighbors[*n]);
+	while ((n = neighbors.next(n))) {
+		ret.push_back(neighbors[*n]);
 	}
-	return neighbors;
+	return ret;
 }
 
-Array Graph::get_successors(GraphVertex *p_vertex) {
-	Array successors;
+Array GraphVertex::get_successors() const {
+	Array ret;
 
 	const uint32_t *n = nullptr;
-	while ((n = p_vertex->neighbors.next(n))) {
-		GraphVertex *a = p_vertex;
-		GraphVertex *b = p_vertex->neighbors[*n];
+	while ((n = neighbors.next(n))) {
+		const GraphVertex *a = this;
+		const GraphVertex *b = neighbors[*n];
 
 		const List<GraphEdge *> &list = graph->get_edges(a->id, b->id);
 
 		for (const List<GraphEdge *>::Element *E = list.front(); E; E = E->next()) {
 			GraphEdge *edge = E->get();
-			if (!edge->directed) {
+			if (!edge->is_directed()) {
 				continue;
 			}
-			if (p_vertex == edge->a) {
-				successors.push_back(edge->b);
+			if (edge->get_a() == this) {
+				ret.push_back(edge->get_b());
 				// There may be multiple edges connected from the same vertex.
 				break;
 			}
 		}
 	}
-	return successors;
+	return ret;
 }
 
-Array Graph::get_predecessors(GraphVertex *p_vertex) {
-	Array predecessors;
+Array GraphVertex::get_predecessors() const {
+	Array ret;
 
 	const uint32_t *n = nullptr;
-	while ((n = p_vertex->neighbors.next(n))) {
-		GraphVertex *a = p_vertex;
-		GraphVertex *b = p_vertex->neighbors[*n];
+	while ((n = neighbors.next(n))) {
+		const GraphVertex *a = this;
+		const GraphVertex *b = neighbors[*n];
 
 		const List<GraphEdge *> &list = graph->get_edges(a->id, b->id);
 
 		for (const List<GraphEdge *>::Element *E = list.front(); E; E = E->next()) {
 			GraphEdge *edge = E->get();
-			if (!edge->directed) {
+			if (!edge->is_directed()) {
 				continue;
 			}
-			if (p_vertex == edge->b) {
-				predecessors.push_back(edge->a);
+			if (edge->get_b() == this) {
+				ret.push_back(edge->get_a());
 				// There may be multiple edges connected from the same vertex.
 				break;
 			}
 		}
 	}
-	return predecessors;
+	return ret;
 }
 
 GraphEdge *Graph::_add_edge(const Variant &p_a, const Variant &p_b, const Variant &p_value, bool p_directed) {
@@ -284,10 +284,6 @@ void Graph::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_vertex_list"), &Graph::get_vertex_list);
 	ClassDB::bind_method(D_METHOD("get_vertex_count"), &Graph::get_vertex_count);
 
-	ClassDB::bind_method(D_METHOD("get_neighbors", "vertex"), &Graph::get_neighbors);
-	ClassDB::bind_method(D_METHOD("get_successors", "vertex"), &Graph::get_successors);
-	ClassDB::bind_method(D_METHOD("get_predecessors", "vertex"), &Graph::get_predecessors);
-
 	ClassDB::bind_method(D_METHOD("add_edge", "a", "b", "value"), &Graph::add_edge, DEFVAL(1.0));
 	ClassDB::bind_method(D_METHOD("add_directed_edge", "from", "to", "value"), &Graph::add_directed_edge, DEFVAL(1.0));
 	ClassDB::bind_method(D_METHOD("remove_edge", "edge"), &Graph::remove_edge);
@@ -322,6 +318,10 @@ void GraphVertex::_notification(int p_what) {
 }
 
 void GraphVertex::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_neighbors"), &GraphVertex::get_neighbors);
+	ClassDB::bind_method(D_METHOD("get_successors"), &GraphVertex::get_successors);
+	ClassDB::bind_method(D_METHOD("get_predecessors"), &GraphVertex::get_predecessors);
+
 	ClassDB::bind_method(D_METHOD("set_value", "value"), &GraphVertex::set_value);
 	ClassDB::bind_method(D_METHOD("get_value"), &GraphVertex::get_value);
 

--- a/core/types/graph.cpp
+++ b/core/types/graph.cpp
@@ -42,6 +42,15 @@ GraphVertex *Graph::add_vertex(const Variant &p_value) {
 	return v;
 }
 
+Array Graph::get_vertex_list() const {
+	Array vertex_list;
+
+	for (Map<GraphVertex *, List<GraphEdge *>>::Element *E = graph->data.front(); E; E = E->next()) {
+		vertex_list.push_back(E->key());
+	}
+	return vertex_list;
+}
+
 void Graph::remove_vertex(GraphVertex *v) {
 	ERR_INVALID_VERTEX(v);
 	// Calls into GraphData::remove_vertex() during NOTIFICATION_PREDELETE
@@ -308,6 +317,7 @@ void Graph::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_vertex", "value"), &Graph::add_vertex);
 	ClassDB::bind_method(D_METHOD("remove_vertex", "vertex"), &Graph::remove_vertex);
 	ClassDB::bind_method(D_METHOD("has_vertex", "vertex"), &Graph::has_vertex);
+	ClassDB::bind_method(D_METHOD("get_vertex_list"), &Graph::get_vertex_list);
 	ClassDB::bind_method(D_METHOD("get_vertex_count"), &Graph::get_vertex_count);
 
 	ClassDB::bind_method(D_METHOD("get_neighbors", "vertex"), &Graph::get_neighbors);

--- a/core/types/graph.cpp
+++ b/core/types/graph.cpp
@@ -9,6 +9,9 @@ using EdgeKey = GraphData::EdgeKey;
 using EdgeList = LocalVector<GraphEdge *, int>;
 
 void GraphData::remove_vertex(GraphVertex *p_vertex) {
+	if (clearing_all) {
+		return;	
+	}
 	EdgeList edges_to_delete;
 
 	const uint32_t *n = nullptr;
@@ -37,6 +40,9 @@ void GraphData::remove_vertex(GraphVertex *p_vertex) {
 }
 
 void GraphData::remove_edge(GraphEdge *p_edge) {
+	if (clearing_all) {
+		return;	
+	}
 	GraphVertex *&a = p_edge->a;
 	GraphVertex *&b = p_edge->b;
 
@@ -497,20 +503,22 @@ Dictionary Graph::get_connected_components() {
 }
 
 void Graph::clear() {
-	Vector<GraphVertex *> to_delete;
+	graph->clearing_all = true;
+	clear_edges();
+
+	LocalVector<GraphVertex *, int> vertices_to_delete;
 
 	const uint32_t *k = nullptr;
 	while ((k = graph->vertices.next(k))) {
-		to_delete.push_back(graph->vertices[*k]);
+		vertices_to_delete.push_back(graph->vertices[*k]);
 	}
-	for (int i = 0; i < to_delete.size(); ++i) {
-		// This will also delete edges, see GraphData::remove_vertex()
-		memdelete(to_delete[i]);
+	for (int i = 0; i < vertices_to_delete.size(); ++i) {
+		memdelete(vertices_to_delete[i]);
 	}
 	graph->vertices.clear();
-	graph->edges.clear();
-
 	next_vertex_id = 1;
+
+	graph->clearing_all = false;
 }
 
 void Graph::clear_edges() {

--- a/core/types/graph.h
+++ b/core/types/graph.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "core/reference.h"
+#include "core/resource.h"
 
 #include "core/hash_map.h"
 #include "core/local_vector.h"
@@ -41,13 +41,12 @@ struct GraphData {
 	_FORCE_INLINE_ EdgeList &get_edges(uint32_t a_id, uint32_t b_id);
 };
 
-class Graph : public Reference {
-	GDCLASS(Graph, Reference);
+class Graph : public Resource {
+	GDCLASS(Graph, Resource);
 
 	GraphData *graph = nullptr;
 
 	uint32_t next_vertex_id = 1;
-	uint32_t next_edge_id = 1;
 
 	Ref<GraphIterator> G;
 	Ref<GraphIteratorDFS> G_dfs; // Default one.
@@ -55,9 +54,17 @@ class Graph : public Reference {
 
 protected:
 	static void _bind_methods();
+
+	// Storage
+	void _set_data(const Dictionary &p_data);
+	Dictionary _get_data() const;
+
+	// Utilities
+	GraphVertex *_add_vertex(const Variant &p_value, uint32_t p_id = 0);
 	GraphEdge *_add_edge(const Variant &p_a, const Variant &p_b, const Variant &p_value, bool p_directed);
 
 public:
+	// Instantiation
 	virtual GraphVertex *_create_vertex();
 	virtual GraphEdge *_create_edge();
 
@@ -87,7 +94,7 @@ public:
 	void clear();
 	void clear_edges();
 
-	// Custom iterator
+	// Iterator
 	void set_iterator(const Ref<GraphIterator> &p_iterator);
 	Ref<GraphIterator> get_iterator() const { return G; }
 

--- a/core/types/graph.h
+++ b/core/types/graph.h
@@ -90,6 +90,8 @@ public:
 	Dictionary get_connected_components();
 	bool is_strongly_connected();
 
+	Array minimum_spanning_tree() const;
+
 	// Cleanup
 	void clear();
 	void clear_edges();

--- a/core/types/graph.h
+++ b/core/types/graph.h
@@ -147,13 +147,11 @@ public:
 class GraphDFS {
 	GraphData *graph = nullptr;
 	Stack<GraphVertex *> stack;
-	OAHashMap<uint32_t, bool> visited;
-	bool discovered = false;
+	Set<uint32_t> visited;
 
 public:
 	bool has_next();
 	GraphVertex *next();
-	bool has_discovered() { return discovered; }
 
 	GraphDFS(GraphVertex *p_root);
 };

--- a/core/types/graph.h
+++ b/core/types/graph.h
@@ -1,24 +1,29 @@
 #pragma once
 
-#include "core/list.h"
 #include "core/hash_map.h"
+#include "core/list.h"
+#include "core/pair.h"
 #include "core/reference.h"
 
 class GraphVertex;
 class GraphEdge;
 
 struct GraphData {
-	struct ObjectPtrHash {
-		static _FORCE_INLINE_ uint32_t hash(const Object *p_obj) {
-			union {
-				const Object *p;
-				unsigned long i;
-			} u;
-			u.p = p_obj;
-			return HashMapHasherDefault::hash((uint64_t)u.i);
+	using EdgeKey = Pair<uint32_t, uint32_t>;
+
+	struct EdgeKeyHasher {
+		static _FORCE_INLINE_ uint32_t hash(const EdgeKey &key) {
+			return key.first ^ key.second;
 		}
 	};
-	HashMap<GraphVertex *, List<GraphEdge *>, ObjectPtrHash> data;
+	struct EdgeKeyComparator {
+		static bool compare(const EdgeKey &a, const EdgeKey &b) {
+			return ((a.first == b.first) && (a.second == b.second)) ||
+				   ((a.first == b.second) && (a.second == b.first));
+		}
+	};
+	HashMap<uint32_t, GraphVertex *> vertices;
+	HashMap<EdgeKey, List<GraphEdge *>, EdgeKeyHasher, EdgeKeyComparator> edges;
 
 	void remove_vertex(GraphVertex *p_vertex);
 	void remove_edge(GraphEdge *p_vertex);
@@ -29,31 +34,34 @@ class Graph : public Reference {
 
 	GraphData *graph = nullptr;
 
+	uint32_t next_vertex_id = 1;
+	uint32_t next_edge_id = 1;
+
 protected:
 	static void _bind_methods();
 
-	GraphEdge *_add_edge(const Variant &a, const Variant &b, real_t weight, bool directed);
+	GraphEdge *_add_edge(const Variant &p_a, const Variant &p_b, const Variant &p_value, bool p_directed);
 
 public:
 	// Vertex API
 	GraphVertex *add_vertex(const Variant &p_value);
 	void remove_vertex(GraphVertex *p_vertex);
-	bool has_vertex(GraphVertex *p_vertex) const { return graph->data.has(p_vertex); }
+	bool has_vertex(GraphVertex *p_vertex) const;
 	Array get_vertex_list() const;
-	int get_vertex_count() const { return graph->data.size(); }
+	int get_vertex_count() const { return graph->vertices.size(); }
 
 	Array get_neighbors(GraphVertex *p_vertex);
 	Array get_successors(GraphVertex *p_vertex);
 	Array get_predecessors(GraphVertex *p_vertex);
 
 	// Edge API
-	GraphEdge *add_edge(const Variant &a, const Variant &b, real_t weight = 1.0);
-	GraphEdge *add_directed_edge(const Variant &a, const Variant &b, real_t weight = 1.0);
+	GraphEdge *add_edge(const Variant &a, const Variant &b, const Variant &p_value);
+	GraphEdge *add_directed_edge(const Variant &p_a, const Variant &p_b, const Variant &p_value);
 	void remove_edge(GraphEdge *e);
 	GraphEdge *find_edge(GraphVertex *a, GraphVertex *b) const;
 	bool has_edge(GraphVertex *a, GraphVertex *b) const;
 	Array get_edge_list(GraphVertex *a = nullptr, GraphVertex *b = nullptr) const;
-	int get_edge_count() const;
+	int get_edge_count() const { return graph->edges.size(); }
 
 	// Cleanup
 	void clear();
@@ -68,9 +76,12 @@ class GraphVertex : public Object {
 
 	friend class Graph;
 	friend struct GraphData;
+
 	GraphData *graph = nullptr;
+	HashMap<uint32_t, GraphVertex *> neighbors;
 
 	Variant value;
+	uint32_t id;
 
 protected:
 	void _notification(int p_what);
@@ -88,11 +99,12 @@ class GraphEdge : public Object {
 	friend struct GraphData;
 	GraphData *graph = nullptr;
 
+	Variant value;
+	uint32_t id;
+
 	GraphVertex *a = nullptr;
 	GraphVertex *b = nullptr;
 	bool directed = false;
-
-	real_t weight = 1.0;
 
 protected:
 	void _notification(int p_what);
@@ -103,9 +115,10 @@ public:
 	GraphVertex *get_vertex_b() const { return b; }
 
 	bool is_loop() { return a == b; }
+	bool is_directed() { return directed; }
 
-	void set_weight(real_t p_weight) { weight = p_weight; }
-	real_t get_weight() const { return weight; }
+	void set_value(const Variant &p_value) { value = p_value; }
+	Variant get_value() const { return value; }
 };
 
 // Cast for bindings.

--- a/core/types/graph.h
+++ b/core/types/graph.h
@@ -26,7 +26,7 @@ public:
 	// Vertex API
 	GraphVertex *add_vertex(const Variant &p_value);
 	void remove_vertex(GraphVertex *p_vertex);
-	bool has_vertex(GraphVertex *p_vertex) const { return graph->data.has(v); }
+	bool has_vertex(GraphVertex *p_vertex) const { return graph->data.has(p_vertex); }
 	Array get_vertex_list() const;
 	int get_vertex_count() const { return graph->data.size(); }
 

--- a/core/types/graph.h
+++ b/core/types/graph.h
@@ -111,8 +111,8 @@ protected:
 	static void _bind_methods();
 
 public:
-	GraphVertex *get_vertex_a() const { return a; }
-	GraphVertex *get_vertex_b() const { return b; }
+	GraphVertex *get_a() const { return a; }
+	GraphVertex *get_b() const { return b; }
 
 	bool is_loop() { return a == b; }
 	bool is_directed() { return directed; }

--- a/core/types/graph.h
+++ b/core/types/graph.h
@@ -8,10 +8,14 @@
 #include "core/pair.h"
 
 #include "core/types/templates/stack.h"
+#include "core/types/templates/queue.h"
 
 class GraphVertex;
 class GraphEdge;
+
 class GraphIterator;
+class GraphIteratorDFS;
+class GraphIteratorBFS;
 
 struct GraphData {
 	using EdgeKey = Pair<uint32_t, uint32_t>;
@@ -45,8 +49,9 @@ class Graph : public Reference {
 	uint32_t next_vertex_id = 1;
 	uint32_t next_edge_id = 1;
 
-	Ref<GraphIterator> default_iterator;
-	Ref<GraphIterator> V;
+	Ref<GraphIterator> G;
+	Ref<GraphIteratorDFS> G_dfs; // Default one.
+	Ref<GraphIteratorBFS> G_bfs;
 
 protected:
 	static void _bind_methods();
@@ -75,8 +80,8 @@ public:
 
 	// Connectivity
 	Array find_connected_component(GraphVertex *p_vertex);
-	bool is_strongly_connected();
 	Dictionary get_connected_components();
+	bool is_strongly_connected();
 
 	// Cleanup
 	void clear();
@@ -84,7 +89,10 @@ public:
 
 	// Custom iterator
 	void set_iterator(const Ref<GraphIterator> &p_iterator);
-	Ref<GraphIterator> get_iterator() const { return V; }
+	Ref<GraphIterator> get_iterator() const { return G; }
+
+	void set_iterator_dfs() { G = G_dfs; }
+	void set_iterator_bfs() { G = G_bfs; }
 
 	Graph();
 	~Graph();
@@ -95,8 +103,10 @@ class GraphVertex : public Object {
 
 	friend class Graph;
 	friend struct GraphData;
+
 	friend class GraphIterator;
 	friend class GraphIteratorDFS;
+	friend class GraphIteratorBFS;
 
 	GraphData *graph = nullptr;
 
@@ -187,7 +197,23 @@ protected:
 	Set<GraphVertex *> visited;
 	GraphVertex *next_vertex = nullptr;
 
+	static void _bind_methods();
 	void advance();
+
+public:
+	virtual void initialize(GraphVertex *p_root);
+	virtual bool has_next() const;
+	virtual GraphVertex *next();
+};
+
+class GraphIteratorBFS : public GraphIterator {
+	GDCLASS(GraphIteratorBFS, GraphIterator);
+
+protected:
+	Queue<GraphVertex *> queue;
+	Set<GraphVertex *> visited;
+
+	static void _bind_methods();
 
 public:
 	virtual void initialize(GraphVertex *p_root);

--- a/core/types/graph.h
+++ b/core/types/graph.h
@@ -95,7 +95,7 @@ public:
 	void remove_vertex(GraphVertex *p_vertex);
 	GraphVertex *find_vertex(const Variant &p_value);
 	bool has_vertex(GraphVertex *p_vertex) const;
-	Array get_vertex_list() const;
+	Array get_vertices() const;
 	int get_vertex_count() const { return graph->vertices.size(); }
 
 	// Edge
@@ -104,7 +104,7 @@ public:
 	void remove_edge(GraphEdge *p_edge);
 	GraphEdge *find_edge(GraphVertex *p_vertex_a, GraphVertex *p_vertex_b) const;
 	bool has_edge(GraphVertex *p_vertex_a, GraphVertex *p_vertex_b) const;
-	Array get_edge_list(GraphVertex *p_vertex_a = nullptr, GraphVertex *p_vertex_b = nullptr) const;
+	Array get_edges(GraphVertex *p_vertex_a = nullptr, GraphVertex *p_vertex_b = nullptr) const;
 	int get_edge_count() const { return graph->edges.size(); }
 
 	// Connectivity

--- a/core/types/graph.h
+++ b/core/types/graph.h
@@ -5,10 +5,9 @@
 #include "core/hash_map.h"
 #include "core/local_vector.h"
 #include "core/oa_hash_map.h"
-#include "core/pair.h"
 
-#include "core/types/templates/stack.h"
 #include "core/types/templates/queue.h"
+#include "core/types/templates/stack.h"
 
 class GraphVertex;
 class GraphEdge;
@@ -18,26 +17,35 @@ class GraphIteratorDFS;
 class GraphIteratorBFS;
 
 struct GraphData {
-	using EdgeKey = Pair<uint32_t, uint32_t>;
+	struct EdgeKey {
+		uint32_t a;
+		uint32_t b;
+
+		EdgeKey(const uint32_t &p_a, const uint32_t &p_b) {
+			if (p_a < p_b) {
+				a = p_a;
+				b = p_b;
+			} else {
+				a = p_b;
+				b = p_a;
+			}
+		}
+		bool operator==(const EdgeKey &other) const {
+			return (a == other.a) && (b == other.b);
+		}
+	};
 	using EdgeList = LocalVector<GraphEdge *, int>;
 
 	struct EdgeKeyHasher {
 		static _FORCE_INLINE_ uint32_t hash(const EdgeKey &key) {
-			return key.first ^ key.second;
-		}
-	};
-	struct EdgeKeyComparator {
-		static bool compare(const EdgeKey &a, const EdgeKey &b) {
-			return ((a.first == b.first) && (a.second == b.second)) ||
-				   ((a.first == b.second) && (a.second == b.first));
+			return (key.a << 16) + key.b;
 		}
 	};
 	HashMap<uint32_t, GraphVertex *> vertices;
-	HashMap<EdgeKey, EdgeList, EdgeKeyHasher, EdgeKeyComparator> edges;
+	HashMap<EdgeKey, EdgeList, EdgeKeyHasher> edges;
 
 	void remove_vertex(GraphVertex *p_vertex);
 	void remove_edge(GraphEdge *p_vertex);
-
 	_FORCE_INLINE_ EdgeList &get_edges(uint32_t a_id, uint32_t b_id);
 };
 

--- a/core/types/graph.h
+++ b/core/types/graph.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "core/list.h"
+#include "core/map.h"
 #include "core/reference.h"
 
 class GraphVertex;

--- a/core/types/graph.h
+++ b/core/types/graph.h
@@ -41,6 +41,7 @@ struct GraphData {
 			return (key.a << 16) + key.b;
 		}
 	};
+	ObjectID id;
 	HashMap<uint32_t, GraphVertex *> vertices;
 	HashMap<EdgeKey, EdgeList, EdgeKeyHasher> edges;
 
@@ -142,6 +143,8 @@ protected:
 	static void _bind_methods();
 
 public:
+	Ref<Graph> get_graph() const;
+
 	Array get_neighbors() const;
 	int get_neighbor_count() const { return neighbors.size(); }
 
@@ -154,7 +157,7 @@ public:
 	void set_value(const Variant &p_value) { value = p_value; }
 	Variant get_value() const { return value; }
 
-	uint32_t get_id() const { return id; }
+	uint32_t get_id() const { return id; } // Used by distance comparator.
 };
 
 class GraphEdge : public Object {

--- a/core/types/graph.h
+++ b/core/types/graph.h
@@ -41,10 +41,12 @@ class Graph : public Reference {
 
 protected:
 	static void _bind_methods();
-
 	GraphEdge *_add_edge(const Variant &p_a, const Variant &p_b, const Variant &p_value, bool p_directed);
 
 public:
+	virtual GraphVertex *_create_vertex();
+	virtual GraphEdge *_create_edge();
+
 	// Vertex API
 	GraphVertex *add_vertex(const Variant &p_value);
 	void remove_vertex(GraphVertex *p_vertex);

--- a/core/types/graph.h
+++ b/core/types/graph.h
@@ -1,12 +1,17 @@
 #pragma once
 
+#include "core/reference.h"
+
 #include "core/hash_map.h"
+#include "core/oa_hash_map.h"
 #include "core/local_vector.h"
 #include "core/pair.h"
-#include "core/reference.h"
+
+#include "core/types/templates/stack.h"
 
 class GraphVertex;
 class GraphEdge;
+class GraphDFS;
 
 struct GraphData {
 	using EdgeKey = Pair<uint32_t, uint32_t>;
@@ -48,7 +53,7 @@ public:
 	virtual GraphVertex *_create_vertex();
 	virtual GraphEdge *_create_edge();
 
-	// Vertex API
+	// Vertex
 	GraphVertex *add_vertex(const Variant &p_value);
 	void remove_vertex(GraphVertex *p_vertex);
 	GraphVertex *find_vertex(const Variant &p_value);
@@ -56,7 +61,7 @@ public:
 	Array get_vertex_list() const;
 	int get_vertex_count() const { return graph->vertices.size(); }
 
-	// Edge API
+	// Edge
 	GraphEdge *add_edge(const Variant &p_vertex_a, const Variant &p_vertex_b, const Variant &p_value);
 	GraphEdge *add_directed_edge(const Variant &p_vertex_from, const Variant &p_vertex_to, const Variant &p_value);
 	void remove_edge(GraphEdge *p_edge);
@@ -64,6 +69,10 @@ public:
 	bool has_edge(GraphVertex *p_vertex_a, GraphVertex *p_vertex_b) const;
 	Array get_edge_list(GraphVertex *p_vertex_a = nullptr, GraphVertex *p_vertex_b = nullptr) const;
 	int get_edge_count() const { return graph->edges.size(); }
+
+	// Connectivity
+	Array find_connected_component(GraphVertex *p_vertex) const;
+	bool is_strongly_connected() const;
 
 	// Cleanup
 	void clear();
@@ -78,6 +87,7 @@ class GraphVertex : public Object {
 
 	friend class Graph;
 	friend struct GraphData;
+	friend class GraphDFS;
 
 	GraphData *graph = nullptr;
 
@@ -132,6 +142,20 @@ public:
 
 	void set_value(const Variant &p_value) { value = p_value; }
 	Variant get_value() const { return value; }
+};
+
+class GraphDFS {
+	GraphData *graph = nullptr;
+	Stack<GraphVertex *> stack;
+	OAHashMap<uint32_t, bool> visited;
+	bool discovered = false;
+
+public:
+	bool has_next();
+	GraphVertex *next();
+	bool has_discovered() { return discovered; }
+
+	GraphDFS(GraphVertex *p_root);
 };
 
 // Cast for bindings.

--- a/core/types/graph.h
+++ b/core/types/graph.h
@@ -1,14 +1,25 @@
 #pragma once
 
 #include "core/list.h"
-#include "core/map.h"
+#include "core/hash_map.h"
 #include "core/reference.h"
 
 class GraphVertex;
 class GraphEdge;
 
 struct GraphData {
-	Map<GraphVertex *, List<GraphEdge *>> data;
+	struct ObjectPtrHash {
+		static _FORCE_INLINE_ uint32_t hash(const Object *p_obj) {
+			union {
+				const Object *p;
+				unsigned long i;
+			} u;
+			u.p = p_obj;
+			return HashMapHasherDefault::hash((uint64_t)u.i);
+		}
+	};
+	HashMap<GraphVertex *, List<GraphEdge *>, ObjectPtrHash> data;
+
 	void remove_vertex(GraphVertex *p_vertex);
 	void remove_edge(GraphEdge *p_vertex);
 };

--- a/core/types/graph.h
+++ b/core/types/graph.h
@@ -10,6 +10,7 @@ class GraphEdge;
 
 struct GraphData {
 	using EdgeKey = Pair<uint32_t, uint32_t>;
+	using EdgeList = LocalVector<GraphEdge *, int>;
 
 	struct EdgeKeyHasher {
 		static _FORCE_INLINE_ uint32_t hash(const EdgeKey &key) {
@@ -23,12 +24,12 @@ struct GraphData {
 		}
 	};
 	HashMap<uint32_t, GraphVertex *> vertices;
-	HashMap<EdgeKey, LocalVector<GraphEdge *>, EdgeKeyHasher, EdgeKeyComparator> edges;
+	HashMap<EdgeKey, EdgeList, EdgeKeyHasher, EdgeKeyComparator> edges;
 
 	void remove_vertex(GraphVertex *p_vertex);
 	void remove_edge(GraphEdge *p_vertex);
 
-	_FORCE_INLINE_ LocalVector<GraphEdge *> &get_edges(uint32_t a_id, uint32_t b_id);
+	_FORCE_INLINE_ EdgeList &get_edges(uint32_t a_id, uint32_t b_id);
 };
 
 class Graph : public Reference {

--- a/core/types/graph.h
+++ b/core/types/graph.h
@@ -8,8 +8,8 @@ class GraphEdge;
 
 struct GraphData {
 	Map<GraphVertex *, List<GraphEdge *>> data;
-	void remove_vertex(GraphVertex *v);
-	void remove_edge(GraphEdge *v);
+	void remove_vertex(GraphVertex *p_vertex);
+	void remove_edge(GraphEdge *p_vertex);
 };
 
 class Graph : public Reference {
@@ -23,25 +23,29 @@ protected:
 	GraphEdge *_add_edge(const Variant &a, const Variant &b, real_t weight, bool directed);
 
 public:
-	Array get_neighbors(GraphVertex *v);
-	Array get_successors(GraphVertex *v);
-	Array get_predecessors(GraphVertex *v);
-
-	GraphVertex *add_vertex(const Variant &v);
-	void remove_vertex(GraphVertex *v);
-	bool has_vertex(GraphVertex *v) const { return graph->data.has(v); }
+	// Vertex API
+	GraphVertex *add_vertex(const Variant &p_value);
+	void remove_vertex(GraphVertex *p_vertex);
+	bool has_vertex(GraphVertex *p_vertex) const { return graph->data.has(v); }
 	Array get_vertex_list() const;
 	int get_vertex_count() const { return graph->data.size(); }
 
+	Array get_neighbors(GraphVertex *p_vertex);
+	Array get_successors(GraphVertex *p_vertex);
+	Array get_predecessors(GraphVertex *p_vertex);
+
+	// Edge API
 	GraphEdge *add_edge(const Variant &a, const Variant &b, real_t weight = 1.0);
 	GraphEdge *add_directed_edge(const Variant &a, const Variant &b, real_t weight = 1.0);
 	void remove_edge(GraphEdge *e);
 	GraphEdge *find_edge(GraphVertex *a, GraphVertex *b) const;
+	bool has_edge(GraphVertex *a, GraphVertex *b) const;
 	Array get_edge_list(GraphVertex *a = nullptr, GraphVertex *b = nullptr) const;
 	int get_edge_count() const;
 
+	// Cleanup
 	void clear();
-	void clear_edges(); // TODO
+	void clear_edges();
 
 	Graph();
 	~Graph();

--- a/core/types/graph.h
+++ b/core/types/graph.h
@@ -50,6 +50,7 @@ public:
 	// Vertex API
 	GraphVertex *add_vertex(const Variant &p_value);
 	void remove_vertex(GraphVertex *p_vertex);
+	GraphVertex *find_vertex(const Variant &p_value);
 	bool has_vertex(GraphVertex *p_vertex) const;
 	Array get_vertex_list() const;
 	int get_vertex_count() const { return graph->vertices.size(); }

--- a/core/types/graph.h
+++ b/core/types/graph.h
@@ -146,7 +146,7 @@ public:
 
 class GraphDFS {
 	GraphData *graph = nullptr;
-	Stack<GraphVertex *> stack;
+	Stack<GraphVertex *, uint32_t> stack;
 	Set<uint32_t> visited;
 
 public:

--- a/core/types/graph.h
+++ b/core/types/graph.h
@@ -74,6 +74,7 @@ protected:
 	// Utilities
 	GraphVertex *_add_vertex(const Variant &p_value, uint32_t p_id = 0);
 	GraphEdge *_add_edge(const Variant &p_a, const Variant &p_b, const Variant &p_value, bool p_directed);
+	GraphEdge *_find_minimum_edge(GraphVertex *p_vertex_a, GraphVertex *p_vertex_b) const;
 
 public:
 	// Instantiation
@@ -103,6 +104,7 @@ public:
 	bool is_strongly_connected();
 
 	Array minimum_spanning_tree() const;
+	Dictionary shortest_path_tree(GraphVertex *p_root) const;
 
 	// Cleanup
 	void clear();
@@ -133,7 +135,7 @@ class GraphVertex : public Object {
 
 	HashMap<uint32_t, GraphVertex *> neighbors;
 	Variant value;
-	uint32_t id;
+	uint32_t id = 0;
 
 protected:
 	void _notification(int p_what);
@@ -151,6 +153,8 @@ public:
 
 	void set_value(const Variant &p_value) { value = p_value; }
 	Variant get_value() const { return value; }
+
+	uint32_t get_id() const { return id; }
 };
 
 class GraphEdge : public Object {
@@ -166,7 +170,7 @@ class GraphEdge : public Object {
 	bool directed = false;
 
 	Variant value;
-	uint32_t id;
+	uint32_t id = 0;
 
 protected:
 	void _notification(int p_what);

--- a/core/types/graph.h
+++ b/core/types/graph.h
@@ -20,7 +20,7 @@ class Graph : public Reference {
 protected:
 	static void _bind_methods();
 
-	GraphEdge *_add_edge(const Variant &a, const Variant &b, real_t weight, bool bidirectional);
+	GraphEdge *_add_edge(const Variant &a, const Variant &b, real_t weight, bool directed);
 
 public:
 	Array get_neighbors(GraphVertex *v);
@@ -74,7 +74,7 @@ class GraphEdge : public Object {
 
 	GraphVertex *a = nullptr;
 	GraphVertex *b = nullptr;
-	bool bidirectional = true;
+	bool directed = false;
 
 	real_t weight = 1.0;
 

--- a/core/types/graph.h
+++ b/core/types/graph.h
@@ -143,8 +143,6 @@ protected:
 	static void _bind_methods();
 
 public:
-	Ref<Graph> get_graph() const;
-
 	Array get_neighbors() const;
 	int get_neighbor_count() const { return neighbors.size(); }
 
@@ -156,6 +154,8 @@ public:
 
 	void set_value(const Variant &p_value) { value = p_value; }
 	Variant get_value() const { return value; }
+
+	Ref<Graph> get_graph() const;
 
 	uint32_t get_id() const { return id; } // Used by distance comparator.
 };
@@ -188,6 +188,8 @@ public:
 
 	void set_value(const Variant &p_value) { value = p_value; }
 	Variant get_value() const { return value; }
+
+	Ref<Graph> get_graph() const;
 };
 
 class GraphIterator : public Reference {

--- a/core/types/graph.h
+++ b/core/types/graph.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "core/hash_map.h"
-#include "core/list.h"
+#include "core/local_vector.h"
 #include "core/pair.h"
 #include "core/reference.h"
 
@@ -23,12 +23,12 @@ struct GraphData {
 		}
 	};
 	HashMap<uint32_t, GraphVertex *> vertices;
-	HashMap<EdgeKey, List<GraphEdge *>, EdgeKeyHasher, EdgeKeyComparator> edges;
+	HashMap<EdgeKey, LocalVector<GraphEdge *>, EdgeKeyHasher, EdgeKeyComparator> edges;
 
 	void remove_vertex(GraphVertex *p_vertex);
 	void remove_edge(GraphEdge *p_vertex);
 
-	_FORCE_INLINE_ List<GraphEdge *> &get_edges(uint32_t a_id, uint32_t b_id);
+	_FORCE_INLINE_ LocalVector<GraphEdge *> &get_edges(uint32_t a_id, uint32_t b_id);
 };
 
 class Graph : public Reference {

--- a/core/types/graph.h
+++ b/core/types/graph.h
@@ -50,6 +50,8 @@ struct GraphData {
 	// Allows to speed up the clean() method by skipping neighbor
 	// updates and removing edges from the adjacency list.
 	bool clearing_all = false; 
+	// Adding/removing vertices while iterating may lead to undefined behavior.
+	bool iterating = false;
 
 	_FORCE_INLINE_ EdgeList &get_edges(uint32_t a_id, uint32_t b_id);
 };
@@ -76,6 +78,12 @@ protected:
 	GraphVertex *_add_vertex(const Variant &p_value, uint32_t p_id = 0);
 	GraphEdge *_add_edge(const Variant &p_a, const Variant &p_b, const Variant &p_value, bool p_directed);
 	GraphEdge *_find_minimum_edge(GraphVertex *p_vertex_a, GraphVertex *p_vertex_b) const;
+
+	// Custom vertex iterator for scripting.
+	const uint32_t *_iter_current = nullptr;
+	Variant _iter_init(const Array &p_iter);
+	Variant _iter_next(const Array &p_iter);
+	Variant _iter_get(const Variant &p_iter);
 
 public:
 	// Instantiation
@@ -141,6 +149,12 @@ class GraphVertex : public Object {
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
+
+	// Custom vertex iterator for scripting.
+	const uint32_t *_iter_current = nullptr;
+	Variant _iter_init(const Array &p_iter);
+	Variant _iter_next(const Array &p_iter);
+	Variant _iter_get(const Variant &p_iter);
 
 public:
 	Array get_neighbors() const;

--- a/core/types/graph.h
+++ b/core/types/graph.h
@@ -27,6 +27,8 @@ struct GraphData {
 
 	void remove_vertex(GraphVertex *p_vertex);
 	void remove_edge(GraphEdge *p_vertex);
+
+	_FORCE_INLINE_ List<GraphEdge *> &get_edges(uint32_t a_id, uint32_t b_id);
 };
 
 class Graph : public Reference {
@@ -55,12 +57,12 @@ public:
 	Array get_predecessors(GraphVertex *p_vertex);
 
 	// Edge API
-	GraphEdge *add_edge(const Variant &a, const Variant &b, const Variant &p_value);
-	GraphEdge *add_directed_edge(const Variant &p_a, const Variant &p_b, const Variant &p_value);
-	void remove_edge(GraphEdge *e);
-	GraphEdge *find_edge(GraphVertex *a, GraphVertex *b) const;
-	bool has_edge(GraphVertex *a, GraphVertex *b) const;
-	Array get_edge_list(GraphVertex *a = nullptr, GraphVertex *b = nullptr) const;
+	GraphEdge *add_edge(const Variant &p_vertex_a, const Variant &p_vertex_b, const Variant &p_value);
+	GraphEdge *add_directed_edge(const Variant &p_vertex_from, const Variant &p_vertex_to, const Variant &p_value);
+	void remove_edge(GraphEdge *p_edge);
+	GraphEdge *find_edge(GraphVertex *p_vertex_a, GraphVertex *p_vertex_b) const;
+	bool has_edge(GraphVertex *p_vertex_a, GraphVertex *p_vertex_b) const;
+	Array get_edge_list(GraphVertex *p_vertex_a = nullptr, GraphVertex *p_vertex_b = nullptr) const;
 	int get_edge_count() const { return graph->edges.size(); }
 
 	// Cleanup
@@ -78,6 +80,7 @@ class GraphVertex : public Object {
 	friend struct GraphData;
 
 	GraphData *graph = nullptr;
+
 	HashMap<uint32_t, GraphVertex *> neighbors;
 
 	Variant value;
@@ -97,14 +100,15 @@ class GraphEdge : public Object {
 
 	friend class Graph;
 	friend struct GraphData;
-	GraphData *graph = nullptr;
 
-	Variant value;
-	uint32_t id;
+	GraphData *graph = nullptr;
 
 	GraphVertex *a = nullptr;
 	GraphVertex *b = nullptr;
 	bool directed = false;
+
+	Variant value;
+	uint32_t id;
 
 protected:
 	void _notification(int p_what);

--- a/core/types/graph.h
+++ b/core/types/graph.h
@@ -88,8 +88,13 @@ protected:
 
 public:
 	Array get_neighbors() const;
+	int get_neighbor_count() const { return neighbors.size(); }
+
 	Array get_successors() const;
+	int get_successor_count() const;
+
 	Array get_predecessors() const;
+	int get_predecessor_count() const;
 
 	void set_value(const Variant &p_value) { value = p_value; }
 	Variant get_value() const { return value; }

--- a/core/types/graph.h
+++ b/core/types/graph.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include "core/list.h"
+#include "core/reference.h"
+
+class GraphVertex;
+class GraphEdge;
+
+class Graph : public Reference {
+	GDCLASS(Graph, Reference);
+
+	Map<GraphVertex *, List<GraphEdge *>> graph;
+
+protected:
+	static void _bind_methods();
+
+	GraphEdge *_add_edge(const Variant &a, const Variant &b, real_t weight, bool bidirectional);
+
+public:
+	Array get_neighborhood(const GraphVertex *v);
+
+	GraphVertex *add_vertex(const Variant &v);
+
+	GraphEdge *add_edge(const Variant &a, const Variant &b, real_t weight = 1.0);
+	GraphEdge *add_directed_edge(const Variant &a, const Variant &b, real_t weight = 1.0);
+	GraphEdge *find_edge(GraphVertex *a, GraphVertex *b) const;
+};
+
+class GraphVertex : public Object {
+	GDCLASS(GraphVertex, Object);
+
+	friend class Graph;
+
+	Variant value;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_value(const Variant &p_value) { value = p_value; }
+	Variant get_value() const { return value; }
+};
+
+class GraphEdge : public Object {
+	GDCLASS(GraphEdge, Object);
+
+	friend class Graph;
+
+	GraphVertex *a = nullptr;
+	GraphVertex *b = nullptr;
+	bool bidirectional = true;
+
+	real_t weight = 1.0;
+
+protected:
+	static void _bind_methods();
+
+public:
+	GraphVertex *get_vertex_a() const { return a; }
+	GraphVertex *get_vertex_b() const { return b; }
+
+	void set_weight(real_t p_weight) { weight = p_weight; }
+	real_t get_weight() const { return weight; }
+};
+
+// Cast for bindings.
+
+template <>
+struct VariantCaster<GraphVertex *> {
+	static _FORCE_INLINE_ GraphVertex *cast(const Variant &p_variant) {
+		return (GraphVertex *)p_variant.operator Object *();
+	}
+};
+
+template <>
+struct VariantCaster<GraphEdge *> {
+	static _FORCE_INLINE_ GraphEdge *cast(const Variant &p_variant) {
+		return (GraphEdge *)p_variant.operator Object *();
+	}
+};

--- a/core/types/graph.h
+++ b/core/types/graph.h
@@ -90,6 +90,8 @@ public:
 	GraphVertex *get_vertex_a() const { return a; }
 	GraphVertex *get_vertex_b() const { return b; }
 
+	bool is_loop() { return a == b; }
+
 	void set_weight(real_t p_weight) { weight = p_weight; }
 	real_t get_weight() const { return weight; }
 };

--- a/core/types/graph.h
+++ b/core/types/graph.h
@@ -3,8 +3,8 @@
 #include "core/reference.h"
 
 #include "core/hash_map.h"
-#include "core/oa_hash_map.h"
 #include "core/local_vector.h"
+#include "core/oa_hash_map.h"
 #include "core/pair.h"
 
 #include "core/types/templates/stack.h"
@@ -76,6 +76,7 @@ public:
 	// Connectivity
 	Array find_connected_component(GraphVertex *p_vertex);
 	bool is_strongly_connected();
+	Dictionary get_connected_components();
 
 	// Cleanup
 	void clear();
@@ -100,7 +101,6 @@ class GraphVertex : public Object {
 	GraphData *graph = nullptr;
 
 	HashMap<uint32_t, GraphVertex *> neighbors;
-
 	Variant value;
 	uint32_t id;
 
@@ -170,8 +170,24 @@ public:
 class GraphIteratorDFS : public GraphIterator {
 	GDCLASS(GraphIteratorDFS, GraphIterator);
 
-	Stack<GraphVertex *, uint32_t> stack;
-	Set<uint32_t> visited;
+public:
+	struct Element {
+		GraphVertex *parent;
+		const uint32_t *neighbor = nullptr;
+
+		Element(){};
+		Element(GraphVertex *p_parent) {
+			parent = p_parent;
+			neighbor = p_parent->neighbors.next(nullptr);
+		}
+	};
+
+protected:
+	Stack<Element> stack;
+	Set<GraphVertex *> visited;
+	GraphVertex *next_vertex = nullptr;
+
+	void advance();
 
 public:
 	virtual void initialize(GraphVertex *p_root);

--- a/core/types/graph.h
+++ b/core/types/graph.h
@@ -52,10 +52,6 @@ public:
 	Array get_vertex_list() const;
 	int get_vertex_count() const { return graph->vertices.size(); }
 
-	Array get_neighbors(GraphVertex *p_vertex);
-	Array get_successors(GraphVertex *p_vertex);
-	Array get_predecessors(GraphVertex *p_vertex);
-
 	// Edge API
 	GraphEdge *add_edge(const Variant &p_vertex_a, const Variant &p_vertex_b, const Variant &p_value);
 	GraphEdge *add_directed_edge(const Variant &p_vertex_from, const Variant &p_vertex_to, const Variant &p_value);
@@ -91,6 +87,10 @@ protected:
 	static void _bind_methods();
 
 public:
+	Array get_neighbors() const;
+	Array get_successors() const;
+	Array get_predecessors() const;
+
 	void set_value(const Variant &p_value) { value = p_value; }
 	Variant get_value() const { return value; }
 };

--- a/core/types/graph.h
+++ b/core/types/graph.h
@@ -46,6 +46,10 @@ struct GraphData {
 
 	void remove_vertex(GraphVertex *p_vertex);
 	void remove_edge(GraphEdge *p_vertex);
+	// Allows to speed up the clean() method by skipping neighbor
+	// updates and removing edges from the adjacency list.
+	bool clearing_all = false; 
+
 	_FORCE_INLINE_ EdgeList &get_edges(uint32_t a_id, uint32_t b_id);
 };
 

--- a/core/types/graph.h
+++ b/core/types/graph.h
@@ -6,10 +6,16 @@
 class GraphVertex;
 class GraphEdge;
 
+struct GraphData {
+	Map<GraphVertex *, List<GraphEdge *>> data;
+	void remove_vertex(GraphVertex *v);
+	void remove_edge(GraphEdge *v);
+};
+
 class Graph : public Reference {
 	GDCLASS(Graph, Reference);
 
-	Map<GraphVertex *, List<GraphEdge *>> graph;
+	GraphData *graph = nullptr;
 
 protected:
 	static void _bind_methods();
@@ -17,23 +23,41 @@ protected:
 	GraphEdge *_add_edge(const Variant &a, const Variant &b, real_t weight, bool bidirectional);
 
 public:
-	Array get_neighborhood(const GraphVertex *v);
+	Array get_neighbors(GraphVertex *v);
+	Array get_successors(GraphVertex *v);
+	Array get_predecessors(GraphVertex *v);
 
 	GraphVertex *add_vertex(const Variant &v);
+	void remove_vertex(GraphVertex *v);
+	bool has_vertex(GraphVertex *v) const { return graph->data.has(v); }
+	Array get_vertex_list() const;
+	int get_vertex_count() const { return graph->data.size(); }
 
 	GraphEdge *add_edge(const Variant &a, const Variant &b, real_t weight = 1.0);
 	GraphEdge *add_directed_edge(const Variant &a, const Variant &b, real_t weight = 1.0);
+	void remove_edge(GraphEdge *e);
 	GraphEdge *find_edge(GraphVertex *a, GraphVertex *b) const;
+	Array get_edge_list(GraphVertex *a = nullptr, GraphVertex *b = nullptr) const;
+	int get_edge_count() const;
+
+	void clear();
+	void clear_edges(); // TODO
+
+	Graph();
+	~Graph();
 };
 
 class GraphVertex : public Object {
 	GDCLASS(GraphVertex, Object);
 
 	friend class Graph;
+	friend struct GraphData;
+	GraphData *graph = nullptr;
 
 	Variant value;
 
 protected:
+	void _notification(int p_what);
 	static void _bind_methods();
 
 public:
@@ -45,6 +69,8 @@ class GraphEdge : public Object {
 	GDCLASS(GraphEdge, Object);
 
 	friend class Graph;
+	friend struct GraphData;
+	GraphData *graph = nullptr;
 
 	GraphVertex *a = nullptr;
 	GraphVertex *b = nullptr;
@@ -53,6 +79,7 @@ class GraphEdge : public Object {
 	real_t weight = 1.0;
 
 protected:
+	void _notification(int p_what);
 	static void _bind_methods();
 
 public:

--- a/core/types/templates/priority_queue.h
+++ b/core/types/templates/priority_queue.h
@@ -1,0 +1,98 @@
+#pragma once
+
+template <class T>
+struct PriorityQueueMinHeapComparator {
+	_FORCE_INLINE_ bool operator()(const T &a, const T &b) const { return (a < b); }
+};
+
+template <class T>
+struct PriorityQueueMaxHeapComparator {
+	_FORCE_INLINE_ bool operator()(const T &a, const T &b) const { return (a > b); }
+};
+
+template <typename T, class Comparator=PriorityQueueMinHeapComparator<T>>
+class PriorityQueue {
+	LocalVector<T, int> vector;
+
+	_FORCE_INLINE_ int parent(int i) const {
+		return (i - 1) / 2;
+	}
+	_FORCE_INLINE_ int left(int i) const {
+		return i * 2 + 1;
+	}
+	_FORCE_INLINE_ int right(int i) const {
+		return i * 2 + 2;
+	}
+	_FORCE_INLINE_ void swap(int i, int j) {
+		T tmp = vector[i];
+		vector[i] = vector[j];
+		vector[j] = tmp;
+	}
+	void bubble_up(int i) {
+		while (i > 0 && compare(vector[i], vector[parent(i)])) {
+			swap(i, parent(i));
+			i = parent(i);
+		}
+	}
+	void sift_down(int i) {
+		while (left(i) < vector.size()) {
+			int c;
+			if (right(i) > vector.size() - 1) {
+				c = left(i);
+			} else if (compare(vector[left(i)], vector[right(i)])) {
+				c = left(i);
+			} else {
+				c = right(i);
+			}
+			if (compare(vector[c], vector[i])) {
+				swap(c, i);
+			}
+			i = c;
+		}
+	}
+
+public:
+	Comparator compare;
+
+	void initialize(const LocalVector<T> &p_elements) {
+		vector.clear();
+		if (p_elements.empty()) {
+			return;
+		}
+		vector = p_elements;
+
+		int i = vector.size() / 2;
+		while (i >= 0) {
+			sift_down(i--);
+		}
+	}
+	void insert(const T &p_value) {
+		vector.push_back(p_value);
+		bubble_up(vector.size() - 1);
+	}
+	void update(const T &p_value) {
+		int i = vector.find(p_value);
+		ERR_FAIL_COND(i < 0);
+		bubble_up(i);
+	}
+	T pop() {
+		T root = vector[0];
+		const int n = vector.size() - 1;
+		vector[0] = vector[n];
+		vector.resize(n);
+		sift_down(0);
+		return root;
+	}
+	_FORCE_INLINE_ bool is_empty() const {
+		return vector.empty();
+	}
+	_FORCE_INLINE_ T top() {
+		ERR_FAIL_COND_V(vector.empty(), T());
+		return vector[0];
+	}
+
+	PriorityQueue() {}
+	PriorityQueue(const LocalVector<T> &p_elements) {
+		initialize(p_elements);
+	}
+};

--- a/core/types/templates/queue.h
+++ b/core/types/templates/queue.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "core/local_vector.h"
+
+// Currently just a simple implementation/wrapper over vector, for breadth-first search.
+template <class T, class U = uint32_t>
+class Queue {
+	LocalVector<T, U> container;
+	U front = 0;
+	U back = 0;
+
+public:
+	_FORCE_INLINE_ void push_back(const T &p_element) {
+		container.push_back(p_element);
+		back++;
+	}
+	_FORCE_INLINE_ T &pop_front() {
+		return container[front++];
+	}
+	_FORCE_INLINE_ bool is_empty() const {
+		return front == back;
+	}
+	_FORCE_INLINE_ U size() const {
+		return container.size();
+	}
+	void reserve(U p_capacity) {
+		container.reserve(p_capacity);
+	}
+	void clear() {
+		container.clear();
+		front = 0;
+        back = 0;
+	}
+};

--- a/core/types/templates/stack.h
+++ b/core/types/templates/stack.h
@@ -6,7 +6,7 @@
 template <class T, class U = uint32_t>
 class Stack {
 	LocalVector<T, U> container;
-	uint32_t index = 0;
+	U index = 0;
 
 public:
 	_FORCE_INLINE_ T &top() {

--- a/core/types/templates/stack.h
+++ b/core/types/templates/stack.h
@@ -28,6 +28,10 @@ public:
 	void reserve(U p_capacity) {
 		container.reserve(p_capacity);
 	}
+	void clear() {
+		container.clear();
+		index = 0;
+	}
 	_FORCE_INLINE_ bool is_empty() const {
 		return index == 0;
 	}

--- a/core/types/templates/stack.h
+++ b/core/types/templates/stack.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "core/local_vector.h"
+
+// Currently just a simple implementation/wrapper over vector, for depth-first search.
+template <class T>
+class Stack {
+	LocalVector<T> container;
+	uint32_t back = 0;
+
+public:
+	_FORCE_INLINE_ void push_back(const T &p_element) {
+		if (back == container.size()) {
+			container.push_back(p_element);
+		} else {
+			container[back] = p_element;
+		}
+		back++;
+	}
+	_FORCE_INLINE_ T &pop_back() {
+		T &element = container[back - 1];
+		back--;
+		return element;
+	}
+	void reserve(uint32_t p_capacity) {
+		container.reserve(p_capacity);
+	}
+	_FORCE_INLINE_ bool is_empty() const {
+		return back == 0;
+	}
+};

--- a/core/types/templates/stack.h
+++ b/core/types/templates/stack.h
@@ -3,29 +3,35 @@
 #include "core/local_vector.h"
 
 // Currently just a simple implementation/wrapper over vector, for depth-first search.
-template <class T>
+template <class T, class U = uint32_t>
 class Stack {
-	LocalVector<T> container;
-	uint32_t back = 0;
+	LocalVector<T, U> container;
+	uint32_t index = 0;
 
 public:
-	_FORCE_INLINE_ void push_back(const T &p_element) {
-		if (back == container.size()) {
+	_FORCE_INLINE_ T &top() {
+		return container[index - 1];
+	}
+	_FORCE_INLINE_ void push(const T &p_element) {
+		if (index == container.size()) {
 			container.push_back(p_element);
 		} else {
-			container[back] = p_element;
+			container[index] = p_element;
 		}
-		back++;
+		index++;
 	}
-	_FORCE_INLINE_ T &pop_back() {
-		T &element = container[back - 1];
-		back--;
+	_FORCE_INLINE_ T &pop() {
+		T &element = container[index - 1];
+		index--;
 		return element;
 	}
-	void reserve(uint32_t p_capacity) {
+	void reserve(U p_capacity) {
 		container.reserve(p_capacity);
 	}
 	_FORCE_INLINE_ bool is_empty() const {
-		return back == 0;
+		return index == 0;
+	}
+	_FORCE_INLINE_ U size() const {
+		return index;
 	}
 };

--- a/core/types/templates/union_find.h
+++ b/core/types/templates/union_find.h
@@ -1,0 +1,124 @@
+#pragma once
+
+#include "core/map.h"
+#include "core/vector.h"
+
+/*
+    Based on Godot's DisjointSet structure:
+	https://github.com/godotengine/godot/blob/11e09e59d/core/math/disjoint_set.h
+    - Assumes duplicate elements are not added to the set for performance reasons.
+    - Supports FIND operation.
+*/
+template <typename T, class C = Comparator<T>, class AL = DefaultAllocator>
+class UnionFind {
+public:
+	struct Element {
+		T object;
+		Element *parent = nullptr;
+		int rank = 0;
+	};
+	using Container = Map<T, Element *, C, AL>;
+
+protected:
+	_FORCE_INLINE_ Element *get_element(T object);
+	Element *get_parent(Element *element);
+
+public:
+	_FORCE_INLINE_ Element *insert(T object); // Make set.
+	void merge(T a, T b); // Union.
+	Element *find(T object); // Find.
+
+	void get_representatives(Vector<T> &out_roots);
+	void get_members(Vector<T> &out_members, T representative);
+
+	~UnionFind();
+
+private:
+    Container elements;
+};
+
+template <typename T, class C, class AL>
+typename UnionFind<T, C, AL>::Element *UnionFind<T, C, AL>::get_parent(Element *element) {
+	if (element->parent != element) {
+		element->parent = get_parent(element->parent);
+	}
+	return element->parent;
+}
+
+template <typename T, class C, class AL>
+typename UnionFind<T, C, AL>::Element *UnionFind<T, C, AL>::find(T object) {
+	return get_parent(get_element(object));
+}
+
+template <typename T, class C, class AL>
+typename UnionFind<T, C, AL>::Element *UnionFind<T, C, AL>::get_element(T object) {
+	typename Container::Element *E = elements.find(object);
+    ERR_FAIL_NULL_V(E, nullptr);
+	return E->value();
+}
+
+template <typename T, class C, class AL>
+typename UnionFind<T, C, AL>::Element *UnionFind<T, C, AL>::insert(T object) {
+	Element *new_element = memnew_allocator(Element, AL);
+	new_element->object = object;
+	new_element->parent = new_element;
+	elements.insert(object, new_element);
+
+	return new_element;
+}
+
+template <typename T, class C, class AL>
+void UnionFind<T, C, AL>::merge(T a, T b) {
+	Element *x = get_element(a);
+	Element *y = get_element(b);
+
+	Element *x_root = get_parent(x);
+	Element *y_root = get_parent(y);
+
+	// Already in the same set.
+	if (x_root == y_root) {
+		return;
+	}
+	// Not in the same set, merge.
+	if (x_root->rank < y_root->rank) {
+		SWAP(x_root, y_root);
+	}
+	// Merge smaller set into larger set.
+	y_root->parent = x_root;
+	if (x_root->rank == y_root->rank) {
+		x_root->rank++;
+	}
+}
+
+template <typename T, class C, class AL>
+void UnionFind<T, C, AL>::get_representatives(Vector<T> &out_representatives) {
+	for (typename Container::Element *E = elements.front(); E; E = E->next()) {
+		Element *element = E->value();
+		if (element->parent == element) {
+			out_representatives.push_back(element->object);
+		}
+	}
+}
+
+template <typename T, class C, class AL>
+void UnionFind<T, C, AL>::get_members(Vector<T> &out_members, T representative) {
+	typename Container::Element *rep_E = elements.find(representative);
+	ERR_FAIL_COND(rep_E == nullptr);
+
+	Element *rep_element = rep_E->value();
+	ERR_FAIL_COND(rep_element->parent != rep_element);
+
+	for (typename Container::Element *E = elements.front(); E; E = E->next()) {
+		Element *parent = get_parent(E->value());
+		if (parent == rep_element) {
+			out_members.push_back(E->key());
+		}
+	}
+}
+
+template <typename T, class C, class AL>
+UnionFind<T, C, AL>::~UnionFind() {
+    for (typename Container::Element *E = elements.front(); E; E = E->next()) {
+		memdelete_allocator<Element, AL>(E->value());
+	}
+}

--- a/core/types/templates/union_find.h
+++ b/core/types/templates/union_find.h
@@ -2,12 +2,11 @@
 
 #include "core/map.h"
 #include "core/vector.h"
-
 /*
-    Based on Godot's DisjointSet structure:
+	Based on Godot's DisjointSet structure:
 	https://github.com/godotengine/godot/blob/11e09e59d/core/math/disjoint_set.h
-    - Assumes duplicate elements are not added to the set for performance reasons.
-    - Supports FIND operation.
+	- Assumes duplicate elements are not added to the set for performance reasons.
+	- Supports FIND operation.
 */
 template <typename T, class C = Comparator<T>, class AL = DefaultAllocator>
 class UnionFind {
@@ -34,7 +33,7 @@ public:
 	~UnionFind();
 
 private:
-    Container elements;
+	Container elements;
 };
 
 template <typename T, class C, class AL>
@@ -53,7 +52,7 @@ typename UnionFind<T, C, AL>::Element *UnionFind<T, C, AL>::find(T object) {
 template <typename T, class C, class AL>
 typename UnionFind<T, C, AL>::Element *UnionFind<T, C, AL>::get_element(T object) {
 	typename Container::Element *E = elements.find(object);
-    ERR_FAIL_NULL_V(E, nullptr);
+	ERR_FAIL_NULL_V(E, nullptr);
 	return E->value();
 }
 
@@ -118,7 +117,7 @@ void UnionFind<T, C, AL>::get_members(Vector<T> &out_members, T representative) 
 
 template <typename T, class C, class AL>
 UnionFind<T, C, AL>::~UnionFind() {
-    for (typename Container::Element *E = elements.front(); E; E = E->next()) {
+	for (typename Container::Element *E = elements.front(); E; E = E->next()) {
 		memdelete_allocator<Element, AL>(E->value());
 	}
 }

--- a/doc/Graph.xml
+++ b/doc/Graph.xml
@@ -195,6 +195,18 @@
 				Removes the specified vertex from the graph. All edges that are connected to the vertex will be automatically deleted.
 			</description>
 		</method>
+		<method name="set_iterator_bfs">
+			<return type="void" />
+			<description>
+				Use breadth-first search iterator.
+			</description>
+		</method>
+		<method name="set_iterator_dfs">
+			<return type="void" />
+			<description>
+				Use depth-first search iterator (default).
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="iterator" type="GraphIterator" setter="set_iterator" getter="get_iterator">

--- a/doc/Graph.xml
+++ b/doc/Graph.xml
@@ -8,6 +8,16 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="_create_edge" qualifiers="virtual">
+			<return type="Object" />
+			<description>
+			</description>
+		</method>
+		<method name="_create_vertex" qualifiers="virtual">
+			<return type="Object" />
+			<description>
+			</description>
+		</method>
 		<method name="add_directed_edge">
 			<return type="GraphEdge" />
 			<argument index="0" name="from" type="Variant" />
@@ -33,17 +43,32 @@
 		<method name="clear">
 			<return type="void" />
 			<description>
+				Removes all vertices and edges from the graph.
 			</description>
 		</method>
 		<method name="clear_edges">
 			<return type="void" />
 			<description>
+				Removes all edges from the graph while retaining all original vertices.
+			</description>
+		</method>
+		<method name="find_connected_component" qualifiers="const">
+			<return type="Array" />
+			<argument index="0" name="vertex" type="GraphVertex" />
+			<description>
+				Returns an array of vertices representing a connected component in an [b]undirected[/b] graph starting from arbitrary [code]vertex[/code] root.
 			</description>
 		</method>
 		<method name="find_edge" qualifiers="const">
 			<return type="GraphEdge" />
 			<argument index="0" name="a" type="GraphVertex" />
 			<argument index="1" name="b" type="GraphVertex" />
+			<description>
+			</description>
+		</method>
+		<method name="find_vertex">
+			<return type="GraphVertex" />
+			<argument index="0" name="value" type="Variant" />
 			<description>
 			</description>
 		</method>
@@ -80,6 +105,12 @@
 			<return type="bool" />
 			<argument index="0" name="vertex" type="GraphVertex" />
 			<description>
+			</description>
+		</method>
+		<method name="is_strongly_connected" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if there exist at least one path connecting any two vertices. Applies both to undirected and directed graphs.
 			</description>
 		</method>
 		<method name="remove_edge">

--- a/doc/Graph.xml
+++ b/doc/Graph.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="Graph" inherits="Reference" version="3.5">
+	<brief_description>
+		A general-purpose mixed graph, characterized by having both undirected (associative) and directed edges.
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="add_directed_edge">
+			<return type="GraphEdge" />
+			<argument index="0" name="a" type="Variant" />
+			<argument index="1" name="b" type="Variant" />
+			<argument index="2" name="weight" type="float" default="1.0" />
+			<description>
+			</description>
+		</method>
+		<method name="add_edge">
+			<return type="GraphEdge" />
+			<argument index="0" name="a" type="Variant" />
+			<argument index="1" name="b" type="Variant" />
+			<argument index="2" name="weight" type="float" default="1.0" />
+			<description>
+			</description>
+		</method>
+		<method name="add_vertex">
+			<return type="GraphVertex" />
+			<argument index="0" name="value" type="Variant" />
+			<description>
+			</description>
+		</method>
+		<method name="find_edge" qualifiers="const">
+			<return type="GraphEdge" />
+			<argument index="0" name="a" type="GraphVertex" />
+			<argument index="1" name="b" type="GraphVertex" />
+			<description>
+			</description>
+		</method>
+	</methods>
+	<constants>
+	</constants>
+</class>

--- a/doc/Graph.xml
+++ b/doc/Graph.xml
@@ -184,7 +184,7 @@
 		<method name="minimum_spanning_tree" qualifiers="const">
 			<return type="Array" />
 			<description>
-				Returns a minimum spanning tree (MST) of this graph. An MST is represented as an [Array] of [GraphEdge]s in this graph, from which you can create a new [Graph], if you need to.
+				Returns a minimum spanning tree (MST) of this graph using Kruskal's algorithm. An MST is represented as an [Array] of [GraphEdge]s in this graph, from which you can create a new [Graph], if you need to.
 				The [member GraphEdge.value] is interpreted as a [float] weight, which is up to you to define.
 				In order to obtain a [i]maximum spanning tree[/i], you can inverse the weights, for example:
 				[codeblock]
@@ -193,7 +193,7 @@
 				var w = a.value.distance_to(b.value) # Euclidean distance.
 				graph.add_edge(a, b, -w) # Notice negative weight.
 				[/codeblock]
-				[b]Note:[b] there may exist several MSTs if some edges have equal weight. If weights are not configured, the method will eliminate all edges that cause cycles (a tree is an acyclic graph).
+				[b]Note:[/b] there may exist several MSTs if some edges have equal weight. If weights are not configured, the method will eliminate all edges that cause cycles (a tree is an acyclic graph).
 			</description>
 		</method>
 		<method name="remove_edge">
@@ -220,6 +220,37 @@
 			<return type="void" />
 			<description>
 				Use depth-first search iterator (default).
+			</description>
+		</method>
+		<method name="shortest_path_tree" qualifiers="const">
+			<return type="Dictionary" />
+			<argument index="0" name="root" type="GraphVertex" />
+			<description>
+				Returns a shortest path tree starting at the [code]root[/code] vertex using Dijkstra's algorithm. This solves the Single-Source Shortest Path (SSSP) problem, which allows to find the shortest paths between a given vertex to all other vertices in the graph. The algorithm is structurally equivalent to the breadth-first search, except that this uses a priority queue to choose the next vertex based on [member GraphEdge.value] weights interpreted as [float] values.
+				The tree is represented as a [Dictionary] containing the following keys:
+				[code]backtrace:[/code] A [Dictionary] which contains exhaustive information that allows to reconstruct the shortest path. The keys hold current [GraphVertex], and values contain previous [GraphVertex]. Therefore, the shortest path between the source to any other connected vertex can be obtained in the following way:
+				[codeblock]
+				# Find the shortest path tree starting from the root vertex of interest.
+				var root = Random.choice(graph.get_vertex_list())
+				var tree = graph.shortest_path_tree(root)
+
+				# Pick any target vertex.
+				var current = Random.choice(graph.get_vertex_list())
+
+				# Extract shortest path.
+				var shortest_path = []
+				while true:
+				    shortest_path.append(current)
+				    var previous = tree.backtrace[current]
+				    if not previous:
+				        break # Reached source vertex (root).
+				    current = previous
+
+				# Invert the path for source-to-target order.
+				shortest_path.invert()
+				[/codeblock]
+				[code]distance:[/code] A [Dictionary] which contains the total distance (sum of edge weights) between source and target. The key is the [GraphVertex], the value is [float].
+				[code]edges:[/code] An [Array] of all [GraphEdge]s reachable from the [code]root[/code] vertex. Since there may be multiple edges between vertices, the edges with the minimum weight are collected only.
 			</description>
 		</method>
 	</methods>

--- a/doc/Graph.xml
+++ b/doc/Graph.xml
@@ -26,8 +26,13 @@
 		for e in graph.get_edge_list():
 		    print(e)
 		[/codeblock]
+		You can also use a built-in (GDScript) iterator to traverse all vertices (may be slower):
+		[codeblock]
+		for v in graph:
+		    print(v)
+		[/codeblock]
 		It is possible to extend [GraphVertex] and [GraphEdge] via script, but you should also override [method _create_vertex] and [method _create_edge] virtual methods to make the [Graph] instantiate the correct instances internally.
-		The graph can be searched by using an [member iterator]:
+		The graph can be searched by using an [member iterator] (using either depth-first or breadth-first search algorithm):
 		[codeblock]
 		var G = graph.iterator
 		G.initialize(root)
@@ -36,6 +41,7 @@
 		    var v = G.next()
 		    print(v)
 		[/codeblock]
+		For performance reasons, the graph uses unordered hashmap data structure, so insertion order of vertices and edges should not be assumed to be the same. Adding or removing vertices/edges while iterating the graph may lead to undefined behavior.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/Graph.xml
+++ b/doc/Graph.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="Graph" inherits="Reference" version="3.5">
+<class name="Graph" inherits="Resource" version="3.5">
 	<brief_description>
 		A general-purpose mixed graph.
 	</brief_description>
@@ -209,6 +209,15 @@
 		</method>
 	</methods>
 	<members>
+		<member name="data" type="Dictionary" setter="_set_data" getter="_get_data" default="{&quot;edges&quot;: [  ],&quot;vertices&quot;: [  ]}">
+			Graph data, which contains all vertices and edges.
+			The vertices are stored in a single [Array] where values and IDs (unsigned int) are stored consecutively.
+			The edges represent an [Array] of edge data. The edge data is represented by an [Array] which stores the following fields:
+			[code]unsigned int:[/code] ID of vertex [code]a[/code]
+			[code]unsigned int:[/code] ID of vertex [code]b[/code]
+			[code]Variant:[/code] Value (can be anything).
+			[code]bool:[/code] Whether the edge is directed or not.
+		</member>
 		<member name="iterator" type="GraphIterator" setter="set_iterator" getter="get_iterator">
 			An iterator used for traversing the graph's vertices. The default iterator is based on depth-first search algorithm. You can extend [GraphIterator] class via script to customize the algorithm.
 			If set to [code]null[/code], the default iterator is used.

--- a/doc/Graph.xml
+++ b/doc/Graph.xml
@@ -181,6 +181,21 @@
 				Returns [code]true[/code] if there exist at least one path connecting any two vertices. Applies both to undirected and directed graphs.
 			</description>
 		</method>
+		<method name="minimum_spanning_tree" qualifiers="const">
+			<return type="Array" />
+			<description>
+				Returns a minimum spanning tree (MST) of this graph. The MST is represented as an [Array] of [GraphEdge]s in this graph, from which you can create a new [Graph], if you need to.
+				The [member GraphEdge.value] is interpreted as a [float] weight, which is up to you to define.
+				In order to obtain a [i]maximum spanning tree[/i], you can inverse the weights, for example:
+				[codeblock]
+				var a = graph.add_vertex(Vector2(0, 0))
+				var b = graph.add_vertex(Vector2(100, 100))
+				var w = a.value.distance_to(b.value) # Euclidean distance.
+				w = 1.0 / w
+				graph.add_edge(a, b, w)
+				[/codeblock]
+			</description>
+		</method>
 		<method name="remove_edge">
 			<return type="void" />
 			<argument index="0" name="edge" type="GraphEdge" />

--- a/doc/Graph.xml
+++ b/doc/Graph.xml
@@ -10,9 +10,9 @@
 	<methods>
 		<method name="add_directed_edge">
 			<return type="GraphEdge" />
-			<argument index="0" name="a" type="Variant" />
-			<argument index="1" name="b" type="Variant" />
-			<argument index="2" name="weight" type="float" default="1.0" />
+			<argument index="0" name="from" type="Variant" />
+			<argument index="1" name="to" type="Variant" />
+			<argument index="2" name="value" type="Variant" default="1.0" />
 			<description>
 			</description>
 		</method>
@@ -20,7 +20,7 @@
 			<return type="GraphEdge" />
 			<argument index="0" name="a" type="Variant" />
 			<argument index="1" name="b" type="Variant" />
-			<argument index="2" name="weight" type="float" default="1.0" />
+			<argument index="2" name="value" type="Variant" default="1.0" />
 			<description>
 			</description>
 		</method>
@@ -30,10 +30,67 @@
 			<description>
 			</description>
 		</method>
+		<method name="clear">
+			<return type="void" />
+			<description>
+			</description>
+		</method>
+		<method name="clear_edges">
+			<return type="void" />
+			<description>
+			</description>
+		</method>
 		<method name="find_edge" qualifiers="const">
 			<return type="GraphEdge" />
 			<argument index="0" name="a" type="GraphVertex" />
 			<argument index="1" name="b" type="GraphVertex" />
+			<description>
+			</description>
+		</method>
+		<method name="get_edge_count" qualifiers="const">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="get_edge_list" qualifiers="const">
+			<return type="Array" />
+			<argument index="0" name="a" type="GraphVertex" default="null" />
+			<argument index="1" name="b" type="GraphVertex" default="null" />
+			<description>
+			</description>
+		</method>
+		<method name="get_vertex_count" qualifiers="const">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="get_vertex_list" qualifiers="const">
+			<return type="Array" />
+			<description>
+			</description>
+		</method>
+		<method name="has_edge" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="a" type="GraphVertex" />
+			<argument index="1" name="b" type="GraphVertex" />
+			<description>
+			</description>
+		</method>
+		<method name="has_vertex" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="vertex" type="GraphVertex" />
+			<description>
+			</description>
+		</method>
+		<method name="remove_edge">
+			<return type="void" />
+			<argument index="0" name="edge" type="GraphEdge" />
+			<description>
+			</description>
+		</method>
+		<method name="remove_vertex">
+			<return type="void" />
+			<argument index="0" name="vertex" type="GraphVertex" />
 			<description>
 			</description>
 		</method>

--- a/doc/Graph.xml
+++ b/doc/Graph.xml
@@ -52,7 +52,7 @@
 				Removes all edges from the graph while retaining all original vertices.
 			</description>
 		</method>
-		<method name="find_connected_component" qualifiers="const">
+		<method name="find_connected_component">
 			<return type="Array" />
 			<argument index="0" name="vertex" type="GraphVertex" />
 			<description>
@@ -107,7 +107,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="is_strongly_connected" qualifiers="const">
+		<method name="is_strongly_connected">
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if there exist at least one path connecting any two vertices. Applies both to undirected and directed graphs.
@@ -126,6 +126,12 @@
 			</description>
 		</method>
 	</methods>
+	<members>
+		<member name="iterator" type="GraphIterator" setter="set_iterator" getter="get_iterator">
+			An iterator used for traversing the graph's vertices, for methods like [method find_connected_component]. The default iterator is based on depth-first search algorithm. You can extend [GraphIterator] class via script to customize the algorithm.
+			If set to [code]null[/code], the default iterator is used.
+		</member>
+	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/Graph.xml
+++ b/doc/Graph.xml
@@ -20,10 +20,10 @@
 		[/codeblock]
 		All graph's vertices and edges can be traversed the following way:
 		[codeblock]
-		for v in graph.get_vertex_list():
+		for v in graph.get_vertices():
 		    print(v)
 
-		for e in graph.get_edge_list():
+		for e in graph.get_edges():
 		    print(e)
 		[/codeblock]
 		You can also use a built-in (GDScript) iterator to traverse all vertices (may be slower):
@@ -115,7 +115,7 @@
 			<argument index="0" name="a" type="GraphVertex" />
 			<argument index="1" name="b" type="GraphVertex" />
 			<description>
-				Returns the first found edge between [code]a[/code] and [code]b[/code] vertices. There may be multiple edges between vertices. If you need to find a specific edge, use [method get_edge_list] instead.
+				Returns the first found edge between [code]a[/code] and [code]b[/code] vertices. There may be multiple edges between vertices. If you need to find a specific edge, use [method get_edges] instead.
 			</description>
 		</method>
 		<method name="find_vertex">
@@ -146,7 +146,7 @@
 				Returns the total number of edges in this graph.
 			</description>
 		</method>
-		<method name="get_edge_list" qualifiers="const">
+		<method name="get_edges" qualifiers="const">
 			<return type="Array" />
 			<argument index="0" name="a" type="GraphVertex" default="null" />
 			<argument index="1" name="b" type="GraphVertex" default="null" />
@@ -160,7 +160,7 @@
 				Returns the total number of vertices in this graph.
 			</description>
 		</method>
-		<method name="get_vertex_list" qualifiers="const">
+		<method name="get_vertices" qualifiers="const">
 			<return type="Array" />
 			<description>
 				Returns a list of [GraphVertex] elements in this graph.
@@ -237,11 +237,11 @@
 				[code]backtrace:[/code] A [Dictionary] which contains exhaustive information that allows to reconstruct the shortest path. The keys hold current [GraphVertex], and values contain previous [GraphVertex]. Therefore, the shortest path between the source to any other connected vertex can be obtained in the following way:
 				[codeblock]
 				# Find the shortest path tree starting from the root vertex of interest.
-				var root = Random.choice(graph.get_vertex_list())
+				var root = Random.choice(graph.get_vertices())
 				var tree = graph.shortest_path_tree(root)
 
 				# Pick any target vertex.
-				var current = Random.choice(graph.get_vertex_list())
+				var current = Random.choice(graph.get_vertices())
 
 				# Extract shortest path.
 				var shortest_path = []

--- a/doc/Graph.xml
+++ b/doc/Graph.xml
@@ -184,16 +184,16 @@
 		<method name="minimum_spanning_tree" qualifiers="const">
 			<return type="Array" />
 			<description>
-				Returns a minimum spanning tree (MST) of this graph. The MST is represented as an [Array] of [GraphEdge]s in this graph, from which you can create a new [Graph], if you need to.
+				Returns a minimum spanning tree (MST) of this graph. An MST is represented as an [Array] of [GraphEdge]s in this graph, from which you can create a new [Graph], if you need to.
 				The [member GraphEdge.value] is interpreted as a [float] weight, which is up to you to define.
 				In order to obtain a [i]maximum spanning tree[/i], you can inverse the weights, for example:
 				[codeblock]
 				var a = graph.add_vertex(Vector2(0, 0))
 				var b = graph.add_vertex(Vector2(100, 100))
 				var w = a.value.distance_to(b.value) # Euclidean distance.
-				w = 1.0 / w
-				graph.add_edge(a, b, w)
+				graph.add_edge(a, b, -w) # Notice negative weight.
 				[/codeblock]
+				[b]Note:[b] there may exist several MSTs if some edges have equal weight. If weights are not configured, the method will eliminate all edges that cause cycles (a tree is an acyclic graph).
 			</description>
 		</method>
 		<method name="remove_edge">

--- a/doc/Graph.xml
+++ b/doc/Graph.xml
@@ -72,6 +72,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_connected_components">
+			<return type="Dictionary" />
+			<description>
+				Returns a [Dictionary] of all [i]connected components[/i] in the graph. The keys consist of a set of vertices called [i]representatives[/i], while values contain all [i]members[/i] vertices of that representative. All members represent a connected component. A representative is considered as a member of the connected component. A connected component may consist of a single vertex.
+			</description>
+		</method>
 		<method name="get_edge_count" qualifiers="const">
 			<return type="int" />
 			<description>

--- a/doc/Graph.xml
+++ b/doc/Graph.xml
@@ -1,9 +1,41 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Graph" inherits="Reference" version="3.5">
 	<brief_description>
-		A general-purpose mixed graph, characterized by having both undirected (associative) and directed edges.
+		A general-purpose mixed graph.
 	</brief_description>
 	<description>
+		A graph which allows to add both undirected (associative) and directed edges, with possibility of having multiple edges between the same pair of vertices.
+		[codeblock]
+		func _ready():
+		    var graph = Graph.new()
+
+		    var a = graph.add_vertex("a")
+		    var b = graph.add_vertex("b")
+		    var c = graph.add_vertex("c")
+
+		    var ab = graph.add_edge(a, b)
+
+		    print(graph.has_edge(a, b)) # Prints True
+		    print(graph.has_edge(a, c)) # Prints False
+		[/codeblock]
+		All graph's vertices and edges can be traversed the following way:
+		[codeblock]
+		for v in graph.get_vertex_list():
+		    print(v)
+
+		for e in graph.get_edge_list():
+		    print(e)
+		[/codeblock]
+		It is possible to extend [GraphVertex] and [GraphEdge] via script, but you should also override [method _create_vertex] and [method _create_edge] virtual methods to make the [Graph] instantiate the correct instances internally.
+		The graph can be searched by using an [member iterator]:
+		[codeblock]
+		var G = graph.iterator
+		G.initialize(root)
+
+		while G.has_next():
+		    var v = G.next()
+		    print(v)
+		[/codeblock]
 	</description>
 	<tutorials>
 	</tutorials>
@@ -11,11 +43,13 @@
 		<method name="_create_edge" qualifiers="virtual">
 			<return type="Object" />
 			<description>
+				Must return an instance of [GraphEdge].
 			</description>
 		</method>
 		<method name="_create_vertex" qualifiers="virtual">
 			<return type="Object" />
 			<description>
+				Must return an instance of [GraphVertex].
 			</description>
 		</method>
 		<method name="add_directed_edge">
@@ -24,6 +58,11 @@
 			<argument index="1" name="to" type="Variant" />
 			<argument index="2" name="value" type="Variant" default="1.0" />
 			<description>
+				Adds a directed edge between [code]a[/code] and [code]b[/code] vertices. The [code]value[/code] could represent a weight of the edge, or other attributes. The following expressions are [i]not[/i] equivalent:
+				[codeblock]
+				graph.has_edge(a, b)  # Prints True
+				graph.has_edge(b, a)  # Prints False
+				[/codeblock]
 			</description>
 		</method>
 		<method name="add_edge">
@@ -32,12 +71,18 @@
 			<argument index="1" name="b" type="Variant" />
 			<argument index="2" name="value" type="Variant" default="1.0" />
 			<description>
+				Adds an undirected (associative) edge between [code]a[/code] and [code]b[/code] vertices. The [code]value[/code] could represent a weight of the edge, or other attributes. The following instructions are equivalent:
+				[codeblock]
+				graph.has_edge(a, b)  # Prints True
+				graph.has_edge(b, a)  # Prints True
+				[/codeblock]
 			</description>
 		</method>
 		<method name="add_vertex">
 			<return type="GraphVertex" />
 			<argument index="0" name="value" type="Variant" />
 			<description>
+				Adds a new vertex to the graph. The [code]value[/code] represents the data or attribute of that vertex.
 			</description>
 		</method>
 		<method name="clear">
@@ -64,23 +109,35 @@
 			<argument index="0" name="a" type="GraphVertex" />
 			<argument index="1" name="b" type="GraphVertex" />
 			<description>
+				Returns the first found edge between [code]a[/code] and [code]b[/code] vertices. There may be multiple edges between vertices. If you need to find a specific edge, use [method get_edge_list] instead.
 			</description>
 		</method>
 		<method name="find_vertex">
 			<return type="GraphVertex" />
 			<argument index="0" name="value" type="Variant" />
 			<description>
+				Returns the first found vertex that contains a specified value.
 			</description>
 		</method>
 		<method name="get_connected_components">
 			<return type="Dictionary" />
 			<description>
-				Returns a [Dictionary] of all [i]connected components[/i] in the graph. The keys consist of a set of vertices called [i]representatives[/i], while values contain all [i]members[/i] vertices of that representative. All members represent a connected component. A representative is considered as a member of the connected component. A connected component may consist of a single vertex.
+				Returns a [Dictionary] of all [i]connected components[/i] in the graph. The keys consist of a set of vertices called [i]representatives[/i], while values contain all [i]members[/i] [Array] of vertices of that representative:
+				[codeblock]
+				var representatives = graph.get_connected_components()
+				for r in representatives:
+				    print("Representative: ", r)
+				    var members = representatives[r]
+				    for m in members:
+				        print("Member: ", m)
+				[/codeblock]
+				All members represent a connected component. A representative is considered as a member of the connected component. A connected component may consist of a single vertex.
 			</description>
 		</method>
 		<method name="get_edge_count" qualifiers="const">
 			<return type="int" />
 			<description>
+				Returns the total number of edges in this graph.
 			</description>
 		</method>
 		<method name="get_edge_list" qualifiers="const">
@@ -88,16 +145,19 @@
 			<argument index="0" name="a" type="GraphVertex" default="null" />
 			<argument index="1" name="b" type="GraphVertex" default="null" />
 			<description>
+				Returns a list of [GraphEdge]s between [code]a[/code] and [code]b[/code] vertices. If both endpoints are [code]null[/code], then the method returns all edges in the graph instead.
 			</description>
 		</method>
 		<method name="get_vertex_count" qualifiers="const">
 			<return type="int" />
 			<description>
+				Returns the total number of vertices in this graph.
 			</description>
 		</method>
 		<method name="get_vertex_list" qualifiers="const">
 			<return type="Array" />
 			<description>
+				Returns a list of [GraphVertex] elements in this graph.
 			</description>
 		</method>
 		<method name="has_edge" qualifiers="const">
@@ -105,12 +165,14 @@
 			<argument index="0" name="a" type="GraphVertex" />
 			<argument index="1" name="b" type="GraphVertex" />
 			<description>
+				Returns whether any edge exists between [code]a[/code] and [code]b[/code] vertices.
 			</description>
 		</method>
 		<method name="has_vertex" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="vertex" type="GraphVertex" />
 			<description>
+				Returns whether the graph contains the specified vertex.
 			</description>
 		</method>
 		<method name="is_strongly_connected">
@@ -123,18 +185,20 @@
 			<return type="void" />
 			<argument index="0" name="edge" type="GraphEdge" />
 			<description>
+				Removes an edge from the graph. If the graph is simple, you could find an edge with [method find_edge] first, and then remove it.
 			</description>
 		</method>
 		<method name="remove_vertex">
 			<return type="void" />
 			<argument index="0" name="vertex" type="GraphVertex" />
 			<description>
+				Removes the specified vertex from the graph. All edges that are connected to the vertex will be automatically deleted.
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="iterator" type="GraphIterator" setter="set_iterator" getter="get_iterator">
-			An iterator used for traversing the graph's vertices, for methods like [method find_connected_component]. The default iterator is based on depth-first search algorithm. You can extend [GraphIterator] class via script to customize the algorithm.
+			An iterator used for traversing the graph's vertices. The default iterator is based on depth-first search algorithm. You can extend [GraphIterator] class via script to customize the algorithm.
 			If set to [code]null[/code], the default iterator is used.
 		</member>
 	</members>

--- a/doc/GraphEdge.xml
+++ b/doc/GraphEdge.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GraphEdge" inherits="Object" version="3.5">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+	</methods>
+	<members>
+		<member name="vertex_a" type="GraphVertex" setter="" getter="get_vertex_a">
+		</member>
+		<member name="vertex_b" type="GraphVertex" setter="" getter="get_vertex_b">
+		</member>
+		<member name="weight" type="float" setter="set_weight" getter="get_weight" default="1.0">
+		</member>
+	</members>
+	<constants>
+	</constants>
+</class>

--- a/doc/GraphEdge.xml
+++ b/doc/GraphEdge.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="GraphEdge" inherits="Object" version="3.5">
 	<brief_description>
+		A data structure used to represent an edge in a [Graph].
 	</brief_description>
 	<description>
+		An edge connects two [GraphVertex] vertices together. The edge's direction is determined by whether it was added via [method Graph.add_edge] or [method Graph.add_directed_edge]. If the edge is directed, then [member a] and [member b] must be interpreted as endpoints of an arrow pointing [i]from[/i] a vertex [i]to[/i] another.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,20 +12,25 @@
 		<method name="is_directed">
 			<return type="bool" />
 			<description>
+				Returns [code]true[/code] if the edge has a notion of direction, otherwise returns [code]false[/code] (associative edge).
 			</description>
 		</method>
 		<method name="is_loop">
 			<return type="bool" />
 			<description>
+				Returns [code]true[/code] if the edge is a self-loop, meaning that [member a] is equal to [member b].
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="a" type="GraphVertex" setter="" getter="get_a">
+			The first endpoint, or the starting vertex of the edge.
 		</member>
 		<member name="b" type="GraphVertex" setter="" getter="get_b">
+			The second endpoint, or the final vertex of the edge.
 		</member>
 		<member name="value" type="Variant" setter="set_value" getter="get_value">
+			Edge's data (could be a weight, a label, a list of attributes etc).
 		</member>
 	</members>
 	<constants>

--- a/doc/GraphEdge.xml
+++ b/doc/GraphEdge.xml
@@ -7,13 +7,23 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="is_directed">
+			<return type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="is_loop">
+			<return type="bool" />
+			<description>
+			</description>
+		</method>
 	</methods>
 	<members>
-		<member name="vertex_a" type="GraphVertex" setter="" getter="get_vertex_a">
+		<member name="a" type="GraphVertex" setter="" getter="get_a">
 		</member>
-		<member name="vertex_b" type="GraphVertex" setter="" getter="get_vertex_b">
+		<member name="b" type="GraphVertex" setter="" getter="get_b">
 		</member>
-		<member name="weight" type="float" setter="set_weight" getter="get_weight" default="1.0">
+		<member name="value" type="Variant" setter="set_value" getter="get_value">
 		</member>
 	</members>
 	<constants>

--- a/doc/GraphEdge.xml
+++ b/doc/GraphEdge.xml
@@ -9,6 +9,12 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_graph" qualifiers="const">
+			<return type="Graph" />
+			<description>
+				Returns the master [Graph] that instantiated and manages this edge.
+			</description>
+		</method>
 		<method name="is_directed">
 			<return type="bool" />
 			<description>

--- a/doc/GraphIterator.xml
+++ b/doc/GraphIterator.xml
@@ -12,7 +12,7 @@
 		<method name="has_next" qualifiers="virtual">
 			<return type="bool" />
 			<description>
-				Must return [code]true[/code] if there exist an element available for next iteration. For example: [code]return not stack.is_empty()[/code].
+				Must return [code]true[/code] if there exist an element available for next iteration. For example: [code]return next_vertex != null[/code].
 			</description>
 		</method>
 		<method name="initialize" qualifiers="virtual">

--- a/doc/GraphIterator.xml
+++ b/doc/GraphIterator.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GraphIterator" inherits="Reference" version="3.5">
+	<brief_description>
+		A class used as a base for implementing custom iterators to traverse a [Graph].
+	</brief_description>
+	<description>
+		The class allows for fine-grained control over graph traversal. The instance of the class can be used individually, or set as a custom iterator for [Graph] via [member Graph.iterator].
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="has_next" qualifiers="virtual">
+			<return type="bool" />
+			<description>
+				Must return [code]true[/code] if there exist an element available for next iteration. For example: [code]return not stack.is_empty()[/code].
+			</description>
+		</method>
+		<method name="initialize" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="root" type="Object" />
+			<description>
+				Must initialize a root node from which an iterator starts to traverse the graph.
+			</description>
+		</method>
+		<method name="next" qualifiers="virtual">
+			<return type="Object" />
+			<description>
+				Must return the next vertex. For the first iteration, all built-in iterators in [Graph] return the root node by convention.
+			</description>
+		</method>
+	</methods>
+	<constants>
+	</constants>
+</class>

--- a/doc/GraphVertex.xml
+++ b/doc/GraphVertex.xml
@@ -7,13 +7,28 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_neighbor_count" qualifiers="const">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
 		<method name="get_neighbors" qualifiers="const">
 			<return type="Array" />
 			<description>
 			</description>
 		</method>
+		<method name="get_predecessor_count" qualifiers="const">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
 		<method name="get_predecessors" qualifiers="const">
 			<return type="Array" />
+			<description>
+			</description>
+		</method>
+		<method name="get_successor_count" qualifiers="const">
+			<return type="int" />
 			<description>
 			</description>
 		</method>

--- a/doc/GraphVertex.xml
+++ b/doc/GraphVertex.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GraphVertex" inherits="Object" version="3.5">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+	</methods>
+	<members>
+		<member name="value" type="Variant" setter="set_value" getter="get_value">
+		</member>
+	</members>
+	<constants>
+	</constants>
+</class>

--- a/doc/GraphVertex.xml
+++ b/doc/GraphVertex.xml
@@ -1,8 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="GraphVertex" inherits="Object" version="3.5">
 	<brief_description>
+		A data structure used to represent a vertex in a [Graph].
 	</brief_description>
 	<description>
+		A vertex holds a data and information about all neighbor vertices that are connected to it. To traverse all neighbors:
+		[codeblock]
+		for n in v.get_neighbors():
+		    print(n)
+		[/codeblock]
+		If you need to traverse the graph without producing duplicates, you may also consider using graph's default [member Graph.iterator].
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,36 +17,43 @@
 		<method name="get_neighbor_count" qualifiers="const">
 			<return type="int" />
 			<description>
+				Returns the total number of neighbor vertices.
 			</description>
 		</method>
 		<method name="get_neighbors" qualifiers="const">
 			<return type="Array" />
 			<description>
+				Returns a list of all [GraphVertex] neighbors.
 			</description>
 		</method>
 		<method name="get_predecessor_count" qualifiers="const">
 			<return type="int" />
 			<description>
+				Returns the total number of predecessor vertices.
 			</description>
 		</method>
 		<method name="get_predecessors" qualifiers="const">
 			<return type="Array" />
 			<description>
+				Returns a list of all [GraphVertex] predecessors (vertices that point to this one).
 			</description>
 		</method>
 		<method name="get_successor_count" qualifiers="const">
 			<return type="int" />
 			<description>
+				Returns the total number of successor vertices.
 			</description>
 		</method>
 		<method name="get_successors" qualifiers="const">
 			<return type="Array" />
 			<description>
+				Returns a list of all [GraphVertex] successors (vertices that point away from this one).
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="value" type="Variant" setter="set_value" getter="get_value">
+			Vertex data (could a label, a list of attributes etc).
 		</member>
 	</members>
 	<constants>

--- a/doc/GraphVertex.xml
+++ b/doc/GraphVertex.xml
@@ -9,6 +9,11 @@
 		for n in v.get_neighbors():
 		    print(n)
 		[/codeblock]
+		You can also use a built-in (GDScript) iterator to traverse all neighbors (may be slower):
+		[codeblock]
+		for n in v:
+		    print(n)
+		[/codeblock]
 		If you need to traverse the graph without producing duplicates, you may also consider using graph's default [member Graph.iterator].
 	</description>
 	<tutorials>

--- a/doc/GraphVertex.xml
+++ b/doc/GraphVertex.xml
@@ -7,6 +7,21 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_neighbors" qualifiers="const">
+			<return type="Array" />
+			<description>
+			</description>
+		</method>
+		<method name="get_predecessors" qualifiers="const">
+			<return type="Array" />
+			<description>
+			</description>
+		</method>
+		<method name="get_successors" qualifiers="const">
+			<return type="Array" />
+			<description>
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="value" type="Variant" setter="set_value" getter="get_value">

--- a/doc/GraphVertex.xml
+++ b/doc/GraphVertex.xml
@@ -14,6 +14,12 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_graph" qualifiers="const">
+			<return type="Graph" />
+			<description>
+				Returns the master [Graph] that instantiated and manages this vertex.
+			</description>
+		</method>
 		<method name="get_neighbor_count" qualifiers="const">
 			<return type="int" />
 			<description>

--- a/goost.h
+++ b/goost.h
@@ -17,6 +17,7 @@
 #include "core/math/random.h"
 #include "core/script/mixin_script/mixin_script.h"
 #include "core/types/linked_list.h"
+#include "core/types/graph.h"
 #include "core/types/variant_map.h"
 #include "core/types/variant_resource.h"
 

--- a/goost.py
+++ b/goost.py
@@ -163,6 +163,9 @@ classes = {
     "GoostGeometry2D": "geometry",
     "GoostImage": "image",
     "GridRect": "gui",
+    "Graph": "core",
+    "GraphVertex": "core",
+    "GraphEdge": "core",
     "ImageBlender": "image",
     "ImageFrames": "image",  # modules/gif
     "ImageIndexed": "image",
@@ -224,6 +227,8 @@ class_dependencies = {
     "GoostEngine" : "InvokeState",
     "GoostGeometry2D" : ["PolyBoolean2D", "PolyDecomp2D", "PolyOffset2D"],
     "LinkedList" : "ListNode",
+    "Graph" : ["GraphVertex", "GraphEdge"],
+    "GraphEdge" : "GraphVertex",
     "MixinScript" : "Mixin",
     "PolyBoolean2D" : ["PolyBooleanParameters2D", "PolyNode2D"],
     "PolyDecomp2D" : "PolyDecompParameters2D",

--- a/goost.py
+++ b/goost.py
@@ -166,6 +166,7 @@ classes = {
     "Graph": "core",
     "GraphVertex": "core",
     "GraphEdge": "core",
+    "GraphIterator": "core",
     "ImageBlender": "image",
     "ImageFrames": "image",  # modules/gif
     "ImageIndexed": "image",
@@ -227,7 +228,7 @@ class_dependencies = {
     "GoostEngine" : "InvokeState",
     "GoostGeometry2D" : ["PolyBoolean2D", "PolyDecomp2D", "PolyOffset2D"],
     "LinkedList" : "ListNode",
-    "Graph" : ["GraphVertex", "GraphEdge"],
+    "Graph" : ["GraphVertex", "GraphEdge", "GraphIterator"],
     "GraphEdge" : "GraphVertex",
     "MixinScript" : "Mixin",
     "PolyBoolean2D" : ["PolyBooleanParameters2D", "PolyNode2D"],

--- a/run.py
+++ b/run.py
@@ -117,7 +117,7 @@ if __name__ == "__main__":
         if args.inner_test_case:
             test_args.append("-ginner_class=%s" % args.inner_test_case)
 
-        if not args.windowed:
+        if not args.windowed or os.getenv("CI"):
             # Not exiting on failure only makes sense while running in
             # windowed mode, this does not matter for console output.
             test_args.append("-gexit=true")

--- a/run.py
+++ b/run.py
@@ -64,6 +64,8 @@ if __name__ == "__main__":
             help='A relative path to test file to run, for instance: "core/math/test_random.gd"')
     tests.add_argument("-tc", "--test-case",
             help="Name of a test case to run. Any test case matching the name will be run.")
+    tests.add_argument("-itc", "--inner-test-case",
+            help="Name of an inner test case to run. Any test case matching the name will be run.")
 
     # Documentation.
     doc = subparsers.add_parser("doc", help="Generate documentation.")
@@ -108,8 +110,13 @@ if __name__ == "__main__":
             # recursively from the directory defined in `.gutconfig.json`.
             res_file = "res://goost/" + args.test_file
             test_args.extend(["-gtest=%s" % res_file, '-gdir='])
+
         if args.test_case:
             test_args.append("-gunit_test_name=%s" % args.test_case)
+
+        if args.inner_test_case:
+            test_args.append("-ginner_class=%s" % args.inner_test_case)
+
         if not args.windowed:
             # Not exiting on failure only makes sense while running in
             # windowed mode, this does not matter for console output.

--- a/scene/2d/spawner_2d.h
+++ b/scene/2d/spawner_2d.h
@@ -10,7 +10,7 @@ public:
 		PROCESS_PHYSICS,
 		PROCESS_IDLE,
 	};
-	static StringName node_spawned;
+	static StringName node_spawned; // TODO: move to StringNames singleton
 
 private:
 	Ref<Resource> resource; // From which a new node is instantiated: scene or script.

--- a/tests/project/goost/core/types/test_graph.gd
+++ b/tests/project/goost/core/types/test_graph.gd
@@ -483,6 +483,75 @@ func test_iterator():
 		steps += 1
 	assert_eq(steps, 4)
 
+	
+func test_save_load():
+	var path = "res://goost/core/types/graph.tres"
+
+	# Save
+	var a = graph.add_vertex("a")
+	var b = graph.add_vertex("b")
+	var c = graph.add_vertex("c")
+
+	var ab = graph.add_edge(a, b, "ab")
+	var ac = graph.add_directed_edge(a, c, "ac")
+	var bc = graph.add_edge(b, c, "bc")
+
+	assert_eq(a.value, "a")
+	assert_eq(b.value, "b")
+	assert_eq(c.value, "c")
+
+	assert_eq(ab.a, a)
+	assert_eq(ab.b, b)
+	assert_eq(ab.value, "ab")
+	assert_false(ab.is_directed())
+
+	assert_eq(ac.a, a)
+	assert_eq(ac.b, c)
+	assert_eq(ac.value, "ac")
+	assert_true(ac.is_directed())
+
+	assert_eq(bc.a, b)
+	assert_eq(bc.b, c)
+	assert_eq(bc.value, "bc")
+	assert_false(bc.is_directed())
+	
+	var _err = ResourceSaver.save(path, graph)
+	assert_file_exists(path)
+
+	# Load
+	graph = load(path)
+
+	a = graph.find_vertex("a")
+	b = graph.find_vertex("b")
+	c = graph.find_vertex("c")
+
+	ab = graph.find_edge(a, b)
+	ac = graph.find_edge(a, c)
+	bc = graph.find_edge(b, c)
+
+	assert_eq(a.value, "a")
+	assert_eq(b.value, "b")
+	assert_eq(c.value, "c")
+
+	assert_eq(ab.a, a)
+	assert_eq(ab.b, b)
+	assert_eq(ab.value, "ab")
+	assert_false(ab.is_directed())
+
+	assert_eq(ac.a, a)
+	assert_eq(ac.b, c)
+	assert_eq(ac.value, "ac")
+	assert_true(ac.is_directed())
+
+	assert_eq(bc.a, b)
+	assert_eq(bc.b, c)
+	assert_eq(bc.value, "bc")
+	assert_false(bc.is_directed())
+
+	# Cleanup
+	var dir = Directory.new()
+	dir.remove(path)
+
 
 class _TestPerformance extends "res://addons/gut/test.gd":
 

--- a/tests/project/goost/core/types/test_graph.gd
+++ b/tests/project/goost/core/types/test_graph.gd
@@ -57,15 +57,15 @@ func test_neighborhood():
     var nb = b.get_neighbors()
     var nc = c.get_neighbors()
 
-    assert_eq(na.size(), 2)
+    assert_eq(a.get_neighbor_count(), 2)
     assert_true(b in na)
     assert_true(c in na)
 
-    assert_eq(nb.size(), 2)
+    assert_eq(b.get_neighbor_count(), 2)
     assert_true(a in nb)
     assert_true(c in nb)
 
-    assert_eq(nc.size(), 2)
+    assert_eq(c.get_neighbor_count(), 2)
     assert_true(a in nc)
     assert_true(b in nc)
 
@@ -82,14 +82,14 @@ func test_neighborhood_directed():
     var sa = a.get_successors()
     var pc = c.get_predecessors()
 
-    assert_eq(na.size(), 2)
+    assert_eq(a.get_neighbor_count(), 2)
     assert_true(b in na)
     assert_true(c in na)
 
-    assert_eq(sa.size(), 1)
+    assert_eq(a.get_successor_count(), 1)
     assert_true(c in sa)
 
-    assert_eq(pc.size(), 1)
+    assert_eq(c.get_predecessor_count(), 1)
     assert_true(a in pc)
 
     var _e3 = graph.add_directed_edge(c, a)

--- a/tests/project/goost/core/types/test_graph.gd
+++ b/tests/project/goost/core/types/test_graph.gd
@@ -14,6 +14,11 @@ func test_add_vertex():
 	assert_eq(b.value, "b")
 
 
+func test_get_graph():
+	var v = graph.add_vertex("a")
+	assert_eq(v.get_graph(), graph)
+
+
 func test_find_vertex():
 	for i in 100:
 		var _v = graph.add_vertex(str(i))

--- a/tests/project/goost/core/types/test_graph.gd
+++ b/tests/project/goost/core/types/test_graph.gd
@@ -14,6 +14,14 @@ func test_add_vertex():
 	assert_eq(b.value, "b")
 
 
+func test_find_vertex():
+	for i in 100:
+		var _v = graph.add_vertex(str(i))
+
+	var v = graph.find_vertex("50")
+	assert_eq(v.value, "50")
+
+
 func test_add_directed_edge():
 	var a = graph.add_vertex("a")
 	var b = graph.add_vertex("b")

--- a/tests/project/goost/core/types/test_graph.gd
+++ b/tests/project/goost/core/types/test_graph.gd
@@ -304,12 +304,93 @@ func test_connected_component_cycle():
 	_e = graph.add_edge(V[1], V[3])
 	_e = graph.add_edge(V[2], V[3])
 
+	graph.set_iterator_dfs()
+
 	var component = graph.find_connected_component(V[0])
 	assert_eq(component.size(), 4)
 	assert_true(V[0] in component)
 	assert_true(V[1] in component)
 	assert_true(V[2] in component)
 	assert_true(V[3] in component)
+
+	graph.set_iterator_bfs()
+
+	component = graph.find_connected_component(V[0])
+	assert_eq(component.size(), 4)
+	assert_true(V[0] in component)
+	assert_true(V[1] in component)
+	assert_true(V[2] in component)
+	assert_true(V[3] in component)
+
+	
+func create_grid(p_graph, p_width, p_height):
+	graph.clear()
+
+	var id = 0
+
+	var grid = []
+	for j in p_height:
+		var row = []
+		for i in p_width:
+			var v = p_graph.add_vertex(id)
+			row.push_back(v)
+			id += 1
+		grid.push_back(row)
+
+	for row in grid:
+		for i in p_width - 1:
+			var a = row[i]
+			var b = row[i + 1]
+			p_graph.add_edge(a, b)
+			
+	for j in p_height - 1:
+		var row_a = grid[j]
+		var row_b = grid[j + 1]
+		
+		for i in p_width:
+			var a = row_a[i]
+			var b = row_b[i]
+			p_graph.add_edge(a, b)
+
+	return grid
+
+
+func test_breadth_iterator():
+	var grid = create_grid(graph, 5, 10)
+
+	graph.set_iterator_bfs()
+	var G = graph.iterator
+	G.initialize(grid[0][0])
+
+	var count = 0
+	while G.has_next():
+		var v = G.next()
+		count += 1
+		if count == 1:
+			assert_eq(v, grid[0][0])
+
+		elif count <= 3:
+			assert_true(v in [grid[1][0], grid[0][1]])
+		
+		elif count >= 4 and count <= 6:
+			assert_true(v in [grid[2][0], grid[1][1], grid[0][2]])
+
+	assert_eq(count, 50)
+
+
+func test_depth_iterator():
+	var grid = create_grid(graph, 10, 10)
+
+	graph.set_iterator_dfs()
+	var G = graph.iterator
+	G.initialize(grid[0][0])
+
+	var count = 0
+	while G.has_next():
+		var _v = G.next()
+		count += 1
+
+	assert_eq(count, 100)
 
 
 func test_get_connected_components():

--- a/tests/project/goost/core/types/test_graph.gd
+++ b/tests/project/goost/core/types/test_graph.gd
@@ -659,6 +659,26 @@ func test_save_load():
 	dir.remove(path)
 
 
+class TestInvalidData extends "res://addons/gut/test.gd":
+	var graph: Graph
+
+	func before_all():
+		Engine.print_error_messages = false
+
+	func before_each():
+		graph = Graph.new()
+
+	func after_all():
+		Engine.print_error_messages = true
+		
+	func test_add_edge():
+		var v = ClassDB.instance("GraphVertex")
+		var e = graph.add_edge(v, Array([]), Array([]))
+		assert_null(e)
+		v.free()
+		e.free()
+
+
 class _TestPerformance extends "res://addons/gut/test.gd":
 
 	func test_add_remove_dense():

--- a/tests/project/goost/core/types/test_graph.gd
+++ b/tests/project/goost/core/types/test_graph.gd
@@ -239,3 +239,28 @@ func test_remove_edge():
     assert_eq(graph.get_edge_count(), 0)
 
     assert_eq(graph.get_vertex_count(), 3)
+
+
+# func test_perf():
+#     var count = 100000
+
+#     var t1 = OS.get_ticks_msec()
+#     for i in count:
+#         graph.add_vertex(i)
+
+#     var vertices = graph.get_vertex_list()
+
+#     for i in count:
+#         var ui = randi() % count
+#         var vi = randi() % count
+#         graph.add_edge(vertices[ui], vertices[vi])
+
+#     var edges = graph.get_edge_list()
+
+#     for i in count:
+#         var vi = randi() % vertices.size()
+#         graph.remove_vertex(vertices[vi])
+#         vertices.remove(vi)
+
+#     var t2 = OS.get_ticks_msec()
+#     gut.p(t2 - t1)

--- a/tests/project/goost/core/types/test_graph.gd
+++ b/tests/project/goost/core/types/test_graph.gd
@@ -264,14 +264,14 @@ func test_self_loop():
 
 #     var t1 = OS.get_ticks_msec()
 #     for i in count:
-#         graph.add_vertex(i)
+#         var _v = graph.add_vertex(i)
 
 #     var vertices = graph.get_vertex_list()
 
 #     for i in count:
 #         var ui = rng.randi() % count
 #         var vi = rng.randi() % count
-#         graph.add_edge(vertices[ui], vertices[vi])
+#         var _e = graph.add_edge(vertices[ui], vertices[vi])
 
 #     for i in count:
 #         var v = vertices[i]

--- a/tests/project/goost/core/types/test_graph.gd
+++ b/tests/project/goost/core/types/test_graph.gd
@@ -264,6 +264,33 @@ func test_self_loop():
 	# Should not crash...
 
 
+func test_connected_component():
+	var a = graph.add_vertex("a")
+	var b = graph.add_vertex("b")
+	var c = graph.add_vertex("c")
+	var d = graph.add_vertex("d")
+	var e = graph.add_vertex("e")
+
+	var _ab = graph.add_edge(a, b)
+	var _bc = graph.add_edge(b, c)
+	var _bd = graph.add_edge(b, d)
+	var ae = graph.add_edge(a, e)
+
+	var abcde = graph.find_connected_component(a)
+	assert_eq(abcde.size(), 5)
+	assert_true(a in abcde)
+	assert_true(b in abcde)
+	assert_true(c in abcde)
+	assert_true(d in abcde)
+	assert_true(e in abcde)
+
+	assert_true(graph.is_strongly_connected())
+
+	graph.remove_edge(ae)
+
+	assert_false(graph.is_strongly_connected())
+
+
 class _TestPerformance extends "res://addons/gut/test.gd":
 
 	func test_add_remove_dense():
@@ -287,6 +314,33 @@ class _TestPerformance extends "res://addons/gut/test.gd":
 		for i in count:
 			var v = vertices[i]
 			graph.remove_vertex(v)
+
+		var t2 = OS.get_ticks_msec()
+		gut.p(t2 - t1)
+
+
+	func test_dfs():
+		var graph = Graph.new()
+		var rng = RandomNumberGenerator.new()
+		rng.seed = 480789
+
+		var count = 100000
+
+		for i in count:
+			var _v = graph.add_vertex(i)
+
+		var vertices = graph.get_vertex_list()
+
+		# Complete graph.
+		for i in count:
+			var ui = rng.randi() % count
+			var vi = rng.randi() % count
+			var _e = graph.add_edge(vertices[ui], vertices[vi])
+
+		var t1 = OS.get_ticks_msec()
+
+		var component = graph.find_connected_component(vertices[0])
+		assert_eq(component.size(), 79500)
 
 		var t2 = OS.get_ticks_msec()
 		gut.p(t2 - t1)

--- a/tests/project/goost/core/types/test_graph.gd
+++ b/tests/project/goost/core/types/test_graph.gd
@@ -53,9 +53,9 @@ func test_neighborhood():
     var _e2 = graph.add_edge(a, c)
     var _e3 = graph.add_edge(b, c)
 
-    var na = graph.get_neighbors(a)
-    var nb = graph.get_neighbors(b)
-    var nc = graph.get_neighbors(c)
+    var na = a.get_neighbors()
+    var nb = b.get_neighbors()
+    var nc = c.get_neighbors()
 
     assert_eq(na.size(), 2)
     assert_true(b in na)
@@ -78,9 +78,9 @@ func test_neighborhood_directed():
     var _e1 = graph.add_edge(a, b)
     var _e2 = graph.add_directed_edge(a, c)
 
-    var na = graph.get_neighbors(a)
-    var sa = graph.get_successors(a)
-    var pc = graph.get_predecessors(c)
+    var na = a.get_neighbors()
+    var sa = a.get_successors()
+    var pc = c.get_predecessors()
 
     assert_eq(na.size(), 2)
     assert_true(b in na)
@@ -94,7 +94,7 @@ func test_neighborhood_directed():
 
     var _e3 = graph.add_directed_edge(c, a)
     var _e4 = graph.add_directed_edge(c, b)
-    var sc = graph.get_successors(c)
+    var sc = c.get_successors()
 
     assert_eq(sc.size(), 2)
     assert_true(a in sc)
@@ -139,9 +139,9 @@ func test_remove_vertex_one_to_many():
     graph.remove_vertex(a)
     
     assert_eq(graph.get_edge_count(), 0)
-    assert_eq(graph.get_neighbors(b).size(), 0)
-    assert_eq(graph.get_neighbors(c).size(), 0)
-    assert_eq(graph.get_neighbors(d).size(), 0)
+    assert_eq(b.get_neighbors().size(), 0)
+    assert_eq(c.get_neighbors().size(), 0)
+    assert_eq(d.get_neighbors().size(), 0)
 
 
 func test_remove_vertex_many_to_many():
@@ -164,20 +164,20 @@ func test_remove_vertex_many_to_many():
     assert_eq(graph.get_vertex_count(), 3)
 
     assert_eq(graph.get_edge_count(), 3)
-    assert_eq(graph.get_neighbors(c).size(), 2)
-    assert_eq(graph.get_neighbors(b).size(), 2)
-    assert_eq(graph.get_neighbors(d).size(), 2)
+    assert_eq(c.get_neighbors().size(), 2)
+    assert_eq(b.get_neighbors().size(), 2)
+    assert_eq(d.get_neighbors().size(), 2)
 
     graph.remove_vertex(b)
 
     assert_eq(graph.get_edge_count(), 1)
-    assert_eq(graph.get_neighbors(c).size(), 1)
-    assert_eq(graph.get_neighbors(d).size(), 1)
+    assert_eq(c.get_neighbors().size(), 1)
+    assert_eq(d.get_neighbors().size(), 1)
 
     graph.remove_vertex(c)
 
     assert_eq(graph.get_edge_count(), 0)
-    assert_eq(graph.get_neighbors(d).size(), 0)
+    assert_eq(d.get_neighbors().size(), 0)
 
 
 func test_clear_edges():
@@ -191,17 +191,17 @@ func test_clear_edges():
 
     assert_eq(graph.get_vertex_count(), 3)
     assert_eq(graph.get_edge_count(), 3)
-    assert_eq(graph.get_neighbors(a).size(), 2)
-    assert_eq(graph.get_neighbors(b).size(), 2)
-    assert_eq(graph.get_neighbors(c).size(), 2)
+    assert_eq(a.get_neighbors().size(), 2)
+    assert_eq(b.get_neighbors().size(), 2)
+    assert_eq(c.get_neighbors().size(), 2)
 
     graph.clear_edges()
 
     assert_eq(graph.get_vertex_count(), 3)
     assert_eq(graph.get_edge_count(), 0)
-    assert_eq(graph.get_neighbors(a).size(), 0)
-    assert_eq(graph.get_neighbors(b).size(), 0)
-    assert_eq(graph.get_neighbors(c).size(), 0)
+    assert_eq(a.get_neighbors().size(), 0)
+    assert_eq(b.get_neighbors().size(), 0)
+    assert_eq(c.get_neighbors().size(), 0)
 
     
 func test_has_edge():
@@ -249,7 +249,7 @@ func test_self_loop():
     var _e1 = graph.add_edge(a, a)
     var _e2 = graph.add_edge(b, a)
 
-    assert_eq(graph.get_neighbors(a)[0], a)
+    assert_eq(a.get_neighbors()[0], a)
 
     graph.remove_vertex(a)
     graph.remove_vertex(b)

--- a/tests/project/goost/core/types/test_graph.gd
+++ b/tests/project/goost/core/types/test_graph.gd
@@ -42,3 +42,138 @@ func test_add_edge():
 
     assert_eq(graph.find_edge(e2.vertex_a, e2.vertex_b), e2)
     assert_eq(graph.find_edge(e2.vertex_b, e2.vertex_a), e2)
+
+
+func test_neighborhood():
+    var a = graph.add_vertex("a")
+    var b = graph.add_vertex("b")
+    var c = graph.add_vertex("c")
+
+    var _e1 = graph.add_edge(a, b)
+    var _e2 = graph.add_edge(a, c)
+    var _e3 = graph.add_edge(b, c)
+
+    var na = graph.get_neighbors(a)
+    var nb = graph.get_neighbors(b)
+    var nc = graph.get_neighbors(c)
+
+    assert_eq(na.size(), 2)
+    assert_true(b in na)
+    assert_true(c in na)
+
+    assert_eq(nb.size(), 2)
+    assert_true(a in nb)
+    assert_true(c in nb)
+
+    assert_eq(nc.size(), 2)
+    assert_true(a in nc)
+    assert_true(b in nc)
+
+
+func test_neighborhood_directed():
+    var a = graph.add_vertex("a")
+    var b = graph.add_vertex("b")
+    var c = graph.add_vertex("c")
+
+    var _e1 = graph.add_edge(a, b)
+    var _e2 = graph.add_directed_edge(a, c)
+
+    var na = graph.get_neighbors(a)
+    var sa = graph.get_successors(a)
+    var pc = graph.get_predecessors(c)
+
+    assert_eq(na.size(), 1)
+    assert_true(b in na)
+
+    assert_eq(sa.size(), 1)
+    assert_true(c in sa)
+
+    assert_eq(pc.size(), 1)
+    assert_true(a in pc)
+
+    var _e3 = graph.add_directed_edge(c, a)
+    var _e4 = graph.add_directed_edge(c, b)
+    var sc = graph.get_successors(c)
+
+    assert_eq(sc.size(), 2)
+    assert_true(a in sc)
+    assert_true(b in sc)
+
+
+func test_edge_list():
+    var a = graph.add_vertex("a")
+    var b = graph.add_vertex("b")
+    var c = graph.add_vertex("c")
+
+    var ab1 = graph.add_edge(a, b)
+    var ab2 = graph.add_edge(a, b)
+    var ac = graph.add_edge(a, c)
+    var bc = graph.add_edge(b, c)
+
+    var edges = graph.get_edge_list(a, b)
+    assert_eq(edges.size(), 2)
+    assert_true(ab1 in edges)
+    assert_true(ab2 in edges)
+
+    edges = graph.get_edge_list()
+    assert_eq(edges.size(), 4)
+    assert_true(ab1 in edges)
+    assert_true(ab2 in edges)
+    assert_true(ac in edges)
+    assert_true(bc in edges)
+
+
+func test_remove_vertex_one_to_many():
+    var a = graph.add_vertex("a")
+    var b = graph.add_vertex("b")
+    var c = graph.add_vertex("c")
+    var d = graph.add_vertex("d")
+
+    var _ab = graph.add_edge(a, b)
+    var _ac = graph.add_edge(a, c)
+    var _ad = graph.add_edge(a, d)
+    
+    assert_eq(graph.get_edge_count(), 3)
+    
+    graph.remove_vertex(a)
+    
+    assert_eq(graph.get_edge_count(), 0)
+    assert_eq(graph.get_neighbors(b).size(), 0)
+    assert_eq(graph.get_neighbors(c).size(), 0)
+    assert_eq(graph.get_neighbors(d).size(), 0)
+
+
+func test_remove_vertex_many_to_many():
+    var a = graph.add_vertex("a")
+    var b = graph.add_vertex("b")
+    var c = graph.add_vertex("c")
+    var d = graph.add_vertex("d")
+
+    var _ab = graph.add_edge(a, b)
+    var _ac = graph.add_edge(a, c)
+    var _ad = graph.add_edge(a, d)
+    var _cb = graph.add_edge(c, b)
+    var _cd = graph.add_edge(c, d)
+    var _bd = graph.add_edge(b, d)
+
+    assert_eq(graph.get_edge_count(), 6)
+
+    graph.remove_vertex(a)
+
+    assert_eq(graph.get_vertex_count(), 3)
+
+    assert_eq(graph.get_edge_count(), 3)
+    assert_eq(graph.get_neighbors(c).size(), 2)
+    assert_eq(graph.get_neighbors(b).size(), 2)
+    assert_eq(graph.get_neighbors(d).size(), 2)
+
+    graph.remove_vertex(b)
+
+    assert_eq(graph.get_edge_count(), 1)
+    assert_eq(graph.get_neighbors(c).size(), 1)
+    assert_eq(graph.get_neighbors(d).size(), 1)
+
+    graph.remove_vertex(c)
+
+    assert_eq(graph.get_edge_count(), 0)
+    assert_eq(graph.get_neighbors(d).size(), 0)

--- a/tests/project/goost/core/types/test_graph.gd
+++ b/tests/project/goost/core/types/test_graph.gd
@@ -264,14 +264,14 @@ func test_self_loop():
 	# Should not crash...
 
 
-class TestPerformance extends "res://addons/gut/test.gd":
+class _TestPerformance extends "res://addons/gut/test.gd":
 
-	func test_add_remove():
+	func test_add_remove_dense():
 		var graph = Graph.new()
 		var rng = RandomNumberGenerator.new()
 		rng.seed = 480789
 
-		var count = 1000000
+		var count = 10
 
 		var t1 = OS.get_ticks_msec()
 		for i in count:
@@ -279,7 +279,7 @@ class TestPerformance extends "res://addons/gut/test.gd":
 
 		var vertices = graph.get_vertex_list()
 
-		for i in count:
+		for i in 1000000:
 			var ui = rng.randi() % count
 			var vi = rng.randi() % count
 			var _e = graph.add_edge(vertices[ui], vertices[vi])

--- a/tests/project/goost/core/types/test_graph.gd
+++ b/tests/project/goost/core/types/test_graph.gd
@@ -74,9 +74,9 @@ func test_add_edge_by_value_connected():
 	var b = graph.find_vertex("b")
 	var c = graph.find_vertex("c")
 
-	assert_true(a in graph.get_vertex_list())
-	assert_true(b in graph.get_vertex_list())
-	assert_true(c in graph.get_vertex_list())
+	assert_true(a in graph.get_vertices())
+	assert_true(b in graph.get_vertices())
+	assert_true(c in graph.get_vertices())
 
 	assert_eq(graph.find_edge(a, b), ab)
 	assert_eq(graph.find_edge(b, a), ab)
@@ -145,7 +145,7 @@ func test_neighborhood_directed():
 	assert_true(b in sc)
 
 
-func test_edge_list():
+func test_get_edges():
 	var a = graph.add_vertex("a")
 	var b = graph.add_vertex("b")
 	var c = graph.add_vertex("c")
@@ -157,13 +157,13 @@ func test_edge_list():
 	var ac = graph.add_edge(a, c)
 	var bc = graph.add_edge(b, c)
 
-	var edges = graph.get_edge_list(a, b)
+	var edges = graph.get_edges(a, b)
 	assert_eq(edges.size(), 2)
 	assert_ne(ab1, ab2, "Multiple undirected edges should be allowed") 
 	assert_true(ab1 in edges)
 	assert_true(ab2 in edges)
 
-	edges = graph.get_edge_list()
+	edges = graph.get_edges()
 	assert_eq(edges.size(), 4)
 	assert_true(ab1 in edges)
 	assert_true(ab2 in edges)
@@ -723,7 +723,7 @@ class _TestPerformance extends "res://addons/gut/test.gd":
 		for i in count:
 			var _v = graph.add_vertex(i)
 
-		var vertices = graph.get_vertex_list()
+		var vertices = graph.get_vertices()
 
 		for i in 1000000:
 			var ui = rng.randi() % count
@@ -748,7 +748,7 @@ class _TestPerformance extends "res://addons/gut/test.gd":
 		for i in count:
 			var _v = graph.add_vertex(i)
 
-		var vertices = graph.get_vertex_list()
+		var vertices = graph.get_vertices()
 
 		for i in count:
 			var ui = rng.randi() % count

--- a/tests/project/goost/core/types/test_graph.gd
+++ b/tests/project/goost/core/types/test_graph.gd
@@ -324,7 +324,7 @@ func test_connected_component_cycle():
 
 	
 func create_grid(p_graph, p_width, p_height):
-	graph.clear()
+	p_graph.clear()
 
 	var id = 0
 
@@ -482,8 +482,42 @@ func test_iterator():
 		var _n = V.next()
 		steps += 1
 	assert_eq(steps, 4)
-
 	
+	
+func test_mst():
+	var V = []
+	V.push_back(graph.add_vertex(Vector2(0, 0)))
+	V.push_back(graph.add_vertex(Vector2(200, 0)))
+	V.push_back(graph.add_vertex(Vector2(50, 60)))
+	V.push_back(graph.add_vertex(Vector2(100, 100)))
+	V.push_back(graph.add_vertex(Vector2(0, 100)))
+
+	# Generate complete graph.
+	for i in range(0, V.size()):
+		var a = V[i]
+		for j in range(i + 1, V.size()):
+			var b = V[j]
+			# Euclidean minimum spanning tree.
+			var w = a.value.distance_to(b.value)
+			var _e = graph.add_edge(a, b, w)
+
+	assert_eq(graph.get_edge_count(), 10, "Should generate complete graph")
+
+	var mst = graph.minimum_spanning_tree()
+
+	assert_false(graph.find_edge(V[0], V[1]) in mst)
+	assert_false(graph.find_edge(V[0], V[3]) in mst)
+	assert_false(graph.find_edge(V[0], V[4]) in mst)
+	assert_false(graph.find_edge(V[1], V[2]) in mst)
+	assert_false(graph.find_edge(V[1], V[4]) in mst)
+	assert_false(graph.find_edge(V[3], V[4]) in mst)
+
+	assert_true(graph.find_edge(V[0], V[2]) in mst)
+	assert_true(graph.find_edge(V[1], V[3]) in mst)
+	assert_true(graph.find_edge(V[2], V[3]) in mst)
+	assert_true(graph.find_edge(V[2], V[4]) in mst)
+
+
 func test_save_load():
 	var path = "res://goost/core/types/graph.tres"
 

--- a/tests/project/goost/core/types/test_graph.gd
+++ b/tests/project/goost/core/types/test_graph.gd
@@ -1,0 +1,44 @@
+extends "res://addons/gut/test.gd"
+
+var graph: Graph
+
+func before_each():
+	graph = Graph.new()
+
+    
+func test_add_vertex():
+    var a = graph.add_vertex("a")
+    var b = graph.add_vertex("b")
+
+    assert_eq(a.value, "a")
+    assert_eq(b.value, "b")
+
+
+func test_add_directed_edge():
+    var a = graph.add_vertex("a")
+    var b = graph.add_vertex("b")
+
+    var e1 = graph.add_directed_edge(a, b)
+
+    assert_eq(graph.find_edge(a, b), e1)
+    assert_null(graph.find_edge(b, a), e1)
+
+    var e2 = graph.add_directed_edge("c", "d")
+
+    assert_eq(graph.find_edge(e2.vertex_a, e2.vertex_b), e2)
+    assert_null(graph.find_edge(e2.vertex_b, e2.vertex_a), e2)
+
+
+func test_add_edge():
+    var a = graph.add_vertex("a")
+    var b = graph.add_vertex("b")
+
+    var e1 = graph.add_edge(a, b)
+
+    assert_eq(graph.find_edge(a, b), e1)
+    assert_eq(graph.find_edge(b, a), e1)
+
+    var e2 = graph.add_edge("c", "d")
+
+    assert_eq(graph.find_edge(e2.vertex_a, e2.vertex_b), e2)
+    assert_eq(graph.find_edge(e2.vertex_b, e2.vertex_a), e2)

--- a/tests/project/goost/core/types/test_graph.gd
+++ b/tests/project/goost/core/types/test_graph.gd
@@ -246,8 +246,8 @@ func test_self_loop():
     var a = graph.add_vertex("a")
     var b = graph.add_vertex("b")
 
-    graph.add_edge(a, a)
-    graph.add_edge(b, a)
+    var _e1 = graph.add_edge(a, a)
+    var _e2 = graph.add_edge(b, a)
 
     assert_eq(graph.get_neighbors(a)[0], a)
 

--- a/tests/project/goost/core/types/test_graph.gd
+++ b/tests/project/goost/core/types/test_graph.gd
@@ -25,8 +25,8 @@ func test_add_directed_edge():
 
     var e2 = graph.add_directed_edge("c", "d")
 
-    assert_eq(graph.find_edge(e2.vertex_a, e2.vertex_b), e2)
-    assert_null(graph.find_edge(e2.vertex_b, e2.vertex_a), e2)
+    assert_eq(graph.find_edge(e2.a, e2.b), e2)
+    assert_null(graph.find_edge(e2.b, e2.a), e2)
 
 
 func test_add_edge():
@@ -40,8 +40,8 @@ func test_add_edge():
 
     var e2 = graph.add_edge("c", "d")
 
-    assert_eq(graph.find_edge(e2.vertex_a, e2.vertex_b), e2)
-    assert_eq(graph.find_edge(e2.vertex_b, e2.vertex_a), e2)
+    assert_eq(graph.find_edge(e2.a, e2.b), e2)
+    assert_eq(graph.find_edge(e2.b, e2.a), e2)
 
 
 func test_neighborhood():

--- a/tests/project/goost/core/types/test_graph.gd
+++ b/tests/project/goost/core/types/test_graph.gd
@@ -57,6 +57,32 @@ func test_add_edge():
 	assert_eq(graph.find_edge(e2.b, e2.a), e2)
 
 
+func test_add_edge_by_value_connected():
+	var ab = graph.add_edge("a", "b")
+	var ac = graph.add_edge("a", "c") # A exists, C does not (yet).
+	var bc = graph.add_edge("b", "c") # B exists, C exists as well.
+
+	assert_eq(graph.get_vertex_count(), 3,
+			"Vertices should be connected by value (no duplicates)")
+	
+	var a = graph.find_vertex("a")
+	var b = graph.find_vertex("b")
+	var c = graph.find_vertex("c")
+
+	assert_true(a in graph.get_vertex_list())
+	assert_true(b in graph.get_vertex_list())
+	assert_true(c in graph.get_vertex_list())
+
+	assert_eq(graph.find_edge(a, b), ab)
+	assert_eq(graph.find_edge(b, a), ab)
+
+	assert_eq(graph.find_edge(a, c), ac)
+	assert_eq(graph.find_edge(c, a), ac)
+
+	assert_eq(graph.find_edge(b, c), bc)
+	assert_eq(graph.find_edge(c, b), bc)
+
+
 func test_neighborhood():
 	var a = graph.add_vertex("a")
 	var b = graph.add_vertex("b")
@@ -155,9 +181,9 @@ func test_remove_vertex_one_to_many():
 	graph.remove_vertex(a)
 
 	assert_eq(graph.get_edge_count(), 0)
-	assert_eq(b.get_neighbors().size(), 0)
-	assert_eq(c.get_neighbors().size(), 0)
-	assert_eq(d.get_neighbors().size(), 0)
+	assert_eq(b.get_neighbor_count(), 0)
+	assert_eq(c.get_neighbor_count(), 0)
+	assert_eq(d.get_neighbor_count(), 0)
 
 
 func test_remove_vertex_many_to_many():
@@ -236,13 +262,9 @@ func test_has_edge():
 
 
 func test_remove_edge():
-	var a = graph.add_vertex("a")
-	var b = graph.add_vertex("b")
-	var c = graph.add_vertex("c")
-
-	var ab = graph.add_edge(a, b)
-	var ac = graph.add_edge(a, c)
-	var bc = graph.add_edge(b, c)
+	var ab = graph.add_edge("a", "b")
+	var ac = graph.add_edge("a", "c")
+	var bc = graph.add_edge("b", "c")
 
 	assert_eq(graph.get_edge_count(), 3)
 

--- a/tests/project/goost/core/types/test_graph.gd
+++ b/tests/project/goost/core/types/test_graph.gd
@@ -206,7 +206,7 @@ func test_remove_vertex_many_to_many():
 
 	assert_eq(graph.get_edge_count(), 6)
 
-	graph.remove_vertex(a)
+	a.free() # By destructor.
 
 	assert_eq(graph.get_vertex_count(), 3)
 
@@ -273,7 +273,7 @@ func test_remove_edge():
 
 	assert_eq(graph.get_edge_count(), 3)
 
-	graph.remove_edge(ab)
+	ab.free() # By destructor
 	assert_eq(graph.get_edge_count(), 2)
 
 	graph.remove_edge(ac)

--- a/tests/project/goost/core/types/test_graph.gd
+++ b/tests/project/goost/core/types/test_graph.gd
@@ -15,8 +15,13 @@ func test_add_vertex():
 
 
 func test_get_graph():
-	var v = graph.add_vertex("a")
-	assert_eq(v.get_graph(), graph)
+	var a = graph.add_vertex("a")
+	var b = graph.add_vertex("b")
+	var e = graph.add_edge(a, b)
+
+	assert_eq(a.get_graph(), graph)
+	assert_eq(b.get_graph(), graph)
+	assert_eq(e.get_graph(), graph)
 
 
 func test_find_vertex():

--- a/tests/project/goost/core/types/test_graph.gd
+++ b/tests/project/goost/core/types/test_graph.gd
@@ -114,13 +114,16 @@ func test_edge_list():
 	var b = graph.add_vertex("b")
 	var c = graph.add_vertex("c")
 
-	var ab1 = graph.add_edge(a, b)
-	var ab2 = graph.add_edge(a, b)
+	# Different weights.
+	var ab1 = graph.add_edge(a, b, 1)
+	var ab2 = graph.add_edge(b, a, 2) 
+
 	var ac = graph.add_edge(a, c)
 	var bc = graph.add_edge(b, c)
 
 	var edges = graph.get_edge_list(a, b)
 	assert_eq(edges.size(), 2)
+	assert_ne(ab1, ab2, "Multiple undirected edges should be allowed") 
 	assert_true(ab1 in edges)
 	assert_true(ab2 in edges)
 

--- a/tests/project/goost/core/types/test_graph.gd
+++ b/tests/project/goost/core/types/test_graph.gd
@@ -291,6 +291,45 @@ func test_connected_component():
 	assert_false(graph.is_strongly_connected())
 
 
+class GraphIteratorCustom extends GraphIterator:
+	var v: GraphVertex
+	var count = 0
+
+	func initialize(root):
+		v = root
+
+	func has_next():
+		count += 1
+		return count < 5
+
+	func next():
+		var n = v
+		v = v.get_successors()[0]
+		return n
+
+
+func test_iterator():
+	var it = graph.iterator
+	assert(it is GraphIterator)
+
+	graph.iterator = GraphIteratorCustom.new()
+
+	var a = graph.add_vertex("a")
+	var b = graph.add_vertex("b")
+	var c = graph.add_vertex("c")
+
+	var _ab = graph.add_directed_edge(a, b)
+	var _bc = graph.add_directed_edge(b, c)
+	var _ca = graph.add_directed_edge(c, a)
+
+	var component = graph.find_connected_component(a)
+	assert_eq(component.size(), 4)
+	assert_eq(component[0], a)
+	assert_eq(component[1], b)
+	assert_eq(component[2], c)
+	assert_eq(component[3], a)
+
+
 class _TestPerformance extends "res://addons/gut/test.gd":
 
 	func test_add_remove_dense():

--- a/tests/project/goost/core/types/test_graph.gd
+++ b/tests/project/goost/core/types/test_graph.gd
@@ -709,6 +709,31 @@ class TestInvalidData extends "res://addons/gut/test.gd":
 		assert_eq(ret, false)
 		v.free()
 
+	func test_gdscript_iterator_add_adge():
+		var ret = graph.add_directed_edge(Array([]), Array([]), 0)
+		assert_not_null(ret)
+		ret = graph._iter_next(Array([]))
+		graph.clear()
+		ret = graph.add_edge(Array([]), ".", 0)
+		ret = graph._iter_next(Array([]))
+		
+	func test_custom_iterator():
+		var V = []
+		for i in 10:
+			V.push_back(graph.add_vertex(i))
+
+		graph.iterator = GraphIteratorCustom.new()
+		var G = graph.iterator
+		G.initialize(V[0])
+
+		var steps = 0
+		while G.has_next():
+			var _n = G.next()
+			if steps == 3:
+				graph.clear()
+			steps += 1
+		assert_eq(steps, 4)
+
 
 class _TestPerformance extends "res://addons/gut/test.gd":
 

--- a/tests/project/goost/core/types/test_graph.gd
+++ b/tests/project/goost/core/types/test_graph.gd
@@ -5,261 +5,261 @@ var graph: Graph
 func before_each():
 	graph = Graph.new()
 
-    
-func test_add_vertex():
-    var a = graph.add_vertex("a")
-    var b = graph.add_vertex("b")
 
-    assert_eq(a.value, "a")
-    assert_eq(b.value, "b")
+func test_add_vertex():
+	var a = graph.add_vertex("a")
+	var b = graph.add_vertex("b")
+
+	assert_eq(a.value, "a")
+	assert_eq(b.value, "b")
 
 
 func test_add_directed_edge():
-    var a = graph.add_vertex("a")
-    var b = graph.add_vertex("b")
+	var a = graph.add_vertex("a")
+	var b = graph.add_vertex("b")
 
-    var e1 = graph.add_directed_edge(a, b)
+	var e1 = graph.add_directed_edge(a, b)
 
-    assert_eq(graph.find_edge(a, b), e1)
-    assert_null(graph.find_edge(b, a), e1)
+	assert_eq(graph.find_edge(a, b), e1)
+	assert_null(graph.find_edge(b, a), e1)
 
-    var e2 = graph.add_directed_edge("c", "d")
+	var e2 = graph.add_directed_edge("c", "d")
 
-    assert_eq(graph.find_edge(e2.a, e2.b), e2)
-    assert_null(graph.find_edge(e2.b, e2.a), e2)
+	assert_eq(graph.find_edge(e2.a, e2.b), e2)
+	assert_null(graph.find_edge(e2.b, e2.a), e2)
 
 
 func test_add_edge():
-    var a = graph.add_vertex("a")
-    var b = graph.add_vertex("b")
+	var a = graph.add_vertex("a")
+	var b = graph.add_vertex("b")
 
-    var e1 = graph.add_edge(a, b)
+	var e1 = graph.add_edge(a, b)
 
-    assert_eq(graph.find_edge(a, b), e1)
-    assert_eq(graph.find_edge(b, a), e1)
+	assert_eq(graph.find_edge(a, b), e1)
+	assert_eq(graph.find_edge(b, a), e1)
 
-    var e2 = graph.add_edge("c", "d")
+	var e2 = graph.add_edge("c", "d")
 
-    assert_eq(graph.find_edge(e2.a, e2.b), e2)
-    assert_eq(graph.find_edge(e2.b, e2.a), e2)
+	assert_eq(graph.find_edge(e2.a, e2.b), e2)
+	assert_eq(graph.find_edge(e2.b, e2.a), e2)
 
 
 func test_neighborhood():
-    var a = graph.add_vertex("a")
-    var b = graph.add_vertex("b")
-    var c = graph.add_vertex("c")
+	var a = graph.add_vertex("a")
+	var b = graph.add_vertex("b")
+	var c = graph.add_vertex("c")
 
-    var _e1 = graph.add_edge(a, b)
-    var _e2 = graph.add_edge(a, c)
-    var _e3 = graph.add_edge(b, c)
+	var _e1 = graph.add_edge(a, b)
+	var _e2 = graph.add_edge(a, c)
+	var _e3 = graph.add_edge(b, c)
 
-    var na = a.get_neighbors()
-    var nb = b.get_neighbors()
-    var nc = c.get_neighbors()
+	var na = a.get_neighbors()
+	var nb = b.get_neighbors()
+	var nc = c.get_neighbors()
 
-    assert_eq(a.get_neighbor_count(), 2)
-    assert_true(b in na)
-    assert_true(c in na)
+	assert_eq(a.get_neighbor_count(), 2)
+	assert_true(b in na)
+	assert_true(c in na)
 
-    assert_eq(b.get_neighbor_count(), 2)
-    assert_true(a in nb)
-    assert_true(c in nb)
+	assert_eq(b.get_neighbor_count(), 2)
+	assert_true(a in nb)
+	assert_true(c in nb)
 
-    assert_eq(c.get_neighbor_count(), 2)
-    assert_true(a in nc)
-    assert_true(b in nc)
+	assert_eq(c.get_neighbor_count(), 2)
+	assert_true(a in nc)
+	assert_true(b in nc)
 
 
 func test_neighborhood_directed():
-    var a = graph.add_vertex("a")
-    var b = graph.add_vertex("b")
-    var c = graph.add_vertex("c")
+	var a = graph.add_vertex("a")
+	var b = graph.add_vertex("b")
+	var c = graph.add_vertex("c")
 
-    var _e1 = graph.add_edge(a, b)
-    var _e2 = graph.add_directed_edge(a, c)
+	var _e1 = graph.add_edge(a, b)
+	var _e2 = graph.add_directed_edge(a, c)
 
-    var na = a.get_neighbors()
-    var sa = a.get_successors()
-    var pc = c.get_predecessors()
+	var na = a.get_neighbors()
+	var sa = a.get_successors()
+	var pc = c.get_predecessors()
 
-    assert_eq(a.get_neighbor_count(), 2)
-    assert_true(b in na)
-    assert_true(c in na)
+	assert_eq(a.get_neighbor_count(), 2)
+	assert_true(b in na)
+	assert_true(c in na)
 
-    assert_eq(a.get_successor_count(), 1)
-    assert_true(c in sa)
+	assert_eq(a.get_successor_count(), 1)
+	assert_true(c in sa)
 
-    assert_eq(c.get_predecessor_count(), 1)
-    assert_true(a in pc)
+	assert_eq(c.get_predecessor_count(), 1)
+	assert_true(a in pc)
 
-    var _e3 = graph.add_directed_edge(c, a)
-    var _e4 = graph.add_directed_edge(c, b)
-    var sc = c.get_successors()
+	var _e3 = graph.add_directed_edge(c, a)
+	var _e4 = graph.add_directed_edge(c, b)
+	var sc = c.get_successors()
 
-    assert_eq(sc.size(), 2)
-    assert_true(a in sc)
-    assert_true(b in sc)
+	assert_eq(sc.size(), 2)
+	assert_true(a in sc)
+	assert_true(b in sc)
 
 
 func test_edge_list():
-    var a = graph.add_vertex("a")
-    var b = graph.add_vertex("b")
-    var c = graph.add_vertex("c")
+	var a = graph.add_vertex("a")
+	var b = graph.add_vertex("b")
+	var c = graph.add_vertex("c")
 
-    var ab1 = graph.add_edge(a, b)
-    var ab2 = graph.add_edge(a, b)
-    var ac = graph.add_edge(a, c)
-    var bc = graph.add_edge(b, c)
+	var ab1 = graph.add_edge(a, b)
+	var ab2 = graph.add_edge(a, b)
+	var ac = graph.add_edge(a, c)
+	var bc = graph.add_edge(b, c)
 
-    var edges = graph.get_edge_list(a, b)
-    assert_eq(edges.size(), 2)
-    assert_true(ab1 in edges)
-    assert_true(ab2 in edges)
+	var edges = graph.get_edge_list(a, b)
+	assert_eq(edges.size(), 2)
+	assert_true(ab1 in edges)
+	assert_true(ab2 in edges)
 
-    edges = graph.get_edge_list()
-    assert_eq(edges.size(), 4)
-    assert_true(ab1 in edges)
-    assert_true(ab2 in edges)
-    assert_true(ac in edges)
-    assert_true(bc in edges)
+	edges = graph.get_edge_list()
+	assert_eq(edges.size(), 4)
+	assert_true(ab1 in edges)
+	assert_true(ab2 in edges)
+	assert_true(ac in edges)
+	assert_true(bc in edges)
 
 
 func test_remove_vertex_one_to_many():
-    var a = graph.add_vertex("a")
-    var b = graph.add_vertex("b")
-    var c = graph.add_vertex("c")
-    var d = graph.add_vertex("d")
+	var a = graph.add_vertex("a")
+	var b = graph.add_vertex("b")
+	var c = graph.add_vertex("c")
+	var d = graph.add_vertex("d")
 
-    var _ab = graph.add_edge(a, b)
-    var _ac = graph.add_edge(a, c)
-    var _ad = graph.add_edge(a, d)
-    
-    assert_eq(graph.get_edge_count(), 3)
-    
-    graph.remove_vertex(a)
-    
-    assert_eq(graph.get_edge_count(), 0)
-    assert_eq(b.get_neighbors().size(), 0)
-    assert_eq(c.get_neighbors().size(), 0)
-    assert_eq(d.get_neighbors().size(), 0)
+	var _ab = graph.add_edge(a, b)
+	var _ac = graph.add_edge(a, c)
+	var _ad = graph.add_edge(a, d)
+
+	assert_eq(graph.get_edge_count(), 3)
+
+	graph.remove_vertex(a)
+
+	assert_eq(graph.get_edge_count(), 0)
+	assert_eq(b.get_neighbors().size(), 0)
+	assert_eq(c.get_neighbors().size(), 0)
+	assert_eq(d.get_neighbors().size(), 0)
 
 
 func test_remove_vertex_many_to_many():
-    var a = graph.add_vertex("a")
-    var b = graph.add_vertex("b")
-    var c = graph.add_vertex("c")
-    var d = graph.add_vertex("d")
+	var a = graph.add_vertex("a")
+	var b = graph.add_vertex("b")
+	var c = graph.add_vertex("c")
+	var d = graph.add_vertex("d")
 
-    var _ab = graph.add_edge(a, b)
-    var _ac = graph.add_edge(a, c)
-    var _ad = graph.add_edge(a, d)
-    var _cb = graph.add_edge(c, b)
-    var _cd = graph.add_edge(c, d)
-    var _bd = graph.add_edge(b, d)
+	var _ab = graph.add_edge(a, b)
+	var _ac = graph.add_edge(a, c)
+	var _ad = graph.add_edge(a, d)
+	var _cb = graph.add_edge(c, b)
+	var _cd = graph.add_edge(c, d)
+	var _bd = graph.add_edge(b, d)
 
-    assert_eq(graph.get_edge_count(), 6)
+	assert_eq(graph.get_edge_count(), 6)
 
-    graph.remove_vertex(a)
+	graph.remove_vertex(a)
 
-    assert_eq(graph.get_vertex_count(), 3)
+	assert_eq(graph.get_vertex_count(), 3)
 
-    assert_eq(graph.get_edge_count(), 3)
-    assert_eq(c.get_neighbors().size(), 2)
-    assert_eq(b.get_neighbors().size(), 2)
-    assert_eq(d.get_neighbors().size(), 2)
+	assert_eq(graph.get_edge_count(), 3)
+	assert_eq(c.get_neighbors().size(), 2)
+	assert_eq(b.get_neighbors().size(), 2)
+	assert_eq(d.get_neighbors().size(), 2)
 
-    graph.remove_vertex(b)
+	graph.remove_vertex(b)
 
-    assert_eq(graph.get_edge_count(), 1)
-    assert_eq(c.get_neighbors().size(), 1)
-    assert_eq(d.get_neighbors().size(), 1)
+	assert_eq(graph.get_edge_count(), 1)
+	assert_eq(c.get_neighbors().size(), 1)
+	assert_eq(d.get_neighbors().size(), 1)
 
-    graph.remove_vertex(c)
+	graph.remove_vertex(c)
 
-    assert_eq(graph.get_edge_count(), 0)
-    assert_eq(d.get_neighbors().size(), 0)
+	assert_eq(graph.get_edge_count(), 0)
+	assert_eq(d.get_neighbors().size(), 0)
 
 
 func test_clear_edges():
-    var a = graph.add_vertex("a")
-    var b = graph.add_vertex("b")
-    var c = graph.add_vertex("c")
+	var a = graph.add_vertex("a")
+	var b = graph.add_vertex("b")
+	var c = graph.add_vertex("c")
 
-    var _ab = graph.add_edge(a, b)
-    var _ac = graph.add_edge(a, c)
-    var _bc = graph.add_edge(b, c)
+	var _ab = graph.add_edge(a, b)
+	var _ac = graph.add_edge(a, c)
+	var _bc = graph.add_edge(b, c)
 
-    assert_eq(graph.get_vertex_count(), 3)
-    assert_eq(graph.get_edge_count(), 3)
-    assert_eq(a.get_neighbors().size(), 2)
-    assert_eq(b.get_neighbors().size(), 2)
-    assert_eq(c.get_neighbors().size(), 2)
+	assert_eq(graph.get_vertex_count(), 3)
+	assert_eq(graph.get_edge_count(), 3)
+	assert_eq(a.get_neighbors().size(), 2)
+	assert_eq(b.get_neighbors().size(), 2)
+	assert_eq(c.get_neighbors().size(), 2)
 
-    graph.clear_edges()
+	graph.clear_edges()
 
-    assert_eq(graph.get_vertex_count(), 3)
-    assert_eq(graph.get_edge_count(), 0)
-    assert_eq(a.get_neighbors().size(), 0)
-    assert_eq(b.get_neighbors().size(), 0)
-    assert_eq(c.get_neighbors().size(), 0)
+	assert_eq(graph.get_vertex_count(), 3)
+	assert_eq(graph.get_edge_count(), 0)
+	assert_eq(a.get_neighbors().size(), 0)
+	assert_eq(b.get_neighbors().size(), 0)
+	assert_eq(c.get_neighbors().size(), 0)
 
-    
+
 func test_has_edge():
-    var a = graph.add_vertex("a")
-    var b = graph.add_vertex("b")
-    var c = graph.add_vertex("c")
+	var a = graph.add_vertex("a")
+	var b = graph.add_vertex("b")
+	var c = graph.add_vertex("c")
 
-    var _ab = graph.add_edge(a, b)
-    var _ac = graph.add_edge(a, c)
+	var _ab = graph.add_edge(a, b)
+	var _ac = graph.add_edge(a, c)
 
-    assert_true(graph.has_edge(a, b))
-    assert_true(graph.has_edge(a, c))
-    assert_true(graph.has_edge(b, a))
-    assert_false(graph.has_edge(b, c))
-    assert_false(graph.has_edge(c, b))
+	assert_true(graph.has_edge(a, b))
+	assert_true(graph.has_edge(a, c))
+	assert_true(graph.has_edge(b, a))
+	assert_false(graph.has_edge(b, c))
+	assert_false(graph.has_edge(c, b))
 
-    
+
 func test_remove_edge():
-    var a = graph.add_vertex("a")
-    var b = graph.add_vertex("b")
-    var c = graph.add_vertex("c")
+	var a = graph.add_vertex("a")
+	var b = graph.add_vertex("b")
+	var c = graph.add_vertex("c")
 
-    var ab = graph.add_edge(a, b)
-    var ac = graph.add_edge(a, c)
-    var bc = graph.add_edge(b, c)
+	var ab = graph.add_edge(a, b)
+	var ac = graph.add_edge(a, c)
+	var bc = graph.add_edge(b, c)
 
-    assert_eq(graph.get_edge_count(), 3)
+	assert_eq(graph.get_edge_count(), 3)
 
-    graph.remove_edge(ab)
-    assert_eq(graph.get_edge_count(), 2)
+	graph.remove_edge(ab)
+	assert_eq(graph.get_edge_count(), 2)
 
-    graph.remove_edge(ac)
-    assert_eq(graph.get_edge_count(), 1)
+	graph.remove_edge(ac)
+	assert_eq(graph.get_edge_count(), 1)
 
-    graph.remove_edge(bc)
-    assert_eq(graph.get_edge_count(), 0)
+	graph.remove_edge(bc)
+	assert_eq(graph.get_edge_count(), 0)
 
-    assert_eq(graph.get_vertex_count(), 3)
+	assert_eq(graph.get_vertex_count(), 3)
 
 
 func test_self_loop():
-    var a = graph.add_vertex("a")
-    var b = graph.add_vertex("b")
+	var a = graph.add_vertex("a")
+	var b = graph.add_vertex("b")
 
-    var _e1 = graph.add_edge(a, a)
-    var _e2 = graph.add_edge(b, a)
+	var _e1 = graph.add_edge(a, a)
+	var _e2 = graph.add_edge(b, a)
 
-    assert_eq(a.get_neighbors()[0], a)
+	assert_eq(a.get_neighbors()[0], a)
 
-    graph.remove_vertex(a)
-    graph.remove_vertex(b)
-    # Should not crash...
+	graph.remove_vertex(a)
+	graph.remove_vertex(b)
+	# Should not crash...
 
 
 # func test_perf():
 #     var rng = RandomNumberGenerator.new()
 #     rng.seed = 480789
-    
+
 #     var count = 100000
 
 #     var t1 = OS.get_ticks_msec()

--- a/tests/project/goost/core/types/test_graph.gd
+++ b/tests/project/goost/core/types/test_graph.gd
@@ -264,26 +264,29 @@ func test_self_loop():
 	# Should not crash...
 
 
-# func test_perf():
-#     var rng = RandomNumberGenerator.new()
-#     rng.seed = 480789
+class TestPerformance extends "res://addons/gut/test.gd":
 
-#     var count = 100000
+	func test_add_remove():
+		var graph = Graph.new()
+		var rng = RandomNumberGenerator.new()
+		rng.seed = 480789
 
-#     var t1 = OS.get_ticks_msec()
-#     for i in count:
-#         var _v = graph.add_vertex(i)
+		var count = 1000000
 
-#     var vertices = graph.get_vertex_list()
+		var t1 = OS.get_ticks_msec()
+		for i in count:
+			var _v = graph.add_vertex(i)
 
-#     for i in count:
-#         var ui = rng.randi() % count
-#         var vi = rng.randi() % count
-#         var _e = graph.add_edge(vertices[ui], vertices[vi])
+		var vertices = graph.get_vertex_list()
 
-#     for i in count:
-#         var v = vertices[i]
-#         graph.remove_vertex(v)
+		for i in count:
+			var ui = rng.randi() % count
+			var vi = rng.randi() % count
+			var _e = graph.add_edge(vertices[ui], vertices[vi])
 
-#     var t2 = OS.get_ticks_msec()
-#     gut.p(t2 - t1)
+		for i in count:
+			var v = vertices[i]
+			graph.remove_vertex(v)
+
+		var t2 = OS.get_ticks_msec()
+		gut.p(t2 - t1)

--- a/tests/project/goost/core/types/test_graph.gd
+++ b/tests/project/goost/core/types/test_graph.gd
@@ -216,3 +216,26 @@ func test_has_edge():
     assert_true(graph.has_edge(b, a))
     assert_false(graph.has_edge(b, c))
     assert_false(graph.has_edge(c, b))
+
+    
+func test_remove_edge():
+    var a = graph.add_vertex("a")
+    var b = graph.add_vertex("b")
+    var c = graph.add_vertex("c")
+
+    var ab = graph.add_edge(a, b)
+    var ac = graph.add_edge(a, c)
+    var bc = graph.add_edge(b, c)
+
+    assert_eq(graph.get_edge_count(), 3)
+
+    graph.remove_edge(ab)
+    assert_eq(graph.get_edge_count(), 2)
+
+    graph.remove_edge(ac)
+    assert_eq(graph.get_edge_count(), 1)
+
+    graph.remove_edge(bc)
+    assert_eq(graph.get_edge_count(), 0)
+
+    assert_eq(graph.get_vertex_count(), 3)

--- a/tests/project/goost/core/types/test_graph.gd
+++ b/tests/project/goost/core/types/test_graph.gd
@@ -428,6 +428,26 @@ func test_depth_iterator():
 	assert_eq(count, 100)
 
 
+func test_gdscript_iterator():
+	for i in 5:
+		var _v = graph.add_vertex(i)
+	for i in range(1, 5):
+		var _e = graph.add_edge(0, i)
+
+	for vertex in graph:
+		assert_not_null(vertex)
+		if OS.is_stdout_verbose():
+			gut.p(vertex.value)
+
+	if OS.is_stdout_verbose():	
+		gut.p("Neighbors:")
+
+	for neighbor in graph.find_vertex(0):
+		assert_not_null(neighbor)
+		if OS.is_stdout_verbose():
+			gut.p(neighbor.value)
+
+
 func test_get_connected_components():
 	var V = []
 	for i in 10:
@@ -677,6 +697,17 @@ class TestInvalidData extends "res://addons/gut/test.gd":
 		assert_null(e)
 		v.free()
 		e.free()
+		
+	func test_gdscript_iterator():
+		var ret = graph._iter_next([])
+		assert_eq(ret, false)
+		graph.clear()
+		ret = graph._iter_get([])
+		
+		var v = ClassDB.instance("GraphVertex")
+		ret = v._iter_next([])
+		assert_eq(ret, false)
+		v.free()
 
 
 class _TestPerformance extends "res://addons/gut/test.gd":

--- a/tests/project/goost/core/types/test_graph.gd
+++ b/tests/project/goost/core/types/test_graph.gd
@@ -177,3 +177,42 @@ func test_remove_vertex_many_to_many():
 
     assert_eq(graph.get_edge_count(), 0)
     assert_eq(graph.get_neighbors(d).size(), 0)
+
+
+func test_clear_edges():
+    var a = graph.add_vertex("a")
+    var b = graph.add_vertex("b")
+    var c = graph.add_vertex("c")
+
+    var _ab = graph.add_edge(a, b)
+    var _ac = graph.add_edge(a, c)
+    var _bc = graph.add_edge(b, c)
+
+    assert_eq(graph.get_vertex_count(), 3)
+    assert_eq(graph.get_edge_count(), 3)
+    assert_eq(graph.get_neighbors(a).size(), 2)
+    assert_eq(graph.get_neighbors(b).size(), 2)
+    assert_eq(graph.get_neighbors(c).size(), 2)
+
+    graph.clear_edges()
+
+    assert_eq(graph.get_vertex_count(), 3)
+    assert_eq(graph.get_edge_count(), 0)
+    assert_eq(graph.get_neighbors(a).size(), 0)
+    assert_eq(graph.get_neighbors(b).size(), 0)
+    assert_eq(graph.get_neighbors(c).size(), 0)
+
+    
+func test_has_edge():
+    var a = graph.add_vertex("a")
+    var b = graph.add_vertex("b")
+    var c = graph.add_vertex("c")
+
+    var _ab = graph.add_edge(a, b)
+    var _ac = graph.add_edge(a, c)
+
+    assert_true(graph.has_edge(a, b))
+    assert_true(graph.has_edge(a, c))
+    assert_true(graph.has_edge(b, a))
+    assert_false(graph.has_edge(b, c))
+    assert_false(graph.has_edge(c, b))

--- a/tests/project/goost/core/types/test_graph.gd
+++ b/tests/project/goost/core/types/test_graph.gd
@@ -82,8 +82,9 @@ func test_neighborhood_directed():
     var sa = graph.get_successors(a)
     var pc = graph.get_predecessors(c)
 
-    assert_eq(na.size(), 1)
+    assert_eq(na.size(), 2)
     assert_true(b in na)
+    assert_true(c in na)
 
     assert_eq(sa.size(), 1)
     assert_true(c in sa)
@@ -241,7 +242,24 @@ func test_remove_edge():
     assert_eq(graph.get_vertex_count(), 3)
 
 
+func test_self_loop():
+    var a = graph.add_vertex("a")
+    var b = graph.add_vertex("b")
+
+    graph.add_edge(a, a)
+    graph.add_edge(b, a)
+
+    assert_eq(graph.get_neighbors(a)[0], a)
+
+    graph.remove_vertex(a)
+    graph.remove_vertex(b)
+    # Should not crash...
+
+
 # func test_perf():
+#     var rng = RandomNumberGenerator.new()
+#     rng.seed = 480789
+    
 #     var count = 100000
 
 #     var t1 = OS.get_ticks_msec()
@@ -251,16 +269,13 @@ func test_remove_edge():
 #     var vertices = graph.get_vertex_list()
 
 #     for i in count:
-#         var ui = randi() % count
-#         var vi = randi() % count
+#         var ui = rng.randi() % count
+#         var vi = rng.randi() % count
 #         graph.add_edge(vertices[ui], vertices[vi])
 
-#     var edges = graph.get_edge_list()
-
 #     for i in count:
-#         var vi = randi() % vertices.size()
-#         graph.remove_vertex(vertices[vi])
-#         vertices.remove(vi)
+#         var v = vertices[i]
+#         graph.remove_vertex(v)
 
 #     var t2 = OS.get_ticks_msec()
 #     gut.p(t2 - t1)

--- a/tests/project/goost/core/types/test_graph.gd
+++ b/tests/project/goost/core/types/test_graph.gd
@@ -340,7 +340,7 @@ class _TestPerformance extends "res://addons/gut/test.gd":
 		var t1 = OS.get_ticks_msec()
 
 		var component = graph.find_connected_component(vertices[0])
-		assert_eq(component.size(), 79500)
+		assert_eq(component.size(), 95884)
 
 		var t2 = OS.get_ticks_msec()
 		gut.p(t2 - t1)

--- a/tests/project/goost/core/types/test_graph.gd
+++ b/tests/project/goost/core/types/test_graph.gd
@@ -521,6 +521,43 @@ func test_mst():
 	assert_true(graph.find_edge(V[2], V[4]) in mst)
 
 
+func test_shortest_path_tree():
+	var V = []
+	for i in 4:
+		V.push_back(graph.add_vertex(i))
+
+	var _e
+	_e = graph.add_edge(V[0], V[1], 2)
+	_e = graph.add_edge(V[0], V[3], 5)
+	_e = graph.add_edge(V[1], V[2], 1)
+	_e = graph.add_edge(V[3], V[2], 3)
+
+	var tree = graph.shortest_path_tree(V[0])
+	assert_eq(tree.edges.size(), 3)
+
+	for current in tree.backtrace:
+		var previous = tree.backtrace[current]
+		var distance = tree.distance[current]
+		match current.value:
+			0:
+				assert_null(previous)
+				assert_eq(distance, 0.0)
+			1:
+				assert_eq(previous.value, 0)
+				assert_eq(distance, 2.0)
+			2:
+				assert_eq(previous.value, 1)
+				assert_eq(distance, 3.0)
+			3:
+				assert_eq(previous.value, 0)
+				assert_eq(distance, 5.0)
+
+		if OS.is_stdout_verbose():
+			print("Current: ", current.value,
+				", Previous: ", previous.value if previous else "None",
+				", Distance: ", distance)
+
+
 func test_save_load():
 	var path = "res://goost/core/types/graph.tres"
 

--- a/tests/project/project.godot
+++ b/tests/project/project.godot
@@ -31,6 +31,7 @@ gdscript/warnings/treat_warnings_as_errors=true
 gdscript/warnings/unused_class_variable=true
 gdscript/warnings/unsafe_cast=true
 gdscript/warnings/unsafe_call_argument=true
+draw/2d/antialiased=true
 
 [editor_plugins]
 


### PR DESCRIPTION
Closes godotengine/godot-proposals#3848.

Intended to implement a mixed graph data structure. Allows to add both associative (undirected) and directed edges, with multiple edges between a pair of vertices, and self-loops.

```gdscript
func _ready():
	var graph = Graph.new()

    var a: GraphVertex = graph.add_vertex("a")
    var b: GraphVertex = graph.add_vertex("b")
    var c: GraphVertex = graph.add_vertex("c")

    var ab: GraphEdge = graph.add_edge(a, b)
    var ac: GraphEdge = graph.add_edge(a, c)
    var bc: GraphEdge = graph.add_edge(b, c)

    print(graph.has_edge(a, b)) # Prints True
    print(graph.has_edge(b, a)) # Prints True
```

*(annotations are optional)*

## To-do

- [x] Handle self-loops (may be already working correctly).
- [x] Provide essential algorithms for graph traversal.
    - [x] Fix DFS
       - https://www.banterly.net/2020/02/09/why-what-you-have-been-thaught-about-dfs-is-wrong-at-least-partially
       - https://11011110.github.io/blog/2013/12/17/stack-based-graph-traversal.html
       - https://gist.github.com/deyindra/165fa58efbf0a3a9d943
- [x] Serialization
- [ ] ... a whole lot of more stuff
