### PR TITLE
Rename `Random.choice()` to `Random.pick()`

### DIFF
--- a/core/math/random.cpp
+++ b/core/math/random.cpp
@@ -65,7 +65,7 @@ Color Random::color_rgb(float r_min, float r_max, float g_min, float g_max, floa
 			randf_range(a_min, a_max));
 }
 
-Variant Random::choice(const Variant &p_from) {
+Variant Random::pick(const Variant &p_from) {
 	switch (p_from.get_type()) {
 		case Variant::STRING: {
 			String str = p_from;
@@ -274,7 +274,7 @@ void Random::_bind_methods() {
 			&Random::color_rgb, DEFVAL(0.0), DEFVAL(1.0), DEFVAL(0.0), DEFVAL(1.0), DEFVAL(0.0), DEFVAL(1.0), DEFVAL(1.0), DEFVAL(1.0));
 
 	ClassDB::bind_method(D_METHOD("range", "from", "to"), &Random::range);
-	ClassDB::bind_method(D_METHOD("choice", "from"), &Random::choice);
+	ClassDB::bind_method(D_METHOD("pick", "from"), &Random::pick);
 	ClassDB::bind_method(D_METHOD("pop", "from"), &Random::pop);
 	ClassDB::bind_method(D_METHOD("choices", "from", "count", "weights", "cumulative"), &Random::choices, DEFVAL(1), DEFVAL(Variant()), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("shuffle", "array"), &Random::shuffle);

--- a/core/math/random.h
+++ b/core/math/random.h
@@ -24,7 +24,7 @@ public:
 	Color color_rgb(float r_min = 0.0, float r_max = 1.0, float g_min = 0.0, float g_max = 1.0, float b_min = 0.0, float b_max = 1.0, float a_min = 1.0, float a_max = 1.0);
 
 	Variant range(const Variant &p_from, const Variant &p_to);
-	Variant choice(const Variant &p_sequence);
+	Variant pick(const Variant &p_sequence);
 	Variant pop(const Variant &p_sequence);
 	Array choices(const Variant &p_sequence, int p_count = 1, const PoolIntArray &p_weights = Variant(), bool p_is_cumulative = false);
 	void shuffle(Array p_array);

--- a/doc/GoostEngine.xml
+++ b/doc/GoostEngine.xml
@@ -44,7 +44,7 @@
 				# Pick a random color constant.
 				static func rand_color_constant():
 				    var colors = GoostEngine.get_color_constants()
-				    var name = Random.choice(colors.keys())
+				    var name = Random.pick(colors.keys())
 				    var color = colors[name]
 				    return color
 				[/codeblock]

--- a/doc/Graph.xml
+++ b/doc/Graph.xml
@@ -237,11 +237,11 @@
 				[code]backtrace:[/code] A [Dictionary] which contains an exhaustive information that allows to reconstruct the shortest path. The keys hold current [GraphVertex], and values contain previous [GraphVertex]. Therefore, the shortest path between the source to any other connected vertex can be obtained in the following way:
 				[codeblock]
 				# Find the shortest path tree starting from the root vertex of interest.
-				var root = Random.choice(graph.get_vertices())
+				var root = Random.pick(graph.get_vertices())
 				var tree = graph.shortest_path_tree(root)
 
 				# Pick any target vertex.
-				var current = Random.choice(graph.get_vertices())
+				var current = Random.pick(graph.get_vertices())
 
 				# Extract shortest path.
 				var shortest_path = []

--- a/doc/Random.xml
+++ b/doc/Random.xml
@@ -19,7 +19,7 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="choice">
+		<method name="pick">
 			<return type="Variant" />
 			<argument index="0" name="from" type="Variant" />
 			<description>
@@ -90,7 +90,7 @@
 			<description>
 				Returns a random element from an [Array] or [Dictionary], and then removes the value from it. If container is empty, prints an error and returns [code]null[/code].
 				For performance reasons, this will modify the original order in the [Array]: the last value is swapped with the popped element, and then [method Array.pop_back] is called. See [method Array.remove] for explanations.
-				Unlike [method choice], the [String] and [b]Pool*Array[/b] types are not supported, since they are passed by value when calling this function.
+				Unlike [method pick], the [String] and [b]Pool*Array[/b] types are not supported, since they are passed by value when calling this function.
 			</description>
 		</method>
 		<method name="range">

--- a/tests/project/goost/core/math/test_random.gd
+++ b/tests/project/goost/core/math/test_random.gd
@@ -135,25 +135,25 @@ func test_randi_range_unbiased():
 	assert_almost_eq(zero_count / float(one_count), 1.0, 0.1)
 
 
-func test_choice():
+func test_pick():
 	var rng = Random.new_instance()
 
 	rng.seed = 58885
-	var element = rng.choice(["Godot", Color.blue, "Goost", Color.red])
+	var element = rng.pick(["Godot", Color.blue, "Goost", Color.red])
 	assert_eq(element, "Goost")
 
 	rng.seed = 222
-	element = rng.choice("Goost")
+	element = rng.pick("Goost")
 	assert_eq(element, "G")
 
 	rng.seed = 335
-	element = rng.choice({0 : "Godot", 1 : "Goost", 2 : "Godex"})
+	element = rng.pick({0 : "Godot", 1 : "Goost", 2 : "Godex"})
 	assert_eq(element, "Goost")
 
 	Engine.print_error_messages = false
 
-	assert_null(rng.choice(""))
-	assert_null(rng.choice([]))
+	assert_null(rng.pick(""))
+	assert_null(rng.pick([]))
 
 	Engine.print_error_messages = true
 


### PR DESCRIPTION
Part of #176.

1. To avoid name collision with `Random.choices()` for weighed selection.
    - If we were to add this to Godot, only `Random.choices()` would be likely merged: https://github.com/godotengine/godot-proposals/issues/3948#issuecomment-1037289197
2. `Random.pick()` will go along with `Random.pop()`
   - There's a similar PR with similar name in Godot:
   - https://github.com/godotengine/godot/pull/57007
   - `pop()` suggested in the proposal:
   - godotengine/godot-proposals#3454
3. Faster and easier to type.