### PR TITLE
Add `Random.pop()` method

### DIFF
--- a/core/math/random.cpp
+++ b/core/math/random.cpp
@@ -96,6 +96,49 @@ Variant Random::choice(const Variant &p_from) {
 	return Variant();
 }
 
+Variant Random::pop(const Variant &p_from) {
+	switch (p_from.get_type()) {
+		case Variant::STRING: {
+			ERR_FAIL_V_MSG(Variant(), "Unsupported: String is passed by value.");
+		} break;
+		case Variant::POOL_BYTE_ARRAY:
+		case Variant::POOL_INT_ARRAY:
+		case Variant::POOL_REAL_ARRAY:
+		case Variant::POOL_STRING_ARRAY:
+		case Variant::POOL_VECTOR2_ARRAY:
+		case Variant::POOL_VECTOR3_ARRAY:
+		case Variant::POOL_COLOR_ARRAY: {
+			ERR_FAIL_V_MSG(Variant(), "Unsupported: Pool*Arrays are passed by value rather than reference.");
+		} break;
+		case Variant::ARRAY: {
+			Array arr = p_from;
+			ERR_FAIL_COND_V_MSG(arr.empty(), Variant(), "Array is empty.");
+
+			int idx = randi() % arr.size();
+			Variant c = arr[idx];
+			// Remove unordered for performance reasons.
+			arr[idx] = arr.back();
+			arr.pop_back();
+
+			return c;
+		} break;
+		case Variant::DICTIONARY: {
+			Dictionary dict = p_from;
+			ERR_FAIL_COND_V_MSG(dict.empty(), Variant(), "Dictionary is empty.");
+
+			int idx = randi() % dict.size();
+			Variant c = dict.get_value_at_index(idx);
+			dict.erase(dict.get_key_at_index(idx));
+
+			return c;
+		} break;
+		default: {
+			ERR_FAIL_V_MSG(Variant(), "Unsupported: the type must be indexable.");
+		}
+	}
+	return Variant();
+}
+
 Array Random::choices(const Variant &p_from, int p_count, const PoolIntArray &p_weights, bool p_is_cumulative) {
 	int sum = 0;
 	LocalVector<int, int> cumulative_weights;
@@ -232,6 +275,7 @@ void Random::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("range", "from", "to"), &Random::range);
 	ClassDB::bind_method(D_METHOD("choice", "from"), &Random::choice);
+	ClassDB::bind_method(D_METHOD("pop", "from"), &Random::pop);
 	ClassDB::bind_method(D_METHOD("choices", "from", "count", "weights", "cumulative"), &Random::choices, DEFVAL(1), DEFVAL(Variant()), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("shuffle", "array"), &Random::shuffle);
 	ClassDB::bind_method(D_METHOD("decision", "probability"), &Random::decision);

--- a/core/math/random.h
+++ b/core/math/random.h
@@ -25,6 +25,7 @@ public:
 
 	Variant range(const Variant &p_from, const Variant &p_to);
 	Variant choice(const Variant &p_sequence);
+	Variant pop(const Variant &p_sequence);
 	Array choices(const Variant &p_sequence, int p_count = 1, const PoolIntArray &p_weights = Variant(), bool p_is_cumulative = false);
 	void shuffle(Array p_array);
 	bool decision(float probability);

--- a/doc/Random.xml
+++ b/doc/Random.xml
@@ -26,6 +26,15 @@
 				Returns a random element from a container or indexable sequence, such as [Array], [Dictionary], [String]. If container is empty, prints an error and returns [code]null[/code].
 			</description>
 		</method>
+		<method name="choices">
+			<return type="Array" />
+			<argument index="0" name="from" type="Variant" />
+			<argument index="1" name="count" type="int" default="1" />
+			<argument index="2" name="weights" type="PoolIntArray" default="null" />
+			<argument index="3" name="cumulative" type="bool" default="false" />
+			<description>
+			</description>
+		</method>
 		<method name="color_hsv">
 			<return type="Color" />
 			<argument index="0" name="hue_min" type="float" default="0.0" />
@@ -73,6 +82,15 @@
 			<return type="Reference" />
 			<description>
 				Instantiates a new local [Random] instance based on [RandomNumberGenerator]. Does not override the [Random] instance accessible at [@GlobalScope].
+			</description>
+		</method>
+		<method name="pop">
+			<return type="Variant" />
+			<argument index="0" name="from" type="Variant" />
+			<description>
+				Returns a random element from an [Array] or [Dictionary], and then removes the value from it. If container is empty, prints an error and returns [code]null[/code].
+				For performance reasons, this will modify the original order in the [Array]: the last value is swapped with the popped element, and then [method Array.pop_back] is called. See [method Array.remove] for explanations.
+				Unlike [method choice], the [String] and [b]Pool*Array[/b] types are not supported, since they are passed by value when calling this function.
 			</description>
 		</method>
 		<method name="range">

--- a/tests/project/goost/core/math/test_random.gd
+++ b/tests/project/goost/core/math/test_random.gd
@@ -158,6 +158,37 @@ func test_choice():
 	Engine.print_error_messages = true
 
 
+func test_pop():
+	var rng = Random.new_instance()
+	rng.seed = 38
+
+	var array = [1, 2, 3, 4]
+	var popped = []
+	for i in array.size():
+		var e = rng.pop(array)
+		assert_not_null(e)
+		popped.push_back(e)
+
+	assert_eq(popped[0], 3)
+	assert_eq(popped[1], 1)
+	assert_eq(popped[2], 4)
+	assert_eq(popped[3], 2)
+	popped.clear()
+
+	var dictionary = {a = 1, b = 2, c = 3, d = 4}
+	var keys = dictionary.keys()
+	for k in keys:
+		var e = rng.pop(dictionary)
+		assert_not_null(e)
+		popped.push_back(e)
+
+	assert_eq(popped[0], 3)
+	assert_eq(popped[1], 2)
+	assert_eq(popped[2], 1)
+	assert_eq(popped[3], 4)
+	popped.clear()
+
+
 func test_shuffle_array():
 	var rng = Random.new_instance()
 


### PR DESCRIPTION
Allows to pop and return random values from either `Array` or `Dictionary`.

Addresses: https://github.com/godotengine/godot-proposals/issues/3454#issuecomment-1024971678