### PR TITLE
Add a way to enumerate edges connected to `GraphVertex`

### DIFF
--- a/core/types/graph.cpp
+++ b/core/types/graph.cpp
@@ -281,7 +281,7 @@ Array GraphVertex::get_edges() const {
 	return ret;
 }
 
-Array GraphVertex::get_inward_edges() const {
+Array GraphVertex::get_incoming_edges() const {
 	Array ret;
 	
 	const uint32_t *v = nullptr;
@@ -297,7 +297,7 @@ Array GraphVertex::get_inward_edges() const {
 	return ret;
 }
 
-Array GraphVertex::get_outward_edges() const {
+Array GraphVertex::get_outgoing_edges() const {
 	Array ret;
 
 	const uint32_t *v = nullptr;
@@ -843,8 +843,8 @@ void GraphVertex::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_predecessor_count"), &GraphVertex::get_predecessor_count);
 
 	ClassDB::bind_method(D_METHOD("get_edges"), &GraphVertex::get_edges);
-	ClassDB::bind_method(D_METHOD("get_inward_edges"), &GraphVertex::get_inward_edges);
-	ClassDB::bind_method(D_METHOD("get_outward_edges"), &GraphVertex::get_outward_edges);
+	ClassDB::bind_method(D_METHOD("get_incoming_edges"), &GraphVertex::get_incoming_edges);
+	ClassDB::bind_method(D_METHOD("get_outgoing_edges"), &GraphVertex::get_outgoing_edges);
 
 	ClassDB::bind_method(D_METHOD("set_value", "value"), &GraphVertex::set_value);
 	ClassDB::bind_method(D_METHOD("get_value"), &GraphVertex::get_value);

--- a/core/types/graph.cpp
+++ b/core/types/graph.cpp
@@ -268,6 +268,51 @@ Array GraphVertex::get_predecessors() const {
 	return ret;
 }
 
+Array GraphVertex::get_edges() const {
+	Array ret;
+	
+	const uint32_t *v = nullptr;
+	while ((v = neighbors.next(v))) {
+		const EdgeList &list = graph->get_edges(this->id, neighbors[*v]->id);
+		for (int i = 0; i < list.size(); ++i) {
+			ret.push_back(list[i]);
+		}
+	}
+	return ret;
+}
+
+Array GraphVertex::get_inward_edges() const {
+	Array ret;
+	
+	const uint32_t *v = nullptr;
+	while ((v = predecessors.next(v))) {
+		const EdgeList &list = graph->get_edges(this->id, predecessors[*v]->id);
+		for (int i = 0; i < list.size(); ++i) {
+			const GraphEdge *edge = list[i];
+			if (edge->is_directed() && this == edge->get_b() && predecessors[*v] == edge->get_a()) {
+				ret.push_back(edge);
+			}
+		}
+	}
+	return ret;
+}
+
+Array GraphVertex::get_outward_edges() const {
+	Array ret;
+
+	const uint32_t *v = nullptr;
+	while ((v = successors.next(v))) {
+		const EdgeList &list = graph->get_edges(this->id, successors[*v]->id);
+		for (int i = 0; i < list.size(); ++i) {
+			const GraphEdge *edge = list[i];
+			if (edge->is_directed() && this == edge->get_a() && successors[*v] == edge->get_b()) {
+				ret.push_back(edge);
+			}
+		}
+	}
+	return ret;
+}
+
 GraphEdge *Graph::_add_edge(const Variant &p_a, const Variant &p_b, const Variant &p_value, bool p_directed) {
 	ERR_FAIL_COND_V(p_a.get_type() == Variant::NIL, nullptr);
 	ERR_FAIL_COND_V(p_b.get_type() == Variant::NIL, nullptr);
@@ -796,6 +841,10 @@ void GraphVertex::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_predecessors"), &GraphVertex::get_predecessors);
 	ClassDB::bind_method(D_METHOD("get_predecessor_count"), &GraphVertex::get_predecessor_count);
+
+	ClassDB::bind_method(D_METHOD("get_edges"), &GraphVertex::get_edges);
+	ClassDB::bind_method(D_METHOD("get_inward_edges"), &GraphVertex::get_inward_edges);
+	ClassDB::bind_method(D_METHOD("get_outward_edges"), &GraphVertex::get_outward_edges);
 
 	ClassDB::bind_method(D_METHOD("set_value", "value"), &GraphVertex::set_value);
 	ClassDB::bind_method(D_METHOD("get_value"), &GraphVertex::get_value);

--- a/core/types/graph.cpp
+++ b/core/types/graph.cpp
@@ -32,8 +32,14 @@ void GraphData::remove_vertex(GraphVertex *p_vertex) {
 		}
 		if (p_vertex != n_vertex) {
 			// Handle self-loops, there's no point to remove neighbors to self,
-			// since the vertex is going to be deleted anyway.
+			// since the vertex is going to be deleted.
 			n_vertex->neighbors.erase(p_vertex->id);
+			if (n_vertex->successors.has(p_vertex->id)) {
+				n_vertex->successors.erase(p_vertex->id);
+			}
+			if (n_vertex->predecessors.has(p_vertex->id)) {
+				n_vertex->predecessors.erase(p_vertex->id);
+			}
 		}
 	}
 	for (int i = 0; i < edges_to_delete.size(); ++i) {
@@ -59,6 +65,10 @@ void GraphData::remove_edge(GraphEdge *p_edge) {
 		if (p_edge == list[i]) {
 			a->neighbors.erase(b->id);
 			b->neighbors.erase(a->id);
+			if (p_edge->directed) {
+				a->successors.erase(b->id);
+				b->predecessors.erase(a->id);
+			}
 			list.remove_unordered(i);
 			break;
 		}
@@ -242,58 +252,20 @@ Array GraphVertex::get_successors() const {
 	Array ret;
 
 	const uint32_t *n = nullptr;
-	while ((n = neighbors.next(n))) {
-		const GraphVertex *a = this;
-		const GraphVertex *b = neighbors[*n];
-
-		const EdgeList &list = graph->get_edges(a->id, b->id);
-
-		for (int i = 0; i < list.size(); ++i) {
-			GraphEdge *edge = list[i];
-			if (!edge->is_directed()) {
-				continue;
-			}
-			if (edge->get_a() == this) {
-				ret.push_back(edge->get_b());
-				// There may be multiple edges connected from the same vertex.
-				break;
-			}
-		}
+	while ((n = successors.next(n))) {
+		ret.push_back(successors[*n]);
 	}
 	return ret;
-}
-
-int GraphVertex::get_successor_count() const {
-	return get_successors().size(); // TODO: can be optimized.
 }
 
 Array GraphVertex::get_predecessors() const {
 	Array ret;
 
 	const uint32_t *n = nullptr;
-	while ((n = neighbors.next(n))) {
-		const GraphVertex *a = this;
-		const GraphVertex *b = neighbors[*n];
-
-		const EdgeList &list = graph->get_edges(a->id, b->id);
-
-		for (int i = 0; i < list.size(); ++i) {
-			GraphEdge *edge = list[i];
-			if (!edge->is_directed()) {
-				continue;
-			}
-			if (edge->get_b() == this) {
-				ret.push_back(edge->get_a());
-				// There may be multiple edges connected from the same vertex.
-				break;
-			}
-		}
+	while ((n = predecessors.next(n))) {
+		ret.push_back(predecessors[*n]);
 	}
 	return ret;
-}
-
-int GraphVertex::get_predecessor_count() const {
-	return get_predecessors().size(); // TODO: can be optimized.
 }
 
 GraphEdge *Graph::_add_edge(const Variant &p_a, const Variant &p_b, const Variant &p_value, bool p_directed) {
@@ -305,6 +277,9 @@ GraphEdge *Graph::_add_edge(const Variant &p_a, const Variant &p_b, const Varian
 	GraphVertex *a = nullptr;
 	GraphVertex *b = nullptr;
 
+	// By default, check if the passed value is GraphVertex.
+	// If not, then attempt to find an existing vertex by value.
+	// If that fails as well, then just create a new vertex.
 	if (p_a.get_type() == Variant::OBJECT) {
 		a = Object::cast_to<GraphVertex>(p_a);
 	}
@@ -326,12 +301,19 @@ GraphEdge *Graph::_add_edge(const Variant &p_a, const Variant &p_b, const Varian
 #ifdef DEBUG_ENABLED
 	ERR_FAIL_NULL_V(a, nullptr);
 	ERR_FAIL_NULL_V(b, nullptr);
-	ERR_FAIL_COND_V_MSG(a->graph != graph, nullptr, "A vertex is not owned by this graph");
-	ERR_FAIL_COND_V_MSG(b->graph != graph, nullptr, "B vertex is not owned by this graph");
+	// This issue may happen when `GraphVertex`
+	// is instantiated outside of `add_vertex()` call.
+	ERR_FAIL_COND_V_MSG(a->graph != graph, nullptr, "The 'A' vertex is not owned by this graph");
+	ERR_FAIL_COND_V_MSG(b->graph != graph, nullptr, "The 'B' vertex is not owned by this graph");
 #endif
+	// Setup neighbors.
 	a->neighbors[b->id] = b;
 	b->neighbors[a->id] = a;
-
+	if (p_directed) {
+		a->successors[b->id] = b;
+		b->predecessors[a->id] = a;
+	}
+	// Instantiate a new edge.
 	GraphEdge *edge = _create_edge();
 	edge->a = a;
 	edge->b = b;
@@ -339,6 +321,7 @@ GraphEdge *Graph::_add_edge(const Variant &p_a, const Variant &p_b, const Varian
 	edge->directed = p_directed;
 	edge->graph = graph;
 
+	// Either add or insert the edge.
 	const auto &key = EdgeKey(a->id, b->id);
 	if (!graph->edges.has(key)) {
 		EdgeList list;

--- a/core/types/graph.h
+++ b/core/types/graph.h
@@ -142,7 +142,11 @@ class GraphVertex : public Object {
 
 	GraphData *graph = nullptr;
 
-	HashMap<uint32_t, GraphVertex *> neighbors;
+	// The `neighbors` includes both successors and predecessors.
+	HashMap<uint32_t, GraphVertex *> neighbors; 
+	HashMap<uint32_t, GraphVertex *> successors;
+	HashMap<uint32_t, GraphVertex *> predecessors;
+
 	Variant value;
 	uint32_t id = 0;
 
@@ -161,10 +165,10 @@ public:
 	int get_neighbor_count() const { return neighbors.size(); }
 
 	Array get_successors() const;
-	int get_successor_count() const;
+	int get_successor_count() const { return successors.size(); }
 
 	Array get_predecessors() const;
-	int get_predecessor_count() const;
+	int get_predecessor_count() const { return predecessors.size(); }
 
 	void set_value(const Variant &p_value) { value = p_value; }
 	Variant get_value() const { return value; }

--- a/core/types/graph.h
+++ b/core/types/graph.h
@@ -173,8 +173,8 @@ public:
 
 	// Edge connectivity.
 	Array get_edges() const;
-	Array get_inward_edges() const;
-	Array get_outward_edges() const;
+	Array get_incoming_edges() const;
+	Array get_outgoing_edges() const;
 
 	void set_value(const Variant &p_value) { value = p_value; }
 	Variant get_value() const { return value; }

--- a/core/types/graph.h
+++ b/core/types/graph.h
@@ -161,6 +161,7 @@ protected:
 	Variant _iter_get(const Variant &p_iter);
 
 public:
+	// Vertex connectivity.
 	Array get_neighbors() const;
 	int get_neighbor_count() const { return neighbors.size(); }
 
@@ -169,6 +170,11 @@ public:
 
 	Array get_predecessors() const;
 	int get_predecessor_count() const { return predecessors.size(); }
+
+	// Edge connectivity.
+	Array get_edges() const;
+	Array get_inward_edges() const;
+	Array get_outward_edges() const;
 
 	void set_value(const Variant &p_value) { value = p_value; }
 	Variant get_value() const { return value; }
@@ -201,8 +207,8 @@ public:
 	GraphVertex *get_a() const { return a; }
 	GraphVertex *get_b() const { return b; }
 
-	bool is_loop() { return a == b; }
-	bool is_directed() { return directed; }
+	bool is_loop() const { return a == b; }
+	bool is_directed() const { return directed; }
 
 	void set_value(const Variant &p_value) { value = p_value; }
 	Variant get_value() const { return value; }

--- a/doc/GraphEdge.xml
+++ b/doc/GraphEdge.xml
@@ -15,13 +15,13 @@
 				Returns the master [Graph] that instantiated and manages this edge.
 			</description>
 		</method>
-		<method name="is_directed">
+		<method name="is_directed" qualifiers="const">
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if the edge has a notion of direction, otherwise returns [code]false[/code] (associative edge).
 			</description>
 		</method>
-		<method name="is_loop">
+		<method name="is_loop" qualifiers="const">
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if the edge is a self-loop, meaning that [member a] is equal to [member b].

--- a/doc/GraphVertex.xml
+++ b/doc/GraphVertex.xml
@@ -4,7 +4,7 @@
 		A data structure used to represent a vertex in a [Graph].
 	</brief_description>
 	<description>
-		A vertex holds a data and information about all neighbor vertices that are connected to it. To traverse all neighbors:
+		A vertex holds a data and information about all neighbor vertices that are connected to it. To traverse all neighbors, use [method get_neighbors]:
 		[codeblock]
 		for n in v.get_neighbors():
 		    print(n)
@@ -14,15 +14,32 @@
 		for n in v:
 		    print(n)
 		[/codeblock]
+		For enumerating edges instead of vertices, use [method get_edges]:
+		[codeblock]
+		for e in v.get_edges():
+		    print(e.a, " ", e.b)
+		[/codeblock]
 		If you need to traverse the graph without producing duplicates, you may also consider using graph's default [member Graph.iterator].
 	</description>
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_edges" qualifiers="const">
+			<return type="Array" />
+			<description>
+				Returns all [GraphEdge]s associated with this vertex, including inward and outward edges, see [method get_inward_edges] and [method get_outward_edges] methods.
+			</description>
+		</method>
 		<method name="get_graph" qualifiers="const">
 			<return type="Graph" />
 			<description>
 				Returns the master [Graph] that instantiated and manages this vertex.
+			</description>
+		</method>
+		<method name="get_inward_edges" qualifiers="const">
+			<return type="Array" />
+			<description>
+				Returns all [GraphEdge]s that point from predecessor vertices.
 			</description>
 		</method>
 		<method name="get_neighbor_count" qualifiers="const">
@@ -35,6 +52,12 @@
 			<return type="Array" />
 			<description>
 				Returns a list of all [GraphVertex] neighbors.
+			</description>
+		</method>
+		<method name="get_outward_edges" qualifiers="const">
+			<return type="Array" />
+			<description>
+				Returns all [GraphEdge]s that point to successor vertices.
 			</description>
 		</method>
 		<method name="get_predecessor_count" qualifiers="const">

--- a/doc/GraphVertex.xml
+++ b/doc/GraphVertex.xml
@@ -27,7 +27,7 @@
 		<method name="get_edges" qualifiers="const">
 			<return type="Array" />
 			<description>
-				Returns all [GraphEdge]s associated with this vertex, including inward and outward edges, see [method get_inward_edges] and [method get_outward_edges] methods.
+				Returns all [GraphEdge]s associated with this vertex, including incoming and outgoing edges, see [method get_incoming_edges] and [method get_outgoing_edges] methods.
 			</description>
 		</method>
 		<method name="get_graph" qualifiers="const">
@@ -36,7 +36,7 @@
 				Returns the master [Graph] that instantiated and manages this vertex.
 			</description>
 		</method>
-		<method name="get_inward_edges" qualifiers="const">
+		<method name="get_incoming_edges" qualifiers="const">
 			<return type="Array" />
 			<description>
 				Returns all [GraphEdge]s that point from predecessor vertices.
@@ -54,7 +54,7 @@
 				Returns a list of all [GraphVertex] neighbors.
 			</description>
 		</method>
-		<method name="get_outward_edges" qualifiers="const">
+		<method name="get_outgoing_edges" qualifiers="const">
 			<return type="Array" />
 			<description>
 				Returns all [GraphEdge]s that point to successor vertices.

--- a/tests/project/goost/core/types/test_graph.gd
+++ b/tests/project/goost/core/types/test_graph.gd
@@ -184,6 +184,30 @@ func test_successors_predecessors_bidirected():
 		assert_gt(v.value, 0)
 
 
+func test_vertex_edges():
+	var V = []
+	for i in 4:
+		V.push_back(graph.add_vertex(i))
+
+	var _e
+	_e = graph.add_edge(0, 1)
+	_e = graph.add_edge(0, 2)
+	_e = graph.add_directed_edge(0, 2) # Outward
+	_e = graph.add_edge(0, 3)
+	_e = graph.add_directed_edge(0, 3) # Outward
+	_e = graph.add_directed_edge(3, 0) # Inward
+
+	assert_eq(V[0].get_edges().size(), 6)
+	assert_eq(V[0].get_outward_edges().size(), 2)
+	assert_eq(V[0].get_inward_edges().size(), 1)
+
+	for edge in V[0].get_outward_edges():
+		assert_true(V[0] == edge.a and V[0] != edge.b)
+
+	for edge in V[0].get_inward_edges():
+		assert_true(V[0] == edge.b and V[0] != edge.a)
+
+
 func test_get_edges():
 	var a = graph.add_vertex("a")
 	var b = graph.add_vertex("b")

--- a/tests/project/goost/core/types/test_graph.gd
+++ b/tests/project/goost/core/types/test_graph.gd
@@ -192,19 +192,19 @@ func test_vertex_edges():
 	var _e
 	_e = graph.add_edge(0, 1)
 	_e = graph.add_edge(0, 2)
-	_e = graph.add_directed_edge(0, 2) # Outward
+	_e = graph.add_directed_edge(0, 2) # Out
 	_e = graph.add_edge(0, 3)
-	_e = graph.add_directed_edge(0, 3) # Outward
-	_e = graph.add_directed_edge(3, 0) # Inward
+	_e = graph.add_directed_edge(0, 3) # Out
+	_e = graph.add_directed_edge(3, 0) # In
 
 	assert_eq(V[0].get_edges().size(), 6)
-	assert_eq(V[0].get_outward_edges().size(), 2)
-	assert_eq(V[0].get_inward_edges().size(), 1)
+	assert_eq(V[0].get_outgoing_edges().size(), 2)
+	assert_eq(V[0].get_incoming_edges().size(), 1)
 
-	for edge in V[0].get_outward_edges():
+	for edge in V[0].get_outgoing_edges():
 		assert_true(V[0] == edge.a and V[0] != edge.b)
 
-	for edge in V[0].get_inward_edges():
+	for edge in V[0].get_incoming_edges():
 		assert_true(V[0] == edge.b and V[0] != edge.a)
 
 

--- a/tests/project/goost/core/types/test_graph.gd
+++ b/tests/project/goost/core/types/test_graph.gd
@@ -145,6 +145,45 @@ func test_neighborhood_directed():
 	assert_true(b in sc)
 
 
+func test_successors_predecessors():
+	var V = []
+	for i in 10:
+		V.push_back(graph.add_vertex(i))
+
+	for i in range(1, 10):
+		var _e = graph.add_directed_edge(0, i)
+		
+	assert_eq(V[0].get_successor_count(), 9)
+	assert_eq(V[0].get_predecessor_count(), 0)
+
+	for v in V[0].get_successors():
+		assert_gt(v.value, 0)
+
+	for v in V:
+		if v == V[0]:
+			continue
+		assert_eq(v.get_predecessor_count(), 1)
+		assert_eq(V[0], v.get_predecessors()[0])
+
+
+func test_successors_predecessors_bidirected():
+	var V = []
+	for i in 10:
+		V.push_back(graph.add_vertex(i))
+
+	for i in range(1, 10):
+		var _ab = graph.add_directed_edge(0, i)
+		var _ba = graph.add_directed_edge(i, 0)
+
+	assert_eq(V[0].get_successor_count(), 9)
+	assert_eq(V[0].get_predecessor_count(), 9)
+
+	for v in V[0].get_successors():
+		assert_gt(v.value, 0)
+	for v in V[0].get_predecessors():
+		assert_gt(v.value, 0)
+
+
 func test_get_edges():
 	var a = graph.add_vertex("a")
 	var b = graph.add_vertex("b")


### PR DESCRIPTION
This allows to traverse edges over of vertices:

```gdscript
for edge in v.get_edges():
    print(edge.a, " ", edge.b)

for edge in v.get_incoming_edges():
    # `b` is predecessor of `a`
    print(edge.a, " ", edge.b)

for edge in v.get_outgoing_edges():
    # `b` is successor of `a`
    print(edge.a, " ", edge.b)
```

@sairam4123 https://github.com/goostengine/goost/pull/172#issuecomment-1044409628